### PR TITLE
feat: add native SQLite integration (db/* functions)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,6 +780,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,6 +1069,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -1567,6 +1588,17 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.3",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2447,6 +2479,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags 2.11.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2791,6 +2837,7 @@ dependencies = [
  "rand 0.10.0",
  "regex",
  "reqwest",
+ "rusqlite",
  "sema-core",
  "sema-reader",
  "serde_json",
@@ -3645,6 +3692,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ tokio-stream = "0.1"
 mime_guess = "2"
 toml = "0.8"
 toml_edit = "0.22"
+rusqlite = { version = "0.31", features = ["bundled"] }
 semver = "1"
 tar = "0.4"
 flate2 = "1"

--- a/crates/sema-stdlib/Cargo.toml
+++ b/crates/sema-stdlib/Cargo.toml
@@ -40,3 +40,4 @@ axum.workspace = true
 tokio-stream.workspace = true
 futures.workspace = true
 mime_guess.workspace = true
+rusqlite.workspace = true

--- a/crates/sema-stdlib/src/lib.rs
+++ b/crates/sema-stdlib/src/lib.rs
@@ -25,6 +25,8 @@ mod predicates;
 mod regex_ops;
 #[cfg(not(target_arch = "wasm32"))]
 mod server;
+#[cfg(not(target_arch = "wasm32"))]
+mod sqlite;
 mod stream;
 mod string;
 #[cfg(not(target_arch = "wasm32"))]
@@ -73,6 +75,8 @@ pub fn register_stdlib(env: &Env, sandbox: &Sandbox) {
     kv::register(env, sandbox);
     #[cfg(not(target_arch = "wasm32"))]
     pdf::register(env, sandbox);
+    #[cfg(not(target_arch = "wasm32"))]
+    sqlite::register(env, sandbox);
 }
 
 fn register_fn_gated(

--- a/crates/sema-stdlib/src/sqlite.rs
+++ b/crates/sema-stdlib/src/sqlite.rs
@@ -1,0 +1,300 @@
+use std::cell::RefCell;
+use std::collections::{BTreeMap, HashMap};
+
+use rusqlite::{params_from_iter, types::Value as SqlValue, Connection};
+use sema_core::{check_arity, SemaError, Value};
+
+thread_local! {
+    static DB_CONNECTIONS: RefCell<HashMap<String, Connection>> = RefCell::new(HashMap::new());
+}
+
+fn sema_to_sql(v: &Value) -> SqlValue {
+    if v.is_nil() {
+        SqlValue::Null
+    } else if let Some(b) = v.as_bool() {
+        SqlValue::Integer(b as i64)
+    } else if let Some(i) = v.as_int() {
+        SqlValue::Integer(i)
+    } else if let Some(f) = v.as_float() {
+        SqlValue::Real(f)
+    } else if let Some(s) = v.as_str() {
+        SqlValue::Text(s.to_string())
+    } else if let Some(bytes) = v.as_bytevector() {
+        SqlValue::Blob(bytes.to_vec())
+    } else {
+        SqlValue::Text(v.to_string())
+    }
+}
+
+fn sql_to_sema(v: &SqlValue) -> Value {
+    match v {
+        SqlValue::Null => Value::nil(),
+        SqlValue::Integer(i) => Value::int(*i),
+        SqlValue::Real(f) => Value::float(*f),
+        SqlValue::Text(s) => Value::string(s),
+        SqlValue::Blob(b) => Value::bytevector(b.clone()),
+    }
+}
+
+pub fn register(env: &sema_core::Env, sandbox: &sema_core::Sandbox) {
+    // (db/open path) or (db/open name path)
+    crate::register_fn_path_gated(
+        env,
+        sandbox,
+        sema_core::Caps::FS_WRITE,
+        "db/open",
+        &[0],
+        |args| {
+            if args.len() == 1 {
+                let path = args[0]
+                    .as_str()
+                    .ok_or_else(|| SemaError::type_error("string", args[0].type_name()))?;
+                let conn =
+                    Connection::open(path).map_err(|e| SemaError::eval(format!("db/open: {e}")))?;
+                conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
+                    .map_err(|e| SemaError::eval(format!("db/open: {e}")))?;
+                DB_CONNECTIONS.with(|c| {
+                    c.borrow_mut().insert(path.to_string(), conn);
+                });
+                Ok(Value::string(path))
+            } else if args.len() == 2 {
+                let name = args[0]
+                    .as_str()
+                    .ok_or_else(|| SemaError::type_error("string", args[0].type_name()))?;
+                let path = args[1]
+                    .as_str()
+                    .ok_or_else(|| SemaError::type_error("string", args[1].type_name()))?;
+                let conn =
+                    Connection::open(path).map_err(|e| SemaError::eval(format!("db/open: {e}")))?;
+                conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
+                    .map_err(|e| SemaError::eval(format!("db/open: {e}")))?;
+                DB_CONNECTIONS.with(|c| {
+                    c.borrow_mut().insert(name.to_string(), conn);
+                });
+                Ok(Value::string(name))
+            } else {
+                Err(SemaError::arity("db/open", "1 or 2", args.len()))
+            }
+        },
+    );
+
+    // (db/open-memory) or (db/open-memory name)
+    crate::register_fn_gated(
+        env,
+        sandbox,
+        sema_core::Caps::FS_WRITE,
+        "db/open-memory",
+        |args| {
+            let name = if args.is_empty() {
+                ":memory:".to_string()
+            } else if args.len() == 1 {
+                args[0]
+                    .as_str()
+                    .ok_or_else(|| SemaError::type_error("string", args[0].type_name()))?
+                    .to_string()
+            } else {
+                return Err(SemaError::arity("db/open-memory", "0 or 1", args.len()));
+            };
+            let conn = Connection::open_in_memory()
+                .map_err(|e| SemaError::eval(format!("db/open-memory: {e}")))?;
+            conn.execute_batch("PRAGMA foreign_keys=ON;")
+                .map_err(|e| SemaError::eval(format!("db/open-memory: {e}")))?;
+            DB_CONNECTIONS.with(|c| {
+                c.borrow_mut().insert(name.clone(), conn);
+            });
+            Ok(Value::string(&name))
+        },
+    );
+
+    // (db/exec handle sql ...params) -> int (affected rows)
+    crate::register_fn(env, "db/exec", |args| {
+        if args.len() < 2 {
+            return Err(SemaError::arity("db/exec", "2+", args.len()));
+        }
+        let handle = args[0]
+            .as_str()
+            .ok_or_else(|| SemaError::type_error("string", args[0].type_name()))?;
+        let sql = args[1]
+            .as_str()
+            .ok_or_else(|| SemaError::type_error("string", args[1].type_name()))?;
+        let params: Vec<SqlValue> = args[2..].iter().map(sema_to_sql).collect();
+
+        DB_CONNECTIONS.with(|c| {
+            let c = c.borrow();
+            let conn = c
+                .get(handle)
+                .ok_or_else(|| SemaError::eval(format!("db/exec: no open database '{handle}'")))?;
+            let affected = conn
+                .execute(sql, params_from_iter(params.iter()))
+                .map_err(|e| SemaError::eval(format!("db/exec: {e}")))?;
+            Ok(Value::int(affected as i64))
+        })
+    });
+
+    // (db/exec-batch handle sql) -> nil (execute multiple statements)
+    crate::register_fn(env, "db/exec-batch", |args| {
+        check_arity!(args, "db/exec-batch", 2);
+        let handle = args[0]
+            .as_str()
+            .ok_or_else(|| SemaError::type_error("string", args[0].type_name()))?;
+        let sql = args[1]
+            .as_str()
+            .ok_or_else(|| SemaError::type_error("string", args[1].type_name()))?;
+
+        DB_CONNECTIONS.with(|c| {
+            let c = c.borrow();
+            let conn = c.get(handle).ok_or_else(|| {
+                SemaError::eval(format!("db/exec-batch: no open database '{handle}'"))
+            })?;
+            conn.execute_batch(sql)
+                .map_err(|e| SemaError::eval(format!("db/exec-batch: {e}")))?;
+            Ok(Value::nil())
+        })
+    });
+
+    // (db/query handle sql ...params) -> list of maps
+    crate::register_fn(env, "db/query", |args| {
+        if args.len() < 2 {
+            return Err(SemaError::arity("db/query", "2+", args.len()));
+        }
+        let handle = args[0]
+            .as_str()
+            .ok_or_else(|| SemaError::type_error("string", args[0].type_name()))?;
+        let sql = args[1]
+            .as_str()
+            .ok_or_else(|| SemaError::type_error("string", args[1].type_name()))?;
+        let params: Vec<SqlValue> = args[2..].iter().map(sema_to_sql).collect();
+
+        DB_CONNECTIONS.with(|c| {
+            let c = c.borrow();
+            let conn = c
+                .get(handle)
+                .ok_or_else(|| SemaError::eval(format!("db/query: no open database '{handle}'")))?;
+            let mut stmt = conn
+                .prepare(sql)
+                .map_err(|e| SemaError::eval(format!("db/query: {e}")))?;
+            let col_count = stmt.column_count();
+            let col_names: Vec<String> = (0..col_count)
+                .map(|i| stmt.column_name(i).unwrap().to_string())
+                .collect();
+
+            let rows = stmt
+                .query_map(params_from_iter(params.iter()), |row| {
+                    let mut map = BTreeMap::new();
+                    for (i, name) in col_names.iter().enumerate() {
+                        let val: SqlValue = row.get(i)?;
+                        map.insert(Value::keyword(name), sql_to_sema(&val));
+                    }
+                    Ok(Value::map(map))
+                })
+                .map_err(|e| SemaError::eval(format!("db/query: {e}")))?;
+
+            let mut result = Vec::new();
+            for row in rows {
+                result.push(row.map_err(|e| SemaError::eval(format!("db/query: {e}")))?);
+            }
+            Ok(Value::list(result))
+        })
+    });
+
+    // (db/query-one handle sql ...params) -> map or nil
+    crate::register_fn(env, "db/query-one", |args| {
+        if args.len() < 2 {
+            return Err(SemaError::arity("db/query-one", "2+", args.len()));
+        }
+        let handle = args[0]
+            .as_str()
+            .ok_or_else(|| SemaError::type_error("string", args[0].type_name()))?;
+        let sql = args[1]
+            .as_str()
+            .ok_or_else(|| SemaError::type_error("string", args[1].type_name()))?;
+        let params: Vec<SqlValue> = args[2..].iter().map(sema_to_sql).collect();
+
+        DB_CONNECTIONS.with(|c| {
+            let c = c.borrow();
+            let conn = c.get(handle).ok_or_else(|| {
+                SemaError::eval(format!("db/query-one: no open database '{handle}'"))
+            })?;
+            let mut stmt = conn
+                .prepare(sql)
+                .map_err(|e| SemaError::eval(format!("db/query-one: {e}")))?;
+            let col_count = stmt.column_count();
+            let col_names: Vec<String> = (0..col_count)
+                .map(|i| stmt.column_name(i).unwrap().to_string())
+                .collect();
+
+            let mut rows = stmt
+                .query_map(params_from_iter(params.iter()), |row| {
+                    let mut map = BTreeMap::new();
+                    for (i, name) in col_names.iter().enumerate() {
+                        let val: SqlValue = row.get(i)?;
+                        map.insert(Value::keyword(name), sql_to_sema(&val));
+                    }
+                    Ok(Value::map(map))
+                })
+                .map_err(|e| SemaError::eval(format!("db/query-one: {e}")))?;
+
+            match rows.next() {
+                Some(row) => row.map_err(|e| SemaError::eval(format!("db/query-one: {e}"))),
+                None => Ok(Value::nil()),
+            }
+        })
+    });
+
+    // (db/last-insert-id handle) -> int
+    crate::register_fn(env, "db/last-insert-id", |args| {
+        check_arity!(args, "db/last-insert-id", 1);
+        let handle = args[0]
+            .as_str()
+            .ok_or_else(|| SemaError::type_error("string", args[0].type_name()))?;
+
+        DB_CONNECTIONS.with(|c| {
+            let c = c.borrow();
+            let conn = c.get(handle).ok_or_else(|| {
+                SemaError::eval(format!("db/last-insert-id: no open database '{handle}'"))
+            })?;
+            Ok(Value::int(conn.last_insert_rowid()))
+        })
+    });
+
+    // (db/tables handle) -> list of strings
+    crate::register_fn(env, "db/tables", |args| {
+        check_arity!(args, "db/tables", 1);
+        let handle = args[0]
+            .as_str()
+            .ok_or_else(|| SemaError::type_error("string", args[0].type_name()))?;
+
+        DB_CONNECTIONS.with(|c| {
+            let c = c.borrow();
+            let conn = c.get(handle).ok_or_else(|| {
+                SemaError::eval(format!("db/tables: no open database '{handle}'"))
+            })?;
+            let mut stmt = conn
+                .prepare(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+                )
+                .map_err(|e| SemaError::eval(format!("db/tables: {e}")))?;
+            let names: Vec<Value> = stmt
+                .query_map([], |row| {
+                    let name: String = row.get(0)?;
+                    Ok(Value::string(&name))
+                })
+                .map_err(|e| SemaError::eval(format!("db/tables: {e}")))?
+                .filter_map(|r| r.ok())
+                .collect();
+            Ok(Value::list(names))
+        })
+    });
+
+    // (db/close handle) -> nil
+    crate::register_fn(env, "db/close", |args| {
+        check_arity!(args, "db/close", 1);
+        let handle = args[0]
+            .as_str()
+            .ok_or_else(|| SemaError::type_error("string", args[0].type_name()))?;
+        DB_CONNECTIONS.with(|c| {
+            c.borrow_mut().remove(handle);
+        });
+        Ok(Value::nil())
+    });
+}

--- a/crates/sema/tests/integration_test.rs
+++ b/crates/sema/tests/integration_test.rs
@@ -13499,3 +13499,200 @@ fn test_with_stream_error_cleanup() {
 
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+// --- SQLite tests ---
+
+#[test]
+fn test_db_open_memory_and_close() {
+    let interp = Interpreter::new();
+    let handle = interp.eval_str(r#"(db/open-memory "test-mem")"#).unwrap();
+    assert_eq!(handle, Value::string("test-mem"));
+    interp.eval_str(r#"(db/close "test-mem")"#).unwrap();
+}
+
+#[test]
+fn test_db_exec_and_query() {
+    let interp = Interpreter::new();
+    interp.eval_str(r#"(db/open-memory "eq")"#).unwrap();
+    interp
+        .eval_str(r#"(db/exec "eq" "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, age INTEGER)")"#)
+        .unwrap();
+    let affected = interp
+        .eval_str(r#"(db/exec "eq" "INSERT INTO users (name, age) VALUES (?, ?)" "Alice" 30)"#)
+        .unwrap();
+    assert_eq!(affected, Value::int(1));
+    interp
+        .eval_str(r#"(db/exec "eq" "INSERT INTO users (name, age) VALUES (?, ?)" "Bob" 25)"#)
+        .unwrap();
+    let rows = interp
+        .eval_str(r#"(db/query "eq" "SELECT name, age FROM users ORDER BY name")"#)
+        .unwrap();
+    let list = rows.as_list().unwrap();
+    assert_eq!(list.len(), 2);
+    let alice = list[0].as_map_ref().unwrap();
+    assert_eq!(alice.get(&Value::keyword("name")).unwrap(), &Value::string("Alice"));
+    assert_eq!(alice.get(&Value::keyword("age")).unwrap(), &Value::int(30));
+    let bob = list[1].as_map_ref().unwrap();
+    assert_eq!(bob.get(&Value::keyword("name")).unwrap(), &Value::string("Bob"));
+    interp.eval_str(r#"(db/close "eq")"#).unwrap();
+}
+
+#[test]
+fn test_db_query_with_params() {
+    let interp = Interpreter::new();
+    interp.eval_str(r#"(db/open-memory "qp")"#).unwrap();
+    interp
+        .eval_str(r#"(db/exec "qp" "CREATE TABLE items (id INTEGER PRIMARY KEY, value REAL)")"#)
+        .unwrap();
+    interp.eval_str(r#"(db/exec "qp" "INSERT INTO items (value) VALUES (?)" 3.14)"#).unwrap();
+    interp.eval_str(r#"(db/exec "qp" "INSERT INTO items (value) VALUES (?)" 2.72)"#).unwrap();
+    interp.eval_str(r#"(db/exec "qp" "INSERT INTO items (value) VALUES (?)" 1.0)"#).unwrap();
+    let rows = interp
+        .eval_str(r#"(db/query "qp" "SELECT value FROM items WHERE value > ?" 2.0)"#)
+        .unwrap();
+    let list = rows.as_list().unwrap();
+    assert_eq!(list.len(), 2);
+    interp.eval_str(r#"(db/close "qp")"#).unwrap();
+}
+
+#[test]
+fn test_db_query_one() {
+    let interp = Interpreter::new();
+    interp.eval_str(r#"(db/open-memory "qo")"#).unwrap();
+    interp
+        .eval_str(r#"(db/exec "qo" "CREATE TABLE kv (key TEXT PRIMARY KEY, val TEXT)")"#)
+        .unwrap();
+    interp
+        .eval_str(r#"(db/exec "qo" "INSERT INTO kv VALUES (?, ?)" "name" "Alice")"#)
+        .unwrap();
+    let result = interp
+        .eval_str(r#"(db/query-one "qo" "SELECT val FROM kv WHERE key = ?" "name")"#)
+        .unwrap();
+    let row = result.as_map_ref().unwrap();
+    assert_eq!(row.get(&Value::keyword("val")).unwrap(), &Value::string("Alice"));
+    let missing = interp
+        .eval_str(r#"(db/query-one "qo" "SELECT val FROM kv WHERE key = ?" "nope")"#)
+        .unwrap();
+    assert!(missing.is_nil());
+    interp.eval_str(r#"(db/close "qo")"#).unwrap();
+}
+
+#[test]
+fn test_db_last_insert_id() {
+    let interp = Interpreter::new();
+    interp.eval_str(r#"(db/open-memory "lid")"#).unwrap();
+    interp
+        .eval_str(r#"(db/exec "lid" "CREATE TABLE t (id INTEGER PRIMARY KEY)")"#)
+        .unwrap();
+    interp.eval_str(r#"(db/exec "lid" "INSERT INTO t DEFAULT VALUES")"#).unwrap();
+    let id = interp.eval_str(r#"(db/last-insert-id "lid")"#).unwrap();
+    assert_eq!(id, Value::int(1));
+    interp.eval_str(r#"(db/exec "lid" "INSERT INTO t DEFAULT VALUES")"#).unwrap();
+    let id2 = interp.eval_str(r#"(db/last-insert-id "lid")"#).unwrap();
+    assert_eq!(id2, Value::int(2));
+    interp.eval_str(r#"(db/close "lid")"#).unwrap();
+}
+
+#[test]
+fn test_db_tables() {
+    let interp = Interpreter::new();
+    interp.eval_str(r#"(db/open-memory "tbl")"#).unwrap();
+    interp.eval_str(r#"(db/exec "tbl" "CREATE TABLE alpha (id INTEGER)")"#).unwrap();
+    interp.eval_str(r#"(db/exec "tbl" "CREATE TABLE beta (id INTEGER)")"#).unwrap();
+    let tables = interp.eval_str(r#"(db/tables "tbl")"#).unwrap();
+    let list = tables.as_list().unwrap();
+    assert_eq!(list.len(), 2);
+    assert_eq!(list[0], Value::string("alpha"));
+    assert_eq!(list[1], Value::string("beta"));
+    interp.eval_str(r#"(db/close "tbl")"#).unwrap();
+}
+
+#[test]
+fn test_db_exec_batch() {
+    let interp = Interpreter::new();
+    interp.eval_str(r#"(db/open-memory "batch")"#).unwrap();
+    interp
+        .eval_str(r#"(db/exec-batch "batch" "CREATE TABLE a (id INTEGER); CREATE TABLE b (id INTEGER);")"#)
+        .unwrap();
+    let tables = interp.eval_str(r#"(db/tables "batch")"#).unwrap();
+    let list = tables.as_list().unwrap();
+    assert_eq!(list.len(), 2);
+    interp.eval_str(r#"(db/close "batch")"#).unwrap();
+}
+
+#[test]
+fn test_db_null_values() {
+    let interp = Interpreter::new();
+    interp.eval_str(r#"(db/open-memory "nv")"#).unwrap();
+    interp
+        .eval_str(r#"(db/exec "nv" "CREATE TABLE t (a TEXT, b INTEGER)")"#)
+        .unwrap();
+    interp
+        .eval_str(r#"(db/exec "nv" "INSERT INTO t VALUES (?, ?)" nil 42)"#)
+        .unwrap();
+    let row = interp
+        .eval_str(r#"(db/query-one "nv" "SELECT a, b FROM t")"#)
+        .unwrap();
+    let map = row.as_map_ref().unwrap();
+    assert!(map.get(&Value::keyword("a")).unwrap().is_nil());
+    assert_eq!(map.get(&Value::keyword("b")).unwrap(), &Value::int(42));
+    interp.eval_str(r#"(db/close "nv")"#).unwrap();
+}
+
+#[test]
+fn test_db_open_file() {
+    let tmp = std::env::temp_dir().join("sema-db-test-file.db");
+    let path = tmp.to_str().unwrap();
+    let _ = std::fs::remove_file(&tmp);
+    let interp = Interpreter::new();
+    interp.eval_str(&format!(r#"(db/open "{path}")"#)).unwrap();
+    interp
+        .eval_str(&format!(r#"(db/exec "{path}" "CREATE TABLE t (v TEXT)")"#))
+        .unwrap();
+    interp
+        .eval_str(&format!(r#"(db/exec "{path}" "INSERT INTO t VALUES (?)" "hello")"#))
+        .unwrap();
+    interp.eval_str(&format!(r#"(db/close "{path}")"#)).unwrap();
+    // Reopen and verify persistence
+    interp.eval_str(&format!(r#"(db/open "{path}")"#)).unwrap();
+    let result = interp
+        .eval_str(&format!(r#"(db/query-one "{path}" "SELECT v FROM t")"#))
+        .unwrap();
+    let map = result.as_map_ref().unwrap();
+    assert_eq!(map.get(&Value::keyword("v")).unwrap(), &Value::string("hello"));
+    interp.eval_str(&format!(r#"(db/close "{path}")"#)).unwrap();
+    let _ = std::fs::remove_file(&tmp);
+}
+
+#[test]
+fn test_db_error_no_open() {
+    let interp = Interpreter::new();
+    let result = interp.eval_str(r#"(db/query "nonexistent" "SELECT 1")"#);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_db_error_bad_sql() {
+    let interp = Interpreter::new();
+    interp.eval_str(r#"(db/open-memory "bad")"#).unwrap();
+    let result = interp.eval_str(r#"(db/exec "bad" "NOT VALID SQL")"#);
+    assert!(result.is_err());
+    interp.eval_str(r#"(db/close "bad")"#).unwrap();
+}
+
+#[test]
+fn test_db_foreign_keys() {
+    let interp = Interpreter::new();
+    interp.eval_str(r#"(db/open-memory "fk")"#).unwrap();
+    interp
+        .eval_str(r#"(db/exec "fk" "CREATE TABLE parent (id INTEGER PRIMARY KEY)")"#)
+        .unwrap();
+    interp
+        .eval_str(r#"(db/exec "fk" "CREATE TABLE child (id INTEGER, pid INTEGER REFERENCES parent(id))")"#)
+        .unwrap();
+    // Inserting a child with non-existent parent should fail because foreign_keys=ON
+    let result = interp
+        .eval_str(r#"(db/exec "fk" "INSERT INTO child VALUES (1, 999)")"#);
+    assert!(result.is_err());
+    interp.eval_str(r#"(db/close "fk")"#).unwrap();
+}


### PR DESCRIPTION
Add SQLite support via rusqlite with bundled SQLite. Implements db/open,
db/open-memory, db/exec, db/exec-batch, db/query, db/query-one,
db/last-insert-id, db/tables, and db/close. Query results are returned
as lists of maps with column names as keywords. Parameterized queries
supported via variadic args. Foreign keys and WAL mode enabled by default.

Closes #21

https://claude.ai/code/session_01DgbLU2fo6SReW1rxPYk5fA