### PR TITLE
Fix module/runtime state bugs and test cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build release install uninstall test test-http check clippy fmt fmt-check clean run lint examples test-providers fuzz fuzz-reader fuzz-eval setup bench-1m bench-10m bench-100m site-dev site-build site-preview site-deploy
+.PHONY: all build release install uninstall test test-embedding-bench test-http check clippy fmt fmt-check clean run lint examples test-providers fuzz fuzz-reader fuzz-eval setup bench-1m bench-10m bench-100m site-dev site-build site-preview site-deploy
 
 build:
 	cargo build
@@ -14,6 +14,9 @@ uninstall:
 
 test:
 	cargo test
+
+test-embedding-bench:
+	cargo test -p sema --test embedding_bench -- --ignored --nocapture
 
 test-http:
 	cargo test -p sema --test integration_test test_http -- --ignored

--- a/crates/sema-eval/src/lib.rs
+++ b/crates/sema-eval/src/lib.rs
@@ -3,8 +3,9 @@ mod eval;
 mod special_forms;
 
 pub use eval::{
-    cache_module, call_stack_depth, capture_stack_trace, clear_module_exports, create_module_env,
-    current_file_dir, current_file_path, eval, eval_string, eval_value, get_cached_module,
-    merge_span_table, pop_file_path, push_call_frame, push_file_path, set_eval_step_limit,
-    set_module_exports, take_module_exports, truncate_call_stack, Interpreter,
+    begin_module_load, cache_module, call_stack_depth, capture_stack_trace, clear_module_exports,
+    create_module_env, current_file_dir, current_file_path, end_module_load, eval, eval_string,
+    eval_value, get_cached_module, merge_span_table, pop_file_path, push_call_frame,
+    push_file_path, reset_runtime_state, set_eval_step_limit, set_module_exports,
+    take_module_exports, truncate_call_stack, Interpreter,
 };

--- a/crates/sema/src/lib.rs
+++ b/crates/sema/src/lib.rs
@@ -68,6 +68,9 @@ impl InterpreterBuilder {
 
     /// Build the [`Interpreter`] with the configured options.
     pub fn build(self) -> Interpreter {
+        sema_eval::reset_runtime_state();
+        sema_llm::builtins::reset_runtime_state();
+
         let env = Env::new();
 
         if self.stdlib {

--- a/crates/sema/src/main.rs
+++ b/crates/sema/src/main.rs
@@ -98,7 +98,12 @@ fn main() {
 
     // Auto-configure LLM unless --no-init or --no-llm
     if !cli.no_init && !cli.no_llm {
-        let _ = interpreter.eval_str("(llm/auto-configure)");
+        if let Err(e) = interpreter.eval_str("(llm/auto-configure)") {
+            if cli.provider.is_some() || cli.model.is_some() {
+                print_error(&e);
+                std::process::exit(1);
+            }
+        }
     }
 
     // Load files first (in order)

--- a/crates/sema/tests/embedding_bench.rs
+++ b/crates/sema/tests/embedding_bench.rs
@@ -107,6 +107,7 @@ fn bench<F: Fn() -> R, R>(name: &str, iterations: usize, f: F) -> std::time::Dur
 }
 
 #[test]
+#[ignore = "expensive benchmark test; run with `make test-embedding-bench`"]
 fn bench_embedding_representations() {
     println!("\n=== EMBEDDING REPRESENTATION BENCHMARK ===\n");
 

--- a/examples/functional-patterns.sema
+++ b/examples/functional-patterns.sema
@@ -191,11 +191,13 @@
       (else (loop (+ (* 3 x) 1) (+ steps 1))))))
 
 (println (format "\nCollatz sequence lengths:"))
-(for-each
-  (fn (n)
-    (println (format "  ~a → ~a steps"
-      (string/pad-left (str n) 4)
-      (collatz n))))
-  (list 1 7 27 97 871 6171))
+(let loop ((nums (list 1 7 27 97 871 6171)))
+  (if (null? nums)
+    nil
+    (let ((n (first nums)))
+      (println (format "  ~a → ~a steps"
+        (string/pad-left (str n) 4)
+        (collatz n)))
+      (loop (rest nums)))))
 
 (println "\nDone!")


### PR DESCRIPTION
## Summary

Fix several module system and runtime state bugs, improve test ergonomics, and clean up benchmarks.

### Module system fixes
- **Cyclic import detection**: Added `MODULE_LOAD_STACK` to detect and report cyclic imports with a clear error instead of stack overflow
- **Nested import export leaking**: Changed `MODULE_EXPORTS` from a single `Option` to a stack (`Vec`) so nested imports don't clobber the outer module's export declarations
- **`load` file context cleanup**: Fixed `eval_load` to only canonicalize the path once, ensuring the file context is always popped even if the file disappears during execution

### Runtime state isolation
- Added `reset_runtime_state()` to both `sema-eval` and `sema-llm`, called on `Interpreter::new()` so each interpreter starts with a clean slate (module cache, file stack, budget, etc.)
- **Scoped budget**: `with-budget` now uses `push_budget_scope`/`pop_budget_scope` so nested budgets restore the outer scope correctly

### LLM configuration
- `llm/auto-configure` now respects `SEMA_DEFAULT_MODEL` and `SEMA_LLM_PROVIDER` environment variables
- CLI `--provider` and `--model` flags work via these env vars

### Span table overflow prevention
- Added `MAX_SPAN_TABLE_ENTRIES` (200k) cap to prevent unbounded memory growth

### Benchmark cleanup
- Removed "simple" benchmark variants and associated results
- Cleaned up Docker and benchmark scripts

### Tests
- Added tests for: cyclic imports, nested export isolation, module cache isolation between interpreters, load file context cleanup, scoped budget restoration, LLM state isolation, CLI --provider/--model flags
- Added `unique_temp_dir` and `lisp_path` test helpers