### PR TITLE
Living Code: docstrings, introspection, self-modification, evolve

### DIFF
--- a/crates/sema-core/src/value.rs
+++ b/crates/sema-core/src/value.rs
@@ -2059,6 +2059,7 @@ impl fmt::Debug for Value {
 #[derive(Debug, Clone)]
 pub struct Env {
     pub bindings: Rc<RefCell<SpurMap<Spur, Value>>>,
+    pub metadata: Rc<RefCell<SpurMap<Spur, BTreeMap<Value, Value>>>>,
     pub parent: Option<Rc<Env>>,
     pub version: Cell<u64>,
 }
@@ -2067,6 +2068,7 @@ impl Env {
     pub fn new() -> Self {
         Env {
             bindings: Rc::new(RefCell::new(SpurMap::new())),
+            metadata: Rc::new(RefCell::new(SpurMap::new())),
             parent: None,
             version: Cell::new(0),
         }
@@ -2075,6 +2077,7 @@ impl Env {
     pub fn with_parent(parent: Rc<Env>) -> Self {
         Env {
             bindings: Rc::new(RefCell::new(SpurMap::new())),
+            metadata: Rc::new(RefCell::new(SpurMap::new())),
             parent: Some(parent),
             version: Cell::new(0),
         }
@@ -2155,6 +2158,26 @@ impl Env {
             } else {
                 false
             }
+        }
+    }
+
+    /// Set a metadata entry for a binding.
+    pub fn set_meta(&self, name: Spur, key: Value, val: Value) {
+        self.metadata
+            .borrow_mut()
+            .entry(name)
+            .or_default()
+            .insert(key, val);
+    }
+
+    /// Get metadata for a binding, searching parent scopes.
+    pub fn get_meta(&self, name: Spur) -> Option<BTreeMap<Value, Value>> {
+        if let Some(meta) = self.metadata.borrow().get(&name) {
+            Some(meta.clone())
+        } else if let Some(parent) = &self.parent {
+            parent.get_meta(name)
+        } else {
+            None
         }
     }
 

--- a/crates/sema-eval/src/doctest.rs
+++ b/crates/sema-eval/src/doctest.rs
@@ -1,0 +1,244 @@
+//! Doctest parser and runner.
+//!
+//! Extracts executable examples from docstrings:
+//! - `>>>` lines are expressions to evaluate
+//! - The next non-blank line is the expected result
+//! - `!! substring` means expect an error containing substring
+//! - `>>>!` means evaluate but don't check result (setup)
+
+use sema_core::{SemaError, Value};
+
+/// A single doctest example.
+#[derive(Debug, Clone)]
+pub struct DocTest {
+    pub input: String,
+    pub expected: Expected,
+    pub line: usize,
+}
+
+/// Expected result of a doctest.
+#[derive(Debug, Clone)]
+pub enum Expected {
+    /// Compare return value (the expected expression as a string).
+    Value(String),
+    /// Expect an error containing this substring.
+    Error(String),
+    /// Don't check the result (setup step).
+    Skip,
+}
+
+/// Result of running a single doctest.
+#[derive(Debug)]
+pub struct DocTestResult {
+    pub input: String,
+    pub passed: bool,
+    pub expected: String,
+    pub actual: String,
+    pub line: usize,
+}
+
+/// Parse doctests from a docstring.
+pub fn parse_doctests(docstring: &str) -> Vec<DocTest> {
+    let mut tests = Vec::new();
+    let lines: Vec<&str> = docstring.lines().collect();
+    let mut i = 0;
+
+    while i < lines.len() {
+        let trimmed = lines[i].trim();
+
+        if let Some(expr) = trimmed.strip_prefix(">>>!") {
+            // Setup-only: evaluate but don't check
+            let expr = expr.trim().to_string();
+            if !expr.is_empty() {
+                tests.push(DocTest {
+                    input: expr,
+                    expected: Expected::Skip,
+                    line: i + 1,
+                });
+            }
+            i += 1;
+        } else if let Some(expr) = trimmed.strip_prefix(">>>") {
+            let expr = expr.trim().to_string();
+            if expr.is_empty() {
+                i += 1;
+                continue;
+            }
+
+            // Look at next non-blank line for expected result
+            i += 1;
+            while i < lines.len() && lines[i].trim().is_empty() {
+                i += 1;
+            }
+
+            if i < lines.len() {
+                let expected_line = lines[i].trim();
+                if let Some(err_match) = expected_line.strip_prefix("!!") {
+                    tests.push(DocTest {
+                        input: expr,
+                        expected: Expected::Error(err_match.trim().to_string()),
+                        line: i + 1,
+                    });
+                    i += 1;
+                } else if expected_line.starts_with(">>>") {
+                    // No expected value, next line is another test
+                    tests.push(DocTest {
+                        input: expr,
+                        expected: Expected::Skip,
+                        line: i,
+                    });
+                    // Don't increment i, re-process this line
+                } else {
+                    tests.push(DocTest {
+                        input: expr,
+                        expected: Expected::Value(expected_line.to_string()),
+                        line: i + 1,
+                    });
+                    i += 1;
+                }
+            } else {
+                // No expected line — treat as skip
+                tests.push(DocTest {
+                    input: expr,
+                    expected: Expected::Skip,
+                    line: i,
+                });
+            }
+        } else {
+            i += 1;
+        }
+    }
+
+    tests
+}
+
+/// Run all doctests, using the provided eval function for execution.
+pub fn run_doctests<F>(docstring: &str, eval_fn: &mut F) -> Vec<DocTestResult>
+where
+    F: FnMut(&str) -> Result<Value, SemaError>,
+{
+    let tests = parse_doctests(docstring);
+    let mut results = Vec::new();
+
+    for test in tests {
+        match &test.expected {
+            Expected::Skip => match eval_fn(&test.input) {
+                Ok(_) => {
+                    results.push(DocTestResult {
+                        input: test.input,
+                        passed: true,
+                        expected: "(skip)".to_string(),
+                        actual: "(skip)".to_string(),
+                        line: test.line,
+                    });
+                }
+                Err(e) => {
+                    results.push(DocTestResult {
+                        input: test.input,
+                        passed: false,
+                        expected: "(skip)".to_string(),
+                        actual: format!("ERROR: {e}"),
+                        line: test.line,
+                    });
+                }
+            },
+            Expected::Value(expected_str) => match eval_fn(&test.input) {
+                Ok(actual) => {
+                    let actual_str = format!("{actual}");
+                    let passed = actual_str.trim() == expected_str.trim();
+                    results.push(DocTestResult {
+                        input: test.input,
+                        passed,
+                        expected: expected_str.clone(),
+                        actual: actual_str,
+                        line: test.line,
+                    });
+                }
+                Err(e) => {
+                    results.push(DocTestResult {
+                        input: test.input,
+                        passed: false,
+                        expected: expected_str.clone(),
+                        actual: format!("ERROR: {e}"),
+                        line: test.line,
+                    });
+                }
+            },
+            Expected::Error(expected_substring) => match eval_fn(&test.input) {
+                Ok(val) => {
+                    results.push(DocTestResult {
+                        input: test.input,
+                        passed: false,
+                        expected: format!("!! {expected_substring}"),
+                        actual: format!("{val}"),
+                        line: test.line,
+                    });
+                }
+                Err(e) => {
+                    let err_str = e.to_string().to_lowercase();
+                    let expected_lower = expected_substring.to_lowercase();
+                    let passed = err_str.contains(&expected_lower);
+                    results.push(DocTestResult {
+                        input: test.input,
+                        passed,
+                        expected: format!("!! {expected_substring}"),
+                        actual: format!("!! {e}"),
+                        line: test.line,
+                    });
+                }
+            },
+        }
+    }
+
+    results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_basic() {
+        let doc = r#"Does something.
+
+   >>> (+ 1 2)
+   3
+
+   >>> (string/trim "  hi  ")
+   "hi""#;
+        let tests = parse_doctests(doc);
+        assert_eq!(tests.len(), 2);
+        assert_eq!(tests[0].input, "(+ 1 2)");
+        assert!(matches!(tests[0].expected, Expected::Value(ref s) if s == "3"));
+        assert_eq!(tests[1].input, r#"(string/trim "  hi  ")"#);
+    }
+
+    #[test]
+    fn test_parse_error_expected() {
+        let doc = r#"Fails on bad input.
+
+   >>> (/ 1 0)
+   !! division by zero"#;
+        let tests = parse_doctests(doc);
+        assert_eq!(tests.len(), 1);
+        assert!(matches!(tests[0].expected, Expected::Error(ref s) if s == "division by zero"));
+    }
+
+    #[test]
+    fn test_parse_setup_step() {
+        let doc = r#"Needs setup.
+
+   >>>! (define x 42)
+   >>> x
+   42"#;
+        let tests = parse_doctests(doc);
+        assert_eq!(tests.len(), 2);
+        assert!(matches!(tests[0].expected, Expected::Skip));
+        assert_eq!(tests[1].input, "x");
+    }
+
+    #[test]
+    fn test_parse_empty_docstring() {
+        let tests = parse_doctests("Just a description, no examples.");
+        assert!(tests.is_empty());
+    }
+}

--- a/crates/sema-eval/src/evolve.rs
+++ b/crates/sema-eval/src/evolve.rs
@@ -1,0 +1,286 @@
+//! LLM-driven genetic programming: `(evolve ...)` implementation.
+
+use std::collections::BTreeMap;
+
+use sema_core::{call_callback, intern, resolve, Env, EvalContext, SemaError, Spur, Value};
+
+use crate::eval;
+
+/// Configuration parsed from `(evolve :name "..." :spec ... ...)` keyword args.
+pub struct EvolveConfig {
+    pub name: Spur,
+    pub name_str: String,
+    pub spec: Spec,
+    pub population: usize,
+    pub generations: usize,
+    pub fitness_fn: Value,
+    pub seed_prompt: String,
+    pub verbose: bool,
+    pub max_attempts: usize,
+}
+
+/// The specification: either inline `(>>> expr expected)` forms or a docstring reference.
+pub enum Spec {
+    /// Inline: list of (>>> expr expected) forms, stored as (input_source, expected_source) pairs.
+    Inline(Vec<SpecCase>),
+    /// Symbol reference: use the docstring's doctests.
+    Docstring(String),
+}
+
+/// A single spec case from inline `(>>> expr expected)`.
+pub struct SpecCase {
+    pub input: String,
+    pub expected: String,
+}
+
+/// A candidate in the population.
+pub struct Candidate {
+    pub source: String,
+    pub fn_value: Option<Value>,
+    pub fitness: f64,
+    pub spec_passed: usize,
+    pub spec_total: usize,
+    pub time_ms: f64,
+    pub error: Option<String>,
+}
+
+/// Parse keyword args from the special form into an EvolveConfig.
+pub fn parse_config(
+    args: &[Value],
+    env: &Env,
+    ctx: &EvalContext,
+) -> Result<EvolveConfig, SemaError> {
+    let mut name: Option<String> = None;
+    let mut spec: Option<Spec> = None;
+    let mut population: usize = 10;
+    let mut generations: usize = 5;
+    let mut fitness_fn: Option<Value> = None;
+    let mut seed_prompt: Option<String> = None;
+    let mut verbose = false;
+    let mut max_attempts: usize = 3;
+
+    let mut i = 0;
+    while i < args.len() {
+        let kw = args[i]
+            .as_keyword()
+            .ok_or_else(|| SemaError::eval(format!("evolve: expected keyword, got {}", args[i])))?;
+        if i + 1 >= args.len() {
+            return Err(SemaError::eval(format!("evolve: missing value for :{kw}")));
+        }
+        let val = eval::eval_value(ctx, &args[i + 1], env)?;
+
+        match kw.as_str() {
+            "name" => {
+                name = Some(
+                    val.as_str()
+                        .ok_or_else(|| SemaError::type_error("string", val.type_name()))?
+                        .to_string(),
+                );
+            }
+            "spec" => {
+                spec = Some(parse_spec(&val, env)?);
+            }
+            "population" => {
+                let v = val
+                    .as_int()
+                    .ok_or_else(|| SemaError::type_error("integer", val.type_name()))?;
+                if v < 0 {
+                    return Err(SemaError::eval("evolve: :population must be non-negative"));
+                }
+                population = v as usize;
+            }
+            "generations" => {
+                let v = val
+                    .as_int()
+                    .ok_or_else(|| SemaError::type_error("integer", val.type_name()))?;
+                if v < 0 {
+                    return Err(SemaError::eval("evolve: :generations must be non-negative"));
+                }
+                generations = v as usize;
+            }
+            "fitness" => {
+                fitness_fn = Some(val);
+            }
+            "seed-prompt" => {
+                seed_prompt = Some(
+                    val.as_str()
+                        .ok_or_else(|| SemaError::type_error("string", val.type_name()))?
+                        .to_string(),
+                );
+            }
+            "verbose" => {
+                verbose = val.is_truthy();
+            }
+            "max-attempts" => {
+                let v = val
+                    .as_int()
+                    .ok_or_else(|| SemaError::type_error("integer", val.type_name()))?;
+                if v < 1 {
+                    return Err(SemaError::eval("evolve: :max-attempts must be at least 1"));
+                }
+                max_attempts = v as usize;
+            }
+            other => {
+                return Err(SemaError::eval(format!("evolve: unknown option :{other}"))
+                    .with_hint("Valid options: :name :spec :population :generations :fitness :seed-prompt :verbose :max-attempts"));
+            }
+        }
+        i += 2;
+    }
+
+    let name_str = name.ok_or_else(|| SemaError::eval("evolve: :name is required"))?;
+    let name_spur = intern(&name_str);
+
+    Ok(EvolveConfig {
+        name: name_spur,
+        name_str,
+        spec: spec.ok_or_else(|| SemaError::eval("evolve: :spec is required"))?,
+        population,
+        generations,
+        fitness_fn: fitness_fn.ok_or_else(|| SemaError::eval("evolve: :fitness is required"))?,
+        seed_prompt: seed_prompt
+            .ok_or_else(|| SemaError::eval("evolve: :seed-prompt is required"))?,
+        verbose,
+        max_attempts,
+    })
+}
+
+/// Parse the :spec value into a Spec enum.
+fn parse_spec(val: &Value, env: &Env) -> Result<Spec, SemaError> {
+    // If it's a list, treat as inline spec: ((>>> expr expected) ...)
+    if let Some(items) = val.as_list() {
+        let mut cases = Vec::new();
+        for item in items {
+            let form = item
+                .as_list()
+                .ok_or_else(|| SemaError::eval("evolve: each spec case must be a list"))?;
+            if form.len() != 3 {
+                return Err(SemaError::eval(
+                    "evolve: spec case must be (>>> expr expected)",
+                ));
+            }
+            let marker = form[0]
+                .as_symbol()
+                .ok_or_else(|| SemaError::eval("evolve: spec case must start with >>>"))?;
+            if marker != ">>>" {
+                return Err(SemaError::eval(format!(
+                    "evolve: spec case must start with >>>, got {marker}"
+                )));
+            }
+            cases.push(SpecCase {
+                input: form[1].to_string(),
+                expected: form[2].to_string(),
+            });
+        }
+        if cases.is_empty() {
+            return Err(SemaError::eval("evolve: :spec list is empty"));
+        }
+        Ok(Spec::Inline(cases))
+    } else if val.as_lambda_rc().is_some() || val.as_native_fn_rc().is_some() {
+        // It's a function — extract its docstring
+        if let Some(lambda) = val.as_lambda_rc() {
+            if let Some(name_spur) = lambda.name {
+                if let Some(meta) = env.get_meta(name_spur) {
+                    if let Some(doc) = meta.get(&Value::keyword("doc")) {
+                        if let Some(s) = doc.as_str() {
+                            let doctests = crate::doctest::parse_doctests(s);
+                            if doctests.is_empty() {
+                                return Err(SemaError::eval(
+                                    "evolve: function has no doctests in its docstring",
+                                )
+                                .with_hint("Add >>> examples to the docstring"));
+                            }
+                            return Ok(Spec::Docstring(s.to_string()));
+                        }
+                    }
+                }
+                return Err(SemaError::eval(format!(
+                    "evolve: function '{}' has no docstring",
+                    resolve(name_spur)
+                )));
+            }
+        }
+        Err(SemaError::eval(
+            "evolve: :spec function must be a named function with doctests",
+        ))
+    } else {
+        Err(SemaError::type_error(
+            "list of (>>> ...) forms or a function with doctests",
+            val.type_name(),
+        ))
+    }
+}
+
+/// Run spec cases against a candidate function in a sandbox env.
+/// Returns (passed, total, time_ms).
+pub fn run_spec(
+    config: &EvolveConfig,
+    ctx: &EvalContext,
+    sandbox_env: &Env,
+) -> (usize, usize, f64) {
+    match &config.spec {
+        Spec::Inline(cases) => {
+            let start = std::time::Instant::now();
+            let mut passed = 0;
+            let total = cases.len();
+            for case in cases {
+                if let Ok(result) = eval::eval_string(ctx, &case.input, sandbox_env) {
+                    let actual = result.to_string();
+                    if actual.trim() == case.expected.trim() {
+                        passed += 1;
+                    }
+                }
+            }
+            let time_ms = start.elapsed().as_secs_f64() * 1000.0;
+            (passed, total, time_ms)
+        }
+        Spec::Docstring(docstring) => {
+            let start = std::time::Instant::now();
+            let results = crate::doctest::run_doctests(docstring, &mut |input| {
+                eval::eval_string(ctx, input, sandbox_env)
+            });
+            let time_ms = start.elapsed().as_secs_f64() * 1000.0;
+            let passed = results.iter().filter(|r| r.passed).count();
+            let total = results.len();
+            (passed, total, time_ms)
+        }
+    }
+}
+
+/// Compute fitness by calling the user's fitness function.
+pub fn compute_fitness(
+    fitness_fn: &Value,
+    candidate_fn: &Value,
+    passed: usize,
+    total: usize,
+    time_ms: f64,
+    ctx: &EvalContext,
+) -> f64 {
+    let mut spec_results = BTreeMap::new();
+    spec_results.insert(Value::keyword("passed"), Value::int(passed as i64));
+    spec_results.insert(Value::keyword("total"), Value::int(total as i64));
+    spec_results.insert(Value::keyword("time-ms"), Value::float(time_ms));
+
+    match call_callback(
+        ctx,
+        fitness_fn,
+        &[candidate_fn.clone(), Value::map(spec_results)],
+    ) {
+        Ok(val) => val
+            .as_float()
+            .or_else(|| val.as_int().map(|i| i as f64))
+            .unwrap_or(0.0),
+        Err(_) => 0.0,
+    }
+}
+
+/// Strip code fences from LLM response.
+pub fn strip_code_fences(response: &str) -> &str {
+    let trimmed = response.trim();
+    let stripped = trimmed
+        .strip_prefix("```lisp")
+        .or_else(|| trimmed.strip_prefix("```sema"))
+        .or_else(|| trimmed.strip_prefix("```"))
+        .unwrap_or(trimmed);
+    stripped.strip_suffix("```").unwrap_or(stripped).trim()
+}

--- a/crates/sema-eval/src/lib.rs
+++ b/crates/sema-eval/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::mutable_key_type)]
 mod destructure;
+pub mod doctest;
 mod eval;
 mod prelude;
 mod special_forms;

--- a/crates/sema-eval/src/lib.rs
+++ b/crates/sema-eval/src/lib.rs
@@ -2,6 +2,7 @@
 mod destructure;
 pub mod doctest;
 mod eval;
+pub mod evolve;
 mod prelude;
 mod special_forms;
 

--- a/crates/sema-eval/src/special_forms.rs
+++ b/crates/sema-eval/src/special_forms.rs
@@ -76,6 +76,7 @@ struct SpecialFormSpurs {
 
     // Runtime self-modification
     become_: Spur,
+    evolve: Spur,
     freeze: Spur,
     history: Spur,
     observe: Spur,
@@ -149,6 +150,7 @@ impl SpecialFormSpurs {
 
             // Runtime self-modification
             become_: intern("become!"),
+            evolve: intern("evolve"),
             freeze: intern("freeze!"),
             history: intern("history"),
             observe: intern("observe!"),
@@ -235,6 +237,7 @@ pub const SPECIAL_FORM_NAMES: &[&str] = &[
     "source-of",
     // Runtime self-modification
     "become!",
+    "evolve",
     "freeze!",
     "history",
     "observe!",
@@ -355,6 +358,8 @@ pub fn try_eval_special(
     // Runtime self-modification
     } else if head_spur == sf.become_ {
         Some(eval_become(args, env, ctx))
+    } else if head_spur == sf.evolve {
+        Some(eval_evolve(args, env, ctx))
     } else if head_spur == sf.freeze {
         Some(eval_freeze(args, env))
     } else if head_spur == sf.history {
@@ -3073,6 +3078,284 @@ fn eval_freeze(args: &[Value], env: &Env) -> Result<Trampoline, SemaError> {
     env.set_meta(spur, Value::keyword("frozen?"), Value::bool(true));
 
     Ok(Trampoline::Value(Value::nil()))
+}
+
+/// (evolve :name "..." :spec ... :fitness fn :seed-prompt "..." ...)
+/// LLM-driven genetic programming.
+fn eval_evolve(args: &[Value], env: &Env, ctx: &EvalContext) -> Result<Trampoline, SemaError> {
+    let config = crate::evolve::parse_config(args, env, ctx)?;
+
+    let system_prompt = "You are writing Sema (a Lisp dialect). Write a function that satisfies \
+                         the given specification. Return ONLY a (fn (params...) body...) expression. \
+                         No markdown, no explanation, no code fences. Just the Sema expression.";
+
+    let crossover_system = "You are writing Sema (a Lisp dialect). You are given two functions that \
+                            solve the same problem. Create a new function that combines the best ideas \
+                            from both. Return ONLY a (fn ...) expression. No markdown, no explanation.";
+
+    let mutate_system = "You are writing Sema (a Lisp dialect). Modify this function to be \
+                         faster or better while still passing all tests. Return ONLY a (fn ...) \
+                         expression. No markdown, no explanation.";
+
+    // Build spec description for prompts
+    let spec_description = match &config.spec {
+        crate::evolve::Spec::Inline(cases) => {
+            let mut desc = String::new();
+            for case in cases {
+                desc.push_str(&format!(
+                    "  ({}) should return {}\n",
+                    case.input, case.expected
+                ));
+            }
+            desc
+        }
+        crate::evolve::Spec::Docstring(ds) => {
+            let mut desc = String::new();
+            for test in crate::doctest::parse_doctests(ds) {
+                match &test.expected {
+                    crate::doctest::Expected::Value(v) => {
+                        desc.push_str(&format!("  ({}) should return {}\n", test.input, v));
+                    }
+                    crate::doctest::Expected::Error(e) => {
+                        desc.push_str(&format!("  ({}) should error with: {}\n", test.input, e));
+                    }
+                    crate::doctest::Expected::Skip => {
+                        desc.push_str(&format!("  ({}) — setup step\n", test.input));
+                    }
+                }
+            }
+            desc
+        }
+    };
+
+    let fn_name = &config.name_str;
+
+    // Generation 0: seed population via LLM
+    let mut population: Vec<crate::evolve::Candidate> = Vec::new();
+
+    if config.verbose {
+        eprintln!(
+            "evolve: seeding {} candidates for '{fn_name}'...",
+            config.population
+        );
+    }
+
+    for slot in 0..config.population {
+        let prompt = format!(
+            "{}\n\nThe function will be bound as '{fn_name}'. Specification:\n{spec_description}\n\
+             Write a (fn ...) expression that satisfies all the above.",
+            config.seed_prompt
+        );
+        let candidate = generate_candidate(env, ctx, &config, &prompt, system_prompt, slot);
+        population.push(candidate);
+    }
+
+    // Log generation 0
+    if config.verbose {
+        log_generation(0, &population);
+    }
+
+    // Evolution loop
+    for gen in 1..=config.generations {
+        let mut next_gen: Vec<crate::evolve::Candidate> = Vec::new();
+
+        // Sort by fitness descending
+        population.sort_by(|a, b| {
+            b.fitness
+                .partial_cmp(&a.fitness)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        // Elite count: top 30%
+        let elite_count = std::cmp::max(1, config.population * 30 / 100);
+        for elite in population.iter().take(elite_count) {
+            next_gen.push(crate::evolve::Candidate {
+                source: elite.source.clone(),
+                fn_value: elite.fn_value.clone(),
+                fitness: elite.fitness,
+                spec_passed: elite.spec_passed,
+                spec_total: elite.spec_total,
+                time_ms: elite.time_ms,
+                error: elite.error.clone(),
+            });
+        }
+
+        // Fill remaining slots with crossover/mutation
+        let viable: Vec<&crate::evolve::Candidate> =
+            population.iter().filter(|c| c.fitness > 0.0).collect();
+
+        for slot in elite_count..config.population {
+            let candidate = if viable.len() >= 2 && slot % 5 != 0 {
+                // Crossover: pick two parents weighted by rank
+                let parent_a = &viable[slot % viable.len()];
+                let parent_b = &viable[(slot * 7 + 3) % viable.len()];
+
+                let prompt = format!(
+                    "Parent A (fitness {:.1}):\n{}\n\nParent B (fitness {:.1}):\n{}\n\n\
+                     Specification:\n{spec_description}\n\
+                     Create a new (fn ...) that combines the best ideas from both parents.",
+                    parent_a.fitness, parent_a.source, parent_b.fitness, parent_b.source,
+                );
+                generate_candidate(env, ctx, &config, &prompt, crossover_system, slot)
+            } else if !viable.is_empty() {
+                // Mutation: modify a single parent
+                let parent = &viable[slot % viable.len()];
+                let prompt = format!(
+                    "Current function (fitness {:.1}):\n{}\n\n\
+                     Specification:\n{spec_description}\n\
+                     Modify this function to be faster or better.",
+                    parent.fitness, parent.source,
+                );
+                generate_candidate(env, ctx, &config, &prompt, mutate_system, slot)
+            } else {
+                // No viable parents — reseed
+                let prompt = format!(
+                    "{}\n\nThe function will be bound as '{fn_name}'. Specification:\n{spec_description}\n\
+                     Write a (fn ...) expression that satisfies all the above.",
+                    config.seed_prompt
+                );
+                generate_candidate(env, ctx, &config, &prompt, system_prompt, slot)
+            };
+            next_gen.push(candidate);
+        }
+
+        population = next_gen;
+
+        if config.verbose {
+            log_generation(gen, &population);
+        }
+    }
+
+    // Return the best candidate
+    population.sort_by(|a, b| {
+        b.fitness
+            .partial_cmp(&a.fitness)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    match population.first() {
+        Some(best) if best.fn_value.is_some() && best.fitness > 0.0 => {
+            let fn_val = best.fn_value.clone().unwrap();
+            if config.verbose {
+                eprintln!(
+                    "evolve: winner for '{}' -- fitness {:.1}, {}/{} spec pass, {:.2}ms",
+                    fn_name, best.fitness, best.spec_passed, best.spec_total, best.time_ms
+                );
+            }
+            Ok(Trampoline::Value(fn_val))
+        }
+        _ => Err(SemaError::eval(format!(
+            "evolve: no viable candidate found for '{fn_name}' after {} generations",
+            config.generations
+        ))),
+    }
+}
+
+/// Generate a single candidate: call LLM, parse, eval in sandbox, run spec, compute fitness.
+/// Retries up to config.max_attempts on failure.
+fn generate_candidate(
+    env: &Env,
+    ctx: &EvalContext,
+    config: &crate::evolve::EvolveConfig,
+    prompt: &str,
+    system: &str,
+    _slot: usize,
+) -> crate::evolve::Candidate {
+    let mut last_error: Option<String> = None;
+    for _attempt in 0..config.max_attempts {
+        // Call LLM
+        let response = match call_llm_complete(env, ctx, prompt, system) {
+            Ok(v) => v,
+            Err(e) => {
+                return crate::evolve::Candidate {
+                    source: String::new(),
+                    fn_value: None,
+                    fitness: 0.0,
+                    spec_passed: 0,
+                    spec_total: 0,
+                    time_ms: 0.0,
+                    error: Some(format!("LLM error: {e}")),
+                };
+            }
+        };
+        let response_str = match response.as_str() {
+            Some(s) => s.to_string(),
+            None => {
+                last_error = Some("LLM returned non-string response".to_string());
+                continue;
+            }
+        };
+        let code = crate::evolve::strip_code_fences(&response_str).to_string();
+
+        // Parse
+        let expr = match sema_reader::read(&code) {
+            Ok(e) => e,
+            Err(e) => {
+                last_error = Some(format!("parse error: {e}"));
+                continue;
+            }
+        };
+
+        // Eval in sandbox
+        let sandbox_env = Env::with_parent(Rc::new(env.clone()));
+        let fn_value = match eval::eval_value(ctx, &expr, &sandbox_env) {
+            Ok(v) => v,
+            Err(e) => {
+                last_error = Some(format!("eval error: {e}"));
+                continue;
+            }
+        };
+
+        // Bind the function by name so spec cases can call it
+        sandbox_env.set(config.name, fn_value.clone());
+
+        // Run spec
+        let (passed, total, time_ms) = crate::evolve::run_spec(config, ctx, &sandbox_env);
+
+        // Compute fitness
+        let fitness = crate::evolve::compute_fitness(
+            &config.fitness_fn,
+            &fn_value,
+            passed,
+            total,
+            time_ms,
+            ctx,
+        );
+
+        return crate::evolve::Candidate {
+            source: code,
+            fn_value: Some(fn_value),
+            fitness,
+            spec_passed: passed,
+            spec_total: total,
+            time_ms,
+            error: None,
+        };
+    }
+
+    // Exhausted retries — zero-fitness sentinel
+    let error_msg = match last_error {
+        Some(e) => format!("max attempts exhausted (last: {e})"),
+        None => "max attempts exhausted".to_string(),
+    };
+    crate::evolve::Candidate {
+        source: String::new(),
+        fn_value: None,
+        fitness: 0.0,
+        spec_passed: 0,
+        spec_total: 0,
+        time_ms: 0.0,
+        error: Some(error_msg),
+    }
+}
+
+fn log_generation(gen: usize, population: &[crate::evolve::Candidate]) {
+    let viable = population.iter().filter(|c| c.fitness > 0.0).count();
+    let best = population.iter().map(|c| c.fitness).fold(0.0f64, f64::max);
+    eprintln!(
+        "  Generation {gen}: {} candidates, {viable} viable, best fitness: {best:.1}",
+        population.len()
+    );
 }
 
 /// Parse parameter list, handling rest params (e.g., `(a b . rest)`)

--- a/crates/sema-eval/src/special_forms.rs
+++ b/crates/sema-eval/src/special_forms.rs
@@ -1,4 +1,5 @@
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
+use std::collections::BTreeMap;
 use std::rc::Rc;
 
 use sema_core::{
@@ -63,6 +64,23 @@ struct SpecialFormSpurs {
     message: Spur,
     prompt: Spur,
 
+    // Introspection
+    ask: Spur,
+    ask_code: Spur,
+    doc: Spur,
+    doc_search: Spur,
+    doctest: Spur,
+    heal: Spur,
+    meta: Spur,
+    source_of: Spur,
+
+    // Runtime self-modification
+    become_: Spur,
+    freeze: Spur,
+    history: Spur,
+    observe: Spur,
+    rollback: Spur,
+
     // Silent aliases for other Lisp dialects
     def: Spur,
     defn: Spur,
@@ -118,6 +136,23 @@ impl SpecialFormSpurs {
             deftool: intern("deftool"),
             message: intern("message"),
             prompt: intern("prompt"),
+
+            // Introspection
+            ask: intern("ask"),
+            ask_code: intern("ask/code"),
+            doc: intern("doc"),
+            doc_search: intern("doc/search"),
+            doctest: intern("doctest"),
+            heal: intern("heal!"),
+            meta: intern("meta"),
+            source_of: intern("source-of"),
+
+            // Runtime self-modification
+            become_: intern("become!"),
+            freeze: intern("freeze!"),
+            history: intern("history"),
+            observe: intern("observe!"),
+            rollback: intern("rollback!"),
 
             // Silent aliases
             def: intern("def"),
@@ -189,6 +224,21 @@ pub const SPECIAL_FORM_NAMES: &[&str] = &[
     "deftool",
     "message",
     "prompt",
+    // Introspection
+    "ask",
+    "ask/code",
+    "doc",
+    "doc/search",
+    "doctest",
+    "heal!",
+    "meta",
+    "source-of",
+    // Runtime self-modification
+    "become!",
+    "freeze!",
+    "history",
+    "observe!",
+    "rollback!",
     // Silent aliases for other Lisp dialects (undocumented)
     "def",
     "defn",
@@ -224,7 +274,7 @@ pub fn try_eval_special(
     } else if head_spur == sf.define_record_type {
         Some(eval_define_record_type(args, env))
     } else if head_spur == sf.defmacro {
-        Some(eval_defmacro(args, env))
+        Some(eval_defmacro(args, env, ctx))
     } else if head_spur == sf.defmethod {
         Some(eval_defmethod(args, env, ctx))
     } else if head_spur == sf.defmulti {
@@ -283,6 +333,36 @@ pub fn try_eval_special(
         Some(eval_message(args, env, ctx))
     } else if head_spur == sf.prompt {
         Some(eval_prompt(args, env, ctx))
+
+    // Introspection
+    } else if head_spur == sf.ask {
+        Some(eval_ask(args, env, ctx))
+    } else if head_spur == sf.ask_code {
+        Some(eval_ask_code(args, env, ctx))
+    } else if head_spur == sf.doc {
+        Some(eval_doc(args, env))
+    } else if head_spur == sf.doc_search {
+        Some(eval_doc_search(args, env, ctx))
+    } else if head_spur == sf.doctest {
+        Some(eval_doctest(args, env, ctx))
+    } else if head_spur == sf.heal {
+        Some(eval_heal(args, env, ctx))
+    } else if head_spur == sf.meta {
+        Some(eval_meta(args, env))
+    } else if head_spur == sf.source_of {
+        Some(eval_source_of(args, env))
+
+    // Runtime self-modification
+    } else if head_spur == sf.become_ {
+        Some(eval_become(args, env, ctx))
+    } else if head_spur == sf.freeze {
+        Some(eval_freeze(args, env))
+    } else if head_spur == sf.history {
+        Some(eval_history(args, env))
+    } else if head_spur == sf.observe {
+        Some(eval_observe(args, env, ctx))
+    } else if head_spur == sf.rollback {
+        Some(eval_rollback(args, env, ctx))
     } else {
         None
     }
@@ -369,7 +449,15 @@ fn eval_define(args: &[Value], env: &Env, ctx: &EvalContext) -> Result<Trampolin
             })
             .collect::<Result<_, _>>()?;
         let (params, rest_param) = parse_params(&param_names);
-        let body = args[1..].to_vec();
+
+        // Detect optional docstring: (define (f x) "doc" body...)
+        let (docstring, body_start) = if args.len() > 2 && args[1].as_str().is_some() {
+            (args[1].as_str().map(|s| s.to_string()), 2)
+        } else {
+            (None, 1)
+        };
+
+        let body = args[body_start..].to_vec();
         if body.is_empty() {
             return Err(SemaError::eval("define: function body cannot be empty"));
         }
@@ -388,6 +476,30 @@ fn eval_define(args: &[Value], env: &Env, ctx: &EvalContext) -> Result<Trampolin
             }
         }
         env.set(name_spur, lambda);
+        if let Some(ref doc) = docstring {
+            env.set_meta(name_spur, Value::keyword("doc"), Value::string(doc));
+        }
+
+        // Store source text
+        let mut source_parts: Vec<Value> = vec![Value::symbol("define"), args[0].clone()];
+        if let Some(ref doc) = docstring {
+            source_parts.push(Value::string(doc));
+        }
+        source_parts.extend_from_slice(&args[body_start..]);
+        let source_form = Value::list(source_parts);
+        env.set_meta(
+            name_spur,
+            Value::keyword("source"),
+            Value::string(&source_form.to_string()),
+        );
+        if let Some(file_path) = ctx.current_file_path() {
+            env.set_meta(
+                name_spur,
+                Value::keyword("file"),
+                Value::string(&file_path.to_string_lossy()),
+            );
+        }
+
         Ok(Trampoline::Value(Value::nil()))
     } else if destructure::is_destructuring_pattern(&args[0]) {
         // (define [a b] expr) or (define {:keys [x y]} expr)
@@ -408,25 +520,66 @@ fn eval_define(args: &[Value], env: &Env, ctx: &EvalContext) -> Result<Trampolin
     }
 }
 
-/// (defun name (params...) body...) => (define (name params...) body...)
+/// (defun name (params...) body...) or (defun name "doc" (params...) body...)
 fn eval_defun(args: &[Value], env: &Env, ctx: &EvalContext) -> Result<Trampoline, SemaError> {
     if args.len() < 3 {
         return Err(SemaError::arity("defun", "3+", args.len()));
     }
-    if args[0].as_symbol_spur().is_none() {
-        return Err(SemaError::type_error("symbol", args[0].type_name()));
+    let name_spur = args[0]
+        .as_symbol_spur()
+        .ok_or_else(|| SemaError::type_error("symbol", args[0].type_name()))?;
+
+    // Detect optional docstring: (defn name "doc" (params) body...)
+    let (docstring, params_idx) = if args[1].as_str().is_some() && args.len() >= 3 {
+        (args[1].as_str().map(|s| s.to_string()), 2)
+    } else {
+        (None, 1)
+    };
+
+    if params_idx >= args.len() {
+        return Err(SemaError::eval(
+            "defun: missing parameter list after docstring",
+        ));
     }
+
     let name = args[0].clone();
-    let params = args[1]
+    let params = args[params_idx]
         .as_list_rc()
-        .ok_or_else(|| SemaError::type_error("list", args[1].type_name()))?;
+        .ok_or_else(|| SemaError::type_error("list", args[params_idx].type_name()))?;
     // Build (name params...) signature list
     let mut sig = vec![name];
     sig.extend(params.iter().cloned());
     // Build transformed args: [(name params...), body...]
     let mut define_args = vec![Value::list(sig)];
-    define_args.extend_from_slice(&args[2..]);
-    eval_define(&define_args, env, ctx)
+    define_args.extend_from_slice(&args[params_idx + 1..]);
+    let result = eval_define(&define_args, env, ctx)?;
+
+    if let Some(ref doc) = docstring {
+        env.set_meta(name_spur, Value::keyword("doc"), Value::string(doc));
+    }
+
+    // Store source text as defn form (overrides define source from eval_define)
+    let mut source_parts = vec![Value::symbol("defn"), args[0].clone()];
+    if let Some(ref doc) = docstring {
+        source_parts.push(Value::string(doc));
+    }
+    source_parts.push(args[params_idx].clone());
+    source_parts.extend_from_slice(&args[params_idx + 1..]);
+    let source_form = Value::list(source_parts);
+    env.set_meta(
+        name_spur,
+        Value::keyword("source"),
+        Value::string(&source_form.to_string()),
+    );
+    if let Some(file_path) = ctx.current_file_path() {
+        env.set_meta(
+            name_spur,
+            Value::keyword("file"),
+            Value::string(&file_path.to_string_lossy()),
+        );
+    }
+
+    Ok(result)
 }
 
 fn eval_set(args: &[Value], env: &Env, ctx: &EvalContext) -> Result<Trampoline, SemaError> {
@@ -800,14 +953,22 @@ fn eval_while(args: &[Value], env: &Env, ctx: &EvalContext) -> Result<Trampoline
     }
 }
 
-fn eval_defmacro(args: &[Value], env: &Env) -> Result<Trampoline, SemaError> {
+fn eval_defmacro(args: &[Value], env: &Env, ctx: &EvalContext) -> Result<Trampoline, SemaError> {
     if args.len() < 3 {
         return Err(SemaError::arity("defmacro", "3+", args.len()));
     }
     let name_spur = args[0]
         .as_symbol_spur()
         .ok_or_else(|| SemaError::eval("defmacro: name must be a symbol"))?;
-    let param_list = args[1]
+
+    // Detect optional docstring: (defmacro name "doc" (params) body...)
+    let (docstring, params_idx) = if args[1].as_str().is_some() && args.len() >= 4 {
+        (args[1].as_str().map(|s| s.to_string()), 2)
+    } else {
+        (None, 1)
+    };
+
+    let param_list = args[params_idx]
         .as_list()
         .ok_or_else(|| SemaError::eval("defmacro: params must be a list"))?;
     let param_names: Vec<Spur> = param_list
@@ -818,7 +979,7 @@ fn eval_defmacro(args: &[Value], env: &Env) -> Result<Trampoline, SemaError> {
         })
         .collect::<Result<_, _>>()?;
     let (params, rest_param) = parse_params(&param_names);
-    let body = args[2..].to_vec();
+    let body = args[params_idx + 1..].to_vec();
 
     let mac = Value::macro_val(Macro {
         params,
@@ -827,6 +988,31 @@ fn eval_defmacro(args: &[Value], env: &Env) -> Result<Trampoline, SemaError> {
         name: name_spur,
     });
     env.set(name_spur, mac);
+    if let Some(ref doc) = docstring {
+        env.set_meta(name_spur, Value::keyword("doc"), Value::string(doc));
+    }
+
+    // Store source text
+    let mut source_parts = vec![Value::symbol("defmacro"), args[0].clone()];
+    if let Some(ref doc) = docstring {
+        source_parts.push(Value::string(doc));
+    }
+    source_parts.push(args[params_idx].clone());
+    source_parts.extend_from_slice(&args[params_idx + 1..]);
+    let source_form = Value::list(source_parts);
+    env.set_meta(
+        name_spur,
+        Value::keyword("source"),
+        Value::string(&source_form.to_string()),
+    );
+    if let Some(file_path) = ctx.current_file_path() {
+        env.set_meta(
+            name_spur,
+            Value::keyword("file"),
+            Value::string(&file_path.to_string_lossy()),
+        );
+    }
+
     Ok(Trampoline::Value(Value::nil()))
 }
 
@@ -2080,6 +2266,784 @@ fn eval_define_record_type(args: &[Value], env: &Env) -> Result<Trampoline, Sema
             )),
         );
     }
+
+    Ok(Trampoline::Value(Value::nil()))
+}
+
+// ── Introspection special forms ───────────────────────────────────
+
+/// Gather context string for the `ask` family of special forms.
+fn gather_ask_context(target: &Value, env: &Env) -> String {
+    if let Some(lambda) = target.as_lambda_rc() {
+        let mut ctx = String::new();
+        let name = lambda
+            .name
+            .map(resolve)
+            .unwrap_or_else(|| "<anonymous>".to_string());
+        ctx.push_str(&format!("Function: {name}\n"));
+
+        let params: Vec<String> = lambda.params.iter().map(|s| resolve(*s)).collect();
+        ctx.push_str(&format!("Parameters: ({})\n", params.join(" ")));
+
+        if let Some(name_spur) = lambda.name {
+            if let Some(meta) = env.get_meta(name_spur) {
+                if let Some(doc) = meta.get(&Value::keyword("doc")) {
+                    if let Some(s) = doc.as_str() {
+                        ctx.push_str(&format!("Documentation:\n{s}\n"));
+                    }
+                }
+                if let Some(source) = meta.get(&Value::keyword("source")) {
+                    if let Some(s) = source.as_str() {
+                        ctx.push_str(&format!("Source code:\n{s}\n"));
+                    }
+                }
+            }
+        }
+        ctx
+    } else if let Some(s) = target.as_str() {
+        if s.ends_with(".sema") {
+            match std::fs::read_to_string(s) {
+                Ok(content) => format!("File: {s}\nContents:\n{content}\n"),
+                Err(e) => format!("File: {s}\nError reading: {e}\n"),
+            }
+        } else {
+            format!("Value: {s}\n")
+        }
+    } else {
+        let repr = target.to_string();
+        let truncated = if repr.len() > 4000 {
+            format!("{}... (truncated)", &repr[..4000])
+        } else {
+            repr
+        };
+        format!("Value ({}):\n{truncated}\n", target.type_name())
+    }
+}
+
+/// Call llm/complete through the env binding.
+fn call_llm_complete(
+    env: &Env,
+    ctx: &EvalContext,
+    prompt: &str,
+    system: &str,
+) -> Result<Value, SemaError> {
+    let llm_complete_spur = intern("llm/complete");
+    let llm_fn = env.get(llm_complete_spur).ok_or_else(|| {
+        SemaError::eval(
+            "ask: llm/complete not available. Configure an LLM provider first with (llm/configure ...)",
+        )
+        .with_hint(
+            "Example: (llm/configure :anthropic {:api-key (env/get \"ANTHROPIC_API_KEY\")})",
+        )
+    })?;
+
+    let mut opts = BTreeMap::new();
+    opts.insert(Value::keyword("system"), Value::string(system));
+
+    let args = vec![Value::string(prompt), Value::map(opts)];
+    sema_core::call_callback(ctx, &llm_fn, &args)
+}
+
+/// (ask target question) — ask a question about any value
+fn eval_ask(args: &[Value], env: &Env, ctx: &EvalContext) -> Result<Trampoline, SemaError> {
+    if args.len() != 2 {
+        return Err(SemaError::arity("ask", "2", args.len()));
+    }
+    let target = eval::eval_value(ctx, &args[0], env)?;
+    let question = eval::eval_value(ctx, &args[1], env)?;
+    let question_str = question
+        .as_str()
+        .ok_or_else(|| SemaError::type_error("string", question.type_name()))?;
+
+    let context = gather_ask_context(&target, env);
+
+    let system = "You are a Sema language expert. You have been given source code and metadata \
+                  for a Sema value. Answer the user's question about it. If suggesting code \
+                  changes, write valid Sema. Be concise.";
+
+    let prompt = format!("{context}\n\nQuestion: {question_str}");
+
+    let result = call_llm_complete(env, ctx, &prompt, system)?;
+    Ok(Trampoline::Value(result))
+}
+
+/// (ask/code target instruction) — get executable Sema code from LLM
+fn eval_ask_code(args: &[Value], env: &Env, ctx: &EvalContext) -> Result<Trampoline, SemaError> {
+    if args.len() != 2 {
+        return Err(SemaError::arity("ask/code", "2", args.len()));
+    }
+    let target = eval::eval_value(ctx, &args[0], env)?;
+    let instruction = eval::eval_value(ctx, &args[1], env)?;
+    let instruction_str = instruction
+        .as_str()
+        .ok_or_else(|| SemaError::type_error("string", instruction.type_name()))?;
+
+    let context = gather_ask_context(&target, env);
+
+    let system = "You are a Sema language expert. Given source code and an instruction, \
+                  respond with ONLY valid Sema code. No markdown, no explanation, no code \
+                  fences. Just the Sema expression.";
+
+    let prompt = format!("{context}\n\nInstruction: {instruction_str}");
+
+    let response = call_llm_complete(env, ctx, &prompt, system)?;
+    let response_str = response
+        .as_str()
+        .ok_or_else(|| SemaError::eval("ask/code: LLM did not return a string"))?;
+
+    let code = response_str
+        .trim()
+        .strip_prefix("```lisp")
+        .or_else(|| response_str.trim().strip_prefix("```"))
+        .unwrap_or(response_str.trim());
+    let code = code.strip_suffix("```").unwrap_or(code).trim();
+
+    match sema_reader::read(code) {
+        Ok(expr) => Ok(Trampoline::Value(expr)),
+        Err(e) => Err(SemaError::eval(format!(
+            "ask/code: failed to parse LLM response as Sema: {e}\nResponse was: {code}"
+        ))),
+    }
+}
+
+/// (heal! sym) or (heal! sym {:max-attempts N}) — use LLM to fix a function so its doctests pass
+fn eval_heal(args: &[Value], env: &Env, ctx: &EvalContext) -> Result<Trampoline, SemaError> {
+    if args.is_empty() || args.len() > 2 {
+        return Err(SemaError::arity("heal!", "1-2", args.len()));
+    }
+    let spur = args[0]
+        .as_symbol_spur()
+        .ok_or_else(|| SemaError::type_error("symbol", args[0].type_name()))?;
+    let name = resolve(spur);
+
+    // Get options
+    let opts = if args.len() > 1 {
+        eval::eval_value(ctx, &args[1], env)?
+    } else {
+        Value::nil()
+    };
+    let max_attempts = opts
+        .as_map_rc()
+        .and_then(|m| m.get(&Value::keyword("max-attempts")).cloned())
+        .and_then(|v| v.as_int())
+        .unwrap_or(3) as usize;
+
+    // Get docstring
+    let docstring = env
+        .get_meta(spur)
+        .and_then(|m| m.get(&Value::keyword("doc")).cloned())
+        .and_then(|v| v.as_str().map(|s| s.to_string()))
+        .ok_or_else(|| {
+            SemaError::eval(format!("heal!: '{name}' has no docstring"))
+                .with_hint("Add a docstring with >>> examples to use heal!")
+        })?;
+
+    // Check for actual doctests
+    let doctests = crate::doctest::parse_doctests(&docstring);
+    if doctests.is_empty() {
+        return Err(SemaError::eval(format!("heal!: '{name}' has no doctests"))
+            .with_hint("Add >>> examples to the docstring"));
+    }
+
+    // Get source
+    let source = env
+        .get_meta(spur)
+        .and_then(|m| m.get(&Value::keyword("source")).cloned())
+        .and_then(|v| v.as_str().map(|s| s.to_string()))
+        .unwrap_or_else(|| format!("<source not available for '{name}'>"));
+
+    // Run doctests first to see what's failing
+    let child_env = Env::with_parent(Rc::new(env.clone()));
+    let initial_results = crate::doctest::run_doctests(&docstring, &mut |input| {
+        eval::eval_string(ctx, input, &child_env)
+    });
+
+    let total = initial_results.len();
+    let passing = initial_results.iter().filter(|r| r.passed).count();
+
+    if passing == total {
+        let mut map = BTreeMap::new();
+        map.insert(Value::keyword("status"), Value::keyword("ok"));
+        map.insert(
+            Value::keyword("message"),
+            Value::string(&format!("All {total} doctests already pass")),
+        );
+        return Ok(Trampoline::Value(Value::map(map)));
+    }
+
+    // Build failure report
+    let mut failure_report = String::new();
+    for r in &initial_results {
+        if r.passed {
+            failure_report.push_str(&format!("  ✓ {} => {}\n", r.input, r.expected));
+        } else {
+            failure_report.push_str(&format!(
+                "  ✗ {} => expected {}, got {}\n",
+                r.input, r.expected, r.actual
+            ));
+        }
+    }
+
+    eprintln!("{name}: {passing}/{total} doctests passing. Healing...");
+
+    // Healing loop
+    let system = "You are writing Sema (a Lisp dialect). Fix this function to pass all its \
+                  doctests. Return ONLY the fixed (defn ...) form. No markdown, no explanation, \
+                  no code fences. Just the Sema expression. Keep the docstring intact.";
+
+    for attempt in 1..=max_attempts {
+        let prompt = format!(
+            "Function source:\n{source}\n\nDoctest results:\n{failure_report}\n\
+             Fix the implementation to pass all doctests. Return only the complete (defn ...) form."
+        );
+
+        let response = call_llm_complete(env, ctx, &prompt, system)?;
+        let response_str = response
+            .as_str()
+            .ok_or_else(|| SemaError::eval("heal!: LLM did not return a string"))?;
+
+        // Strip code fences if present
+        let code = response_str
+            .trim()
+            .strip_prefix("```lisp")
+            .or_else(|| response_str.trim().strip_prefix("```sema"))
+            .or_else(|| response_str.trim().strip_prefix("```"))
+            .unwrap_or(response_str.trim());
+        let code = code.strip_suffix("```").unwrap_or(code).trim();
+
+        eprintln!("  Attempt {attempt}: parsing candidate...");
+
+        // Parse the candidate
+        let candidate_expr = match sema_reader::read(code) {
+            Ok(expr) => expr,
+            Err(e) => {
+                eprintln!("  Attempt {attempt}: parse error: {e}");
+                continue;
+            }
+        };
+
+        // Eval in sandbox
+        let sandbox_env = Env::with_parent(Rc::new(env.clone()));
+        if let Err(e) = eval::eval_value(ctx, &candidate_expr, &sandbox_env) {
+            eprintln!("  Attempt {attempt}: eval error: {e}");
+            continue;
+        }
+
+        // Run doctests against the candidate
+        let candidate_results = crate::doctest::run_doctests(&docstring, &mut |input| {
+            eval::eval_string(ctx, input, &sandbox_env)
+        });
+
+        let candidate_passing = candidate_results.iter().filter(|r| r.passed).count();
+        let candidate_total = candidate_results.len();
+
+        if candidate_passing == candidate_total {
+            eprintln!("  ✓ Healed! {candidate_total}/{candidate_total} doctests pass.");
+            eprintln!("  New implementation:\n  {code}");
+
+            // Apply: eval the candidate in the real env
+            eval::eval_value(ctx, &candidate_expr, env)?;
+
+            let mut map = BTreeMap::new();
+            map.insert(Value::keyword("status"), Value::keyword("healed"));
+            map.insert(Value::keyword("attempts"), Value::int(attempt as i64));
+            map.insert(Value::keyword("source"), Value::string(code));
+            return Ok(Trampoline::Value(Value::map(map)));
+        } else {
+            eprintln!(
+                "  Attempt {attempt}: {candidate_passing}/{candidate_total} passing (not enough)"
+            );
+        }
+    }
+
+    Err(SemaError::eval(format!(
+        "heal!: failed to heal '{name}' after {max_attempts} attempts"
+    )))
+}
+
+/// (meta sym) — return metadata map for a symbol
+fn eval_meta(args: &[Value], env: &Env) -> Result<Trampoline, SemaError> {
+    if args.len() != 1 {
+        return Err(SemaError::arity("meta", "1", args.len()));
+    }
+    let spur = args[0]
+        .as_symbol_spur()
+        .ok_or_else(|| SemaError::type_error("symbol", args[0].type_name()))?;
+
+    let mut result = BTreeMap::new();
+
+    // Add stored metadata (doc, etc.)
+    if let Some(meta) = env.get_meta(spur) {
+        result.extend(meta);
+    }
+
+    // Add name
+    result.insert(Value::keyword("name"), Value::string(&resolve(spur)));
+
+    // Add type and arity info from the value itself
+    if let Some(val) = env.get(spur) {
+        result.insert(Value::keyword("type"), Value::keyword(val.type_name()));
+        if let Some(lambda) = val.as_lambda_rc() {
+            let param_names: Vec<Value> = lambda
+                .params
+                .iter()
+                .map(|s| Value::symbol(&resolve(*s)))
+                .collect();
+            result.insert(Value::keyword("params"), Value::list(param_names));
+            result.insert(
+                Value::keyword("arity"),
+                Value::int(lambda.params.len() as i64),
+            );
+            if lambda.rest_param.is_some() {
+                result.insert(Value::keyword("variadic?"), Value::bool(true));
+            }
+        } else if let Some(mac) = val.as_macro_rc() {
+            let param_names: Vec<Value> = mac
+                .params
+                .iter()
+                .map(|s| Value::symbol(&resolve(*s)))
+                .collect();
+            result.insert(Value::keyword("params"), Value::list(param_names));
+            result.insert(Value::keyword("arity"), Value::int(mac.params.len() as i64));
+            if mac.rest_param.is_some() {
+                result.insert(Value::keyword("variadic?"), Value::bool(true));
+            }
+        }
+    }
+
+    if result.is_empty() {
+        Ok(Trampoline::Value(Value::nil()))
+    } else {
+        Ok(Trampoline::Value(Value::map(result)))
+    }
+}
+
+/// (source-of sym) — return the source text of a definition
+fn eval_source_of(args: &[Value], env: &Env) -> Result<Trampoline, SemaError> {
+    if args.len() != 1 {
+        return Err(SemaError::arity("source-of", "1", args.len()));
+    }
+    let spur = args[0]
+        .as_symbol_spur()
+        .ok_or_else(|| SemaError::type_error("symbol", args[0].type_name()))?;
+    let source = env
+        .get_meta(spur)
+        .and_then(|m| m.get(&Value::keyword("source")).cloned())
+        .unwrap_or_else(Value::nil);
+    Ok(Trampoline::Value(source))
+}
+
+/// (doc sym) — pretty-print documentation for a symbol
+fn eval_doc(args: &[Value], env: &Env) -> Result<Trampoline, SemaError> {
+    if args.len() != 1 {
+        return Err(SemaError::arity("doc", "1", args.len()));
+    }
+    let spur = args[0]
+        .as_symbol_spur()
+        .ok_or_else(|| SemaError::type_error("symbol", args[0].type_name()))?;
+    let name = resolve(spur);
+
+    let mut output = String::new();
+
+    // Function signature
+    if let Some(val) = env.get(spur) {
+        if let Some(lambda) = val.as_lambda_rc() {
+            let params: Vec<String> = lambda.params.iter().map(|s| resolve(*s)).collect();
+            let params_str = params.join(" ");
+            if let Some(rest) = &lambda.rest_param {
+                output.push_str(&format!(
+                    "{name} : (fn {params_str} . {})\n",
+                    resolve(*rest)
+                ));
+            } else {
+                output.push_str(&format!("{name} : (fn {params_str})\n"));
+            }
+        } else if val.as_native_fn_rc().is_some() {
+            output.push_str(&format!("{name} : <native function>\n"));
+        } else if val.as_macro_rc().is_some() {
+            output.push_str(&format!("{name} : <macro>\n"));
+        }
+    }
+
+    // Docstring
+    if let Some(meta) = env.get_meta(spur) {
+        if let Some(doc) = meta.get(&Value::keyword("doc")) {
+            if let Some(s) = doc.as_str() {
+                output.push('\n');
+                output.push_str(s);
+                output.push('\n');
+            }
+        }
+    }
+
+    if output.is_empty() {
+        output = format!("No documentation for '{name}'.\n");
+    }
+
+    eprint!("{output}");
+    Ok(Trampoline::Value(Value::nil()))
+}
+
+/// (doc/search "query") — search all bindings by name or docstring content
+fn eval_doc_search(args: &[Value], env: &Env, ctx: &EvalContext) -> Result<Trampoline, SemaError> {
+    if args.len() != 1 {
+        return Err(SemaError::arity("doc/search", "1", args.len()));
+    }
+    let query_val = eval::eval_value(ctx, &args[0], env)?;
+    let query = query_val
+        .as_str()
+        .ok_or_else(|| SemaError::type_error("string", query_val.type_name()))?
+        .to_lowercase();
+
+    let mut results = Vec::new();
+    for spur in env.all_names() {
+        let name = resolve(spur);
+        let name_lower = name.to_lowercase();
+        let mut matches = name_lower.contains(&query);
+
+        if !matches {
+            if let Some(meta) = env.get_meta(spur) {
+                if let Some(doc) = meta.get(&Value::keyword("doc")) {
+                    if let Some(s) = doc.as_str() {
+                        matches = s.to_lowercase().contains(&query);
+                    }
+                }
+            }
+        }
+
+        if matches {
+            let mut entry = BTreeMap::new();
+            entry.insert(Value::keyword("name"), Value::string(&name));
+            if let Some(meta) = env.get_meta(spur) {
+                if let Some(doc) = meta.get(&Value::keyword("doc")) {
+                    entry.insert(Value::keyword("doc"), doc.clone());
+                }
+            }
+            results.push(Value::map(entry));
+        }
+    }
+
+    Ok(Trampoline::Value(Value::list(results)))
+}
+
+/// (doctest sym) — run doctests from a symbol's docstring
+fn eval_doctest(args: &[Value], env: &Env, ctx: &EvalContext) -> Result<Trampoline, SemaError> {
+    if args.len() != 1 {
+        return Err(SemaError::arity("doctest", "1", args.len()));
+    }
+    let spur = args[0]
+        .as_symbol_spur()
+        .ok_or_else(|| SemaError::type_error("symbol", args[0].type_name()))?;
+    let name = resolve(spur);
+
+    // Get docstring from metadata
+    let docstring = env
+        .get_meta(spur)
+        .and_then(|m| m.get(&Value::keyword("doc")).cloned())
+        .and_then(|v| v.as_str().map(|s| s.to_string()))
+        .ok_or_else(|| SemaError::eval(format!("doctest: no docstring for '{name}'")))?;
+
+    // Create child env for isolated evaluation
+    let child_env = Env::with_parent(Rc::new(env.clone()));
+
+    // Run doctests
+    let results = crate::doctest::run_doctests(&docstring, &mut |input| {
+        eval::eval_string(ctx, input, &child_env)
+    });
+
+    let total = results.len() as i64;
+    let passed = results.iter().filter(|r| r.passed).count() as i64;
+
+    // Print results
+    for r in &results {
+        if r.passed {
+            eprintln!("  ✓ {} => {}", r.input, r.expected);
+        } else {
+            eprintln!(
+                "  ✗ {} => expected {}, got {}",
+                r.input, r.expected, r.actual
+            );
+        }
+    }
+
+    let mut map = BTreeMap::new();
+    map.insert(Value::keyword("passed"), Value::int(passed));
+    map.insert(Value::keyword("total"), Value::int(total));
+    map.insert(Value::keyword("name"), Value::string(&name));
+    Ok(Trampoline::Value(Value::map(map)))
+}
+
+// ── Runtime self-modification special forms ───────────────────────
+
+/// (observe! target sample-size callback)
+/// Wraps target function with a logger. After sample-size calls, invokes callback with call log
+/// and restores the original function.
+fn eval_observe(args: &[Value], env: &Env, ctx: &EvalContext) -> Result<Trampoline, SemaError> {
+    if args.len() != 3 {
+        return Err(SemaError::arity("observe!", "3", args.len()));
+    }
+    let spur = args[0]
+        .as_symbol_spur()
+        .ok_or_else(|| SemaError::type_error("symbol", args[0].type_name()))?;
+    let sample_size = eval::eval_value(ctx, &args[1], env)?;
+    let sample_n = sample_size
+        .as_int()
+        .ok_or_else(|| SemaError::type_error("integer", sample_size.type_name()))?
+        as usize;
+    let callback = eval::eval_value(ctx, &args[2], env)?;
+
+    let original = env
+        .get(spur)
+        .ok_or_else(|| SemaError::eval(format!("observe!: '{}' is not defined", resolve(spur))))?;
+
+    let call_log: Rc<RefCell<Vec<Value>>> = Rc::new(RefCell::new(Vec::new()));
+    let call_count = Rc::new(Cell::new(0usize));
+    let original_for_call = original.clone();
+    let original_for_restore = original.clone();
+    let callback_clone = callback;
+    let log_clone = call_log.clone();
+    let count_clone = call_count;
+    let env_clone = env.clone();
+    let spur_copy = spur;
+
+    let wrapper_name = format!("{}/observed", resolve(spur));
+    let wrapper = Value::native_fn(sema_core::NativeFn::with_ctx(
+        wrapper_name,
+        move |ctx, call_args| {
+            let start = std::time::Instant::now();
+            let result = sema_core::call_callback(ctx, &original_for_call, call_args)?;
+            let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+
+            let mut entry = BTreeMap::new();
+            entry.insert(Value::keyword("args"), Value::list(call_args.to_vec()));
+            entry.insert(Value::keyword("result"), result.clone());
+            entry.insert(Value::keyword("time-ms"), Value::float(elapsed_ms));
+            log_clone.borrow_mut().push(Value::map(entry));
+
+            let n = count_clone.get() + 1;
+            count_clone.set(n);
+
+            if n >= sample_n {
+                let log_entries = log_clone.borrow().clone();
+                env_clone.set(spur_copy, original_for_restore.clone());
+                sema_core::call_callback(ctx, &callback_clone, &[Value::list(log_entries)])?;
+            }
+
+            Ok(result)
+        },
+    ));
+
+    env.set(spur, wrapper);
+    Ok(Trampoline::Value(Value::nil()))
+}
+
+/// (become! target new-definition)
+/// Replace a function's definition at runtime. Validates doctests if present.
+/// Saves old version to history metadata.
+fn eval_become(args: &[Value], env: &Env, ctx: &EvalContext) -> Result<Trampoline, SemaError> {
+    if args.len() != 2 {
+        return Err(SemaError::arity("become!", "2", args.len()));
+    }
+    let spur = args[0]
+        .as_symbol_spur()
+        .ok_or_else(|| SemaError::type_error("symbol", args[0].type_name()))?;
+    let name = resolve(spur);
+
+    // Check if frozen
+    if let Some(meta) = env.get_meta(spur) {
+        if meta.get(&Value::keyword("frozen?")) == Some(&Value::bool(true)) {
+            return Err(SemaError::eval(format!(
+                "become!: '{name}' is frozen and cannot be modified"
+            ))
+            .with_hint("Use (history <name>) to inspect previous versions"));
+        }
+    }
+
+    // Get the current value
+    let current = env
+        .get(spur)
+        .ok_or_else(|| SemaError::eval(format!("become!: '{name}' is not defined")))?;
+
+    // Evaluate the new definition
+    let new_def = eval::eval_value(ctx, &args[1], env)?;
+
+    // If the function has doctests, validate the candidate passes them
+    if let Some(meta) = env.get_meta(spur) {
+        if let Some(doc_val) = meta.get(&Value::keyword("doc")) {
+            if let Some(docstring) = doc_val.as_str() {
+                let doctests = crate::doctest::parse_doctests(docstring);
+                if !doctests.is_empty() {
+                    // Create sandbox env with the new function bound
+                    let sandbox_env = Env::with_parent(Rc::new(env.clone()));
+                    sandbox_env.set(spur, new_def.clone());
+
+                    let results = crate::doctest::run_doctests(docstring, &mut |input| {
+                        eval::eval_string(ctx, input, &sandbox_env)
+                    });
+
+                    let total = results.len();
+                    let passed = results.iter().filter(|r| r.passed).count();
+
+                    if passed < total {
+                        let mut failures = String::new();
+                        for r in &results {
+                            if !r.passed {
+                                failures.push_str(&format!(
+                                    "\n  {} => expected {}, got {}",
+                                    r.input, r.expected, r.actual
+                                ));
+                            }
+                        }
+                        return Err(SemaError::eval(format!(
+                            "become!: candidate for '{name}' fails {}/{total} doctests:{failures}",
+                            total - passed
+                        )));
+                    }
+                }
+            }
+        }
+    }
+
+    // Save current version to history
+    let history_key = Value::keyword("history");
+    let mut history_list: Vec<Value> = env
+        .get_meta(spur)
+        .and_then(|m| m.get(&history_key).cloned())
+        .and_then(|v| v.as_list().map(|l| l.to_vec()))
+        .unwrap_or_default();
+
+    let mut version_entry = BTreeMap::new();
+    version_entry.insert(
+        Value::keyword("version"),
+        Value::int(history_list.len() as i64 + 1),
+    );
+    version_entry.insert(Value::keyword("value"), current);
+    if let Some(meta) = env.get_meta(spur) {
+        if let Some(source) = meta.get(&Value::keyword("source")) {
+            version_entry.insert(Value::keyword("source"), source.clone());
+        }
+    }
+    history_list.push(Value::map(version_entry));
+    env.set_meta(spur, history_key, Value::list(history_list));
+
+    // Install the new definition
+    env.set(spur, new_def);
+
+    Ok(Trampoline::Value(Value::nil()))
+}
+
+/// (history name) — return the history list for a binding
+fn eval_history(args: &[Value], env: &Env) -> Result<Trampoline, SemaError> {
+    if args.len() != 1 {
+        return Err(SemaError::arity("history", "1", args.len()));
+    }
+    let spur = args[0]
+        .as_symbol_spur()
+        .ok_or_else(|| SemaError::type_error("symbol", args[0].type_name()))?;
+    let history_key = Value::keyword("history");
+    let history = env
+        .get_meta(spur)
+        .and_then(|m| m.get(&history_key).cloned())
+        .unwrap_or_else(|| Value::list(vec![]));
+    Ok(Trampoline::Value(history))
+}
+
+/// (rollback! sym version-number) — restore a previous version from history
+fn eval_rollback(args: &[Value], env: &Env, ctx: &EvalContext) -> Result<Trampoline, SemaError> {
+    if args.len() != 2 {
+        return Err(SemaError::arity("rollback!", "2", args.len()));
+    }
+    let spur = args[0]
+        .as_symbol_spur()
+        .ok_or_else(|| SemaError::type_error("symbol", args[0].type_name()))?;
+    let name = resolve(spur);
+    let version_val = eval::eval_value(ctx, &args[1], env)?;
+    let version = version_val
+        .as_int()
+        .ok_or_else(|| SemaError::type_error("integer", version_val.type_name()))?;
+
+    // Check if frozen
+    if let Some(meta) = env.get_meta(spur) {
+        if meta.get(&Value::keyword("frozen?")) == Some(&Value::bool(true)) {
+            return Err(SemaError::eval(format!(
+                "rollback!: '{name}' is frozen and cannot be modified"
+            )));
+        }
+    }
+
+    let history_list = env
+        .get_meta(spur)
+        .and_then(|m| m.get(&Value::keyword("history")).cloned())
+        .and_then(|v| v.as_list().map(|l| l.to_vec()))
+        .unwrap_or_default();
+
+    // Find the entry with matching version number
+    let entry = history_list
+        .iter()
+        .find(|e| {
+            e.as_map_rc()
+                .and_then(|m| m.get(&Value::keyword("version")).cloned())
+                .and_then(|v| v.as_int())
+                == Some(version)
+        })
+        .ok_or_else(|| {
+            SemaError::eval(format!(
+                "rollback!: version {version} not found in history for '{name}'"
+            ))
+            .with_hint(format!(
+                "Available versions: {}",
+                history_list
+                    .iter()
+                    .filter_map(|e| e
+                        .as_map_rc()
+                        .and_then(|m| m.get(&Value::keyword("version")).cloned())
+                        .and_then(|v| v.as_int()))
+                    .map(|v| v.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ))
+        })?;
+
+    let old_value = entry
+        .as_map_rc()
+        .and_then(|m| m.get(&Value::keyword("value")).cloned())
+        .ok_or_else(|| SemaError::eval("rollback!: history entry missing :value"))?;
+
+    // Save current version to history before rolling back
+    let current = env
+        .get(spur)
+        .ok_or_else(|| SemaError::eval(format!("rollback!: '{name}' is not defined")))?;
+
+    let mut updated_history = history_list;
+    let mut rollback_entry = BTreeMap::new();
+    rollback_entry.insert(
+        Value::keyword("version"),
+        Value::int(updated_history.len() as i64 + 1),
+    );
+    rollback_entry.insert(Value::keyword("value"), current);
+    updated_history.push(Value::map(rollback_entry));
+    env.set_meta(
+        spur,
+        Value::keyword("history"),
+        Value::list(updated_history),
+    );
+
+    // Restore the old value
+    env.set(spur, old_value);
+
+    Ok(Trampoline::Value(Value::nil()))
+}
+
+/// (freeze! sym) — permanently prevent further become!/rollback! on a function
+fn eval_freeze(args: &[Value], env: &Env) -> Result<Trampoline, SemaError> {
+    if args.len() != 1 {
+        return Err(SemaError::arity("freeze!", "1", args.len()));
+    }
+    let spur = args[0]
+        .as_symbol_spur()
+        .ok_or_else(|| SemaError::type_error("symbol", args[0].type_name()))?;
+
+    env.set_meta(spur, Value::keyword("frozen?"), Value::bool(true));
 
     Ok(Trampoline::Value(Value::nil()))
 }

--- a/crates/sema-eval/src/special_forms.rs
+++ b/crates/sema-eval/src/special_forms.rs
@@ -2867,24 +2867,29 @@ fn eval_become(args: &[Value], env: &Env, ctx: &EvalContext) -> Result<Trampolin
     // Evaluate the new definition
     let new_def = eval::eval_value(ctx, &args[1], env)?;
 
-    // If the function has doctests, validate the candidate passes them
+    // If the function has doctests, validate the candidate passes them.
+    // Temporarily install new_def so recursive calls see the new version.
     if let Some(meta) = env.get_meta(spur) {
         if let Some(doc_val) = meta.get(&Value::keyword("doc")) {
             if let Some(docstring) = doc_val.as_str() {
                 let doctests = crate::doctest::parse_doctests(docstring);
                 if !doctests.is_empty() {
-                    // Create sandbox env with the new function bound
-                    let sandbox_env = Env::with_parent(Rc::new(env.clone()));
-                    sandbox_env.set(spur, new_def.clone());
+                    // Temporarily swap in the new definition so recursive calls
+                    // resolve to the candidate, not the old version.
+                    env.set(spur, new_def.clone());
 
+                    let child_env = Env::with_parent(Rc::new(env.clone()));
                     let results = crate::doctest::run_doctests(docstring, &mut |input| {
-                        eval::eval_string(ctx, input, &sandbox_env)
+                        eval::eval_string(ctx, input, &child_env)
                     });
 
                     let total = results.len();
                     let passed = results.iter().filter(|r| r.passed).count();
 
                     if passed < total {
+                        // Restore the old definition on failure
+                        env.set(spur, current.clone());
+
                         let mut failures = String::new();
                         for r in &results {
                             if !r.passed {
@@ -2899,6 +2904,9 @@ fn eval_become(args: &[Value], env: &Env, ctx: &EvalContext) -> Result<Trampolin
                             total - passed
                         )));
                     }
+
+                    // Doctests passed — restore current so history save below captures it
+                    env.set(spur, current.clone());
                 }
             }
         }
@@ -2926,8 +2934,13 @@ fn eval_become(args: &[Value], env: &Env, ctx: &EvalContext) -> Result<Trampolin
     history_list.push(Value::map(version_entry));
     env.set_meta(spur, history_key, Value::list(history_list));
 
-    // Install the new definition
+    // Install the new definition and update source metadata
     env.set(spur, new_def);
+    env.set_meta(
+        spur,
+        Value::keyword("source"),
+        Value::string(&args[1].to_string()),
+    );
 
     Ok(Trampoline::Value(Value::nil()))
 }
@@ -3004,10 +3017,16 @@ fn eval_rollback(args: &[Value], env: &Env, ctx: &EvalContext) -> Result<Trampol
             ))
         })?;
 
-    let old_value = entry
+    let entry_map = entry
         .as_map_rc()
-        .and_then(|m| m.get(&Value::keyword("value")).cloned())
+        .ok_or_else(|| SemaError::eval("rollback!: history entry is not a map"))?;
+
+    let old_value = entry_map
+        .get(&Value::keyword("value"))
+        .cloned()
         .ok_or_else(|| SemaError::eval("rollback!: history entry missing :value"))?;
+
+    let old_source = entry_map.get(&Value::keyword("source")).cloned();
 
     // Save current version to history before rolling back
     let current = env
@@ -3021,6 +3040,11 @@ fn eval_rollback(args: &[Value], env: &Env, ctx: &EvalContext) -> Result<Trampol
         Value::int(updated_history.len() as i64 + 1),
     );
     rollback_entry.insert(Value::keyword("value"), current);
+    if let Some(meta) = env.get_meta(spur) {
+        if let Some(source) = meta.get(&Value::keyword("source")) {
+            rollback_entry.insert(Value::keyword("source"), source.clone());
+        }
+    }
     updated_history.push(Value::map(rollback_entry));
     env.set_meta(
         spur,
@@ -3028,8 +3052,11 @@ fn eval_rollback(args: &[Value], env: &Env, ctx: &EvalContext) -> Result<Trampol
         Value::list(updated_history),
     );
 
-    // Restore the old value
+    // Restore the old value and source metadata
     env.set(spur, old_value);
+    if let Some(source) = old_source {
+        env.set_meta(spur, Value::keyword("source"), source);
+    }
 
     Ok(Trampoline::Value(Value::nil()))
 }

--- a/crates/sema-reader/src/lib.rs
+++ b/crates/sema-reader/src/lib.rs
@@ -4,6 +4,7 @@ mod reader;
 
 pub use reader::read;
 pub use reader::read_many;
+pub use reader::read_many_with_directives;
 pub use reader::read_many_with_spans;
 pub use reader::read_many_with_spans_recover;
 pub use reader::read_many_with_symbol_spans;

--- a/crates/sema-reader/src/reader.rs
+++ b/crates/sema-reader/src/reader.rs
@@ -654,6 +654,58 @@ pub fn read_many_with_spans_recover(
     (exprs, parser.span_map, parser.symbol_spans, errors)
 }
 
+/// Directives parsed from `;;@key value` comments, associated with form indices.
+pub type Directives = Vec<(usize, BTreeMap<String, String>)>;
+
+/// Read all s-expressions, returning spans and directive comments (`;;@key value`).
+///
+/// Directive comments are lines starting with `;;@`. They are associated with
+/// the next top-level form that follows them. Returns a vec of
+/// (form_index, directives) pairs.
+pub fn read_many_with_directives(
+    input: &str,
+) -> Result<(Vec<Value>, SpanMap, Directives), SemaError> {
+    let tokens = tokenize(input)?;
+    let mut parser = Parser::new(tokens);
+    let mut exprs = Vec::new();
+    let mut all_directives: Vec<(usize, BTreeMap<String, String>)> = Vec::new();
+    let mut pending_directives: BTreeMap<String, String> = BTreeMap::new();
+
+    loop {
+        // Manually handle trivia to capture directive comments
+        while let Some(t) = parser.tokens.get(parser.pos) {
+            match &t.token {
+                Token::Comment(text) => {
+                    if let Some(directive) = text.strip_prefix(";;@") {
+                        let directive = directive.trim();
+                        if let Some((key, value)) = directive.split_once(' ') {
+                            pending_directives.insert(key.to_string(), value.trim().to_string());
+                        } else if !directive.is_empty() {
+                            // Boolean directive like ;;@adaptive
+                            pending_directives.insert(directive.to_string(), String::new());
+                        }
+                    }
+                    parser.pos += 1;
+                }
+                Token::Newline => {
+                    parser.pos += 1;
+                }
+                _ => break,
+            }
+        }
+        if parser.peek().is_none() {
+            break;
+        }
+        let form_index = exprs.len();
+        exprs.push(parser.parse_expr()?);
+        if !pending_directives.is_empty() {
+            all_directives.push((form_index, std::mem::take(&mut pending_directives)));
+        }
+    }
+
+    Ok((exprs, parser.span_map, all_directives))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1931,5 +1983,79 @@ mod tests {
         // "nil" parses as Value::nil(), not a symbol — should not be in symbol_spans
         let (_, _, sym_spans) = read_many_with_symbol_spans("nil").unwrap();
         assert!(sym_spans.is_empty());
+    }
+
+    // ── directive tests ──
+
+    #[test]
+    fn test_read_directives_basic() {
+        let input = ";;@since 1.8.0\n;;@deprecated Use bar instead\n(defn foo (x) x)";
+        let (exprs, _, directives) = read_many_with_directives(input).unwrap();
+        assert_eq!(exprs.len(), 1);
+        assert_eq!(directives.len(), 1);
+        assert_eq!(directives[0].0, 0);
+        assert_eq!(directives[0].1.get("since").unwrap(), "1.8.0");
+        assert_eq!(
+            directives[0].1.get("deprecated").unwrap(),
+            "Use bar instead"
+        );
+    }
+
+    #[test]
+    fn test_read_directives_multiple_forms() {
+        let input = ";;@since 1.0.0\n(defn a () 1)\n\n;;@since 2.0.0\n;;@tags math\n(defn b () 2)\n\n(defn c () 3)";
+        let (exprs, _, directives) = read_many_with_directives(input).unwrap();
+        assert_eq!(exprs.len(), 3);
+        assert_eq!(directives.len(), 2);
+        assert_eq!(directives[0].0, 0);
+        assert_eq!(directives[0].1.get("since").unwrap(), "1.0.0");
+        assert_eq!(directives[1].0, 1);
+        assert_eq!(directives[1].1.get("since").unwrap(), "2.0.0");
+        assert_eq!(directives[1].1.get("tags").unwrap(), "math");
+    }
+
+    #[test]
+    fn test_read_directives_none() {
+        let input = "(+ 1 2)";
+        let (exprs, _, directives) = read_many_with_directives(input).unwrap();
+        assert_eq!(exprs.len(), 1);
+        assert!(directives.is_empty());
+    }
+
+    #[test]
+    fn test_read_directives_boolean() {
+        let input = ";;@adaptive\n;;@self-heal\n(defn foo (x) x)";
+        let (exprs, _, directives) = read_many_with_directives(input).unwrap();
+        assert_eq!(exprs.len(), 1);
+        assert_eq!(directives.len(), 1);
+        assert_eq!(directives[0].1.get("adaptive").unwrap(), "");
+        assert_eq!(directives[0].1.get("self-heal").unwrap(), "");
+    }
+
+    #[test]
+    fn test_read_directives_regular_comments_ignored() {
+        let input =
+            ";; This is a regular comment\n;;@since 1.0.0\n; Another comment\n(defn foo (x) x)";
+        let (exprs, _, directives) = read_many_with_directives(input).unwrap();
+        assert_eq!(exprs.len(), 1);
+        assert_eq!(directives.len(), 1);
+        assert_eq!(directives[0].1.len(), 1);
+        assert_eq!(directives[0].1.get("since").unwrap(), "1.0.0");
+    }
+
+    #[test]
+    fn test_read_directives_empty_input() {
+        let (exprs, _, directives) = read_many_with_directives("").unwrap();
+        assert!(exprs.is_empty());
+        assert!(directives.is_empty());
+    }
+
+    #[test]
+    fn test_read_directives_orphaned() {
+        // Directives at end of file with no following form should be discarded
+        let input = "(defn a () 1)\n;;@orphaned true";
+        let (exprs, _, directives) = read_many_with_directives(input).unwrap();
+        assert_eq!(exprs.len(), 1);
+        assert!(directives.is_empty());
     }
 }

--- a/crates/sema-stdlib/src/io.rs
+++ b/crates/sema-stdlib/src/io.rs
@@ -174,6 +174,150 @@ pub fn register(env: &sema_core::Env, sandbox: &sema_core::Sandbox) {
         Ok(Value::list(exprs))
     });
 
+    crate::register_fn_path_gated(env, sandbox, Caps::FS_READ, "read-source", &[0], |args| {
+        check_arity!(args, "read-source", 1);
+        let path_str = args[0]
+            .as_str()
+            .ok_or_else(|| SemaError::type_error("string", args[0].type_name()))?;
+
+        let paths: Vec<String> = if path_str.contains('*') {
+            glob::glob(path_str)
+                .map_err(|e| SemaError::eval(format!("read-source: invalid glob: {e}")))?
+                .filter_map(|r| r.ok())
+                .map(|p| p.to_string_lossy().to_string())
+                .collect()
+        } else {
+            vec![path_str.to_string()]
+        };
+
+        let mut all_defs = Vec::new();
+        for path in &paths {
+            let content = std::fs::read_to_string(path)
+                .map_err(|e| SemaError::Io(format!("read-source {path}: {e}")))?;
+            let (exprs, _spans, directives) = sema_reader::read_many_with_directives(&content)?;
+
+            let dir_map: std::collections::HashMap<
+                usize,
+                &std::collections::BTreeMap<String, String>,
+            > = directives.iter().map(|(idx, dirs)| (*idx, dirs)).collect();
+
+            for (i, expr) in exprs.iter().enumerate() {
+                let mut entry = std::collections::BTreeMap::new();
+                let source_text = expr.to_string();
+
+                if let Some(list) = expr.as_list() {
+                    if let Some(head) = list.first().and_then(|v| v.as_symbol()) {
+                        match head.as_str() {
+                            "defn" | "defun" if list.len() >= 4 => {
+                                entry.insert(Value::keyword("type"), Value::keyword("defn"));
+                                let name = list.get(1).map(|v| v.to_string()).unwrap_or_default();
+                                entry.insert(Value::keyword("name"), Value::string(&name));
+                                let (doc, params_idx) =
+                                    if list.get(2).and_then(|v| v.as_str()).is_some() {
+                                        (list[2].as_str().map(|s| s.to_string()), 3)
+                                    } else {
+                                        (None, 2)
+                                    };
+                                if let Some(d) = &doc {
+                                    entry.insert(Value::keyword("doc"), Value::string(d));
+                                }
+                                if let Some(params) = list.get(params_idx) {
+                                    entry.insert(Value::keyword("params"), params.clone());
+                                }
+                                if list.len() > params_idx + 1 {
+                                    entry.insert(
+                                        Value::keyword("body"),
+                                        Value::list(list[params_idx + 1..].to_vec()),
+                                    );
+                                }
+                            }
+                            "define" if list.len() >= 3 => {
+                                if let Some(sig) = list.get(1).and_then(|v| v.as_list()) {
+                                    entry.insert(Value::keyword("type"), Value::keyword("defn"));
+                                    let name =
+                                        sig.first().map(|v| v.to_string()).unwrap_or_default();
+                                    entry.insert(Value::keyword("name"), Value::string(&name));
+                                    entry.insert(
+                                        Value::keyword("params"),
+                                        Value::list(sig[1..].to_vec()),
+                                    );
+                                    let body_start = if list
+                                        .get(2)
+                                        .and_then(|v| v.as_str())
+                                        .is_some()
+                                    {
+                                        if let Some(d) = list[2].as_str() {
+                                            entry.insert(Value::keyword("doc"), Value::string(d));
+                                        }
+                                        3
+                                    } else {
+                                        2
+                                    };
+                                    if list.len() > body_start {
+                                        entry.insert(
+                                            Value::keyword("body"),
+                                            Value::list(list[body_start..].to_vec()),
+                                        );
+                                    }
+                                } else {
+                                    entry.insert(Value::keyword("type"), Value::keyword("define"));
+                                    let name =
+                                        list.get(1).map(|v| v.to_string()).unwrap_or_default();
+                                    entry.insert(Value::keyword("name"), Value::string(&name));
+                                }
+                            }
+                            "defmacro" if list.len() >= 4 => {
+                                entry.insert(Value::keyword("type"), Value::keyword("defmacro"));
+                                let name = list.get(1).map(|v| v.to_string()).unwrap_or_default();
+                                entry.insert(Value::keyword("name"), Value::string(&name));
+                                let (doc, params_idx) =
+                                    if list.get(2).and_then(|v| v.as_str()).is_some() {
+                                        (list[2].as_str().map(|s| s.to_string()), 3)
+                                    } else {
+                                        (None, 2)
+                                    };
+                                if let Some(d) = &doc {
+                                    entry.insert(Value::keyword("doc"), Value::string(d));
+                                }
+                                if let Some(params) = list.get(params_idx) {
+                                    entry.insert(Value::keyword("params"), params.clone());
+                                }
+                                if list.len() > params_idx + 1 {
+                                    entry.insert(
+                                        Value::keyword("body"),
+                                        Value::list(list[params_idx + 1..].to_vec()),
+                                    );
+                                }
+                            }
+                            _ => {
+                                entry.insert(Value::keyword("type"), Value::keyword("expr"));
+                            }
+                        }
+                    } else {
+                        entry.insert(Value::keyword("type"), Value::keyword("expr"));
+                    }
+                } else {
+                    entry.insert(Value::keyword("type"), Value::keyword("expr"));
+                }
+
+                entry.insert(Value::keyword("source"), Value::string(&source_text));
+                entry.insert(Value::keyword("file"), Value::string(path));
+
+                if let Some(dirs) = dir_map.get(&i) {
+                    let mut dir_entries = std::collections::BTreeMap::new();
+                    for (k, v) in *dirs {
+                        dir_entries.insert(Value::keyword(k), Value::string(v));
+                    }
+                    entry.insert(Value::keyword("directives"), Value::map(dir_entries));
+                }
+
+                all_defs.push(Value::map(entry));
+            }
+        }
+
+        Ok(Value::list(all_defs))
+    });
+
     register_fn(env, "error", |args| {
         if args.is_empty() {
             return Err(SemaError::eval("error called with no message"));

--- a/crates/sema-stdlib/src/meta.rs
+++ b/crates/sema-stdlib/src/meta.rs
@@ -81,6 +81,32 @@ pub fn register(env: &sema_core::Env) {
         Ok(Value::float(elapsed.as_secs_f64() * 1000.0))
     });
 
+    // (bench thunk iterations) — run zero-arg thunk N times, return timing stats
+    register_fn(env, "bench", |args| {
+        check_arity!(args, "bench", 2);
+        let iterations = args[1]
+            .as_int()
+            .ok_or_else(|| SemaError::type_error("integer", args[1].type_name()))?
+            as usize;
+
+        let start = std::time::Instant::now();
+        for _ in 0..iterations {
+            crate::list::call_function(&args[0], &[])?;
+        }
+        let total_ms = start.elapsed().as_secs_f64() * 1000.0;
+        let mean_ms = if iterations > 0 {
+            total_ms / iterations as f64
+        } else {
+            0.0
+        };
+
+        let mut map = std::collections::BTreeMap::new();
+        map.insert(Value::keyword("iterations"), Value::int(iterations as i64));
+        map.insert(Value::keyword("total-ms"), Value::float(total_ms));
+        map.insert(Value::keyword("mean-ms"), Value::float(mean_ms));
+        Ok(Value::map(map))
+    });
+
     // (assert condition) or (assert condition message) — throws if condition is falsy
     register_fn(env, "assert", |args| {
         if args.is_empty() || args.len() > 2 {

--- a/crates/sema/src/main.rs
+++ b/crates/sema/src/main.rs
@@ -349,6 +349,19 @@ enum Commands {
         #[arg(long)]
         no_cache: bool,
     },
+    /// Run doctests from source files
+    Test {
+        /// Source files to scan for doctests
+        files: Vec<String>,
+
+        /// Verbose output — show each doctest result
+        #[arg(short, long)]
+        verbose: bool,
+
+        /// Attempt to heal failing doctests using LLM
+        #[arg(long)]
+        heal: bool,
+    },
     /// Format Sema source files
     Fmt {
         /// Files or glob patterns to format (default: **/*.sema in current directory)
@@ -668,6 +681,13 @@ fn main() {
                     eprintln!("Error: {e}");
                     std::process::exit(1);
                 }
+            }
+            Commands::Test {
+                files,
+                verbose,
+                heal,
+            } => {
+                run_doctests(&files, verbose, heal);
             }
             Commands::Fmt {
                 files,
@@ -2033,6 +2053,135 @@ fn run_bytecode_bytes(
         main_cache_slots,
     )?;
     vm.execute(closure, &interpreter.ctx)
+}
+
+fn run_doctests(files: &[String], verbose: bool, heal: bool) {
+    if files.is_empty() {
+        eprintln!("Usage: sema test <file.sema> ...");
+        std::process::exit(1);
+    }
+
+    let mut total_passed: i64 = 0;
+    let mut total_tests: i64 = 0;
+    let mut total_healed: i64 = 0;
+    let mut any_failed = false;
+
+    for file in files {
+        let content = match std::fs::read_to_string(file) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("Error reading {file}: {e}");
+                any_failed = true;
+                continue;
+            }
+        };
+
+        // Each file gets its own interpreter for isolation
+        let interp = Interpreter::new();
+
+        let path = std::path::Path::new(file);
+        if let Ok(canonical) = path.canonicalize() {
+            interp.ctx.push_file_path(canonical);
+        }
+        if let Err(e) = interp.eval_str_in_global(&content) {
+            interp.ctx.pop_file_path();
+            eprintln!("Error loading {file}: {e}");
+            any_failed = true;
+            continue;
+        }
+        interp.ctx.pop_file_path();
+
+        // Find all symbols with :doc metadata and run their doctests
+        let all_names = interp.global_env.all_names();
+        for spur in &all_names {
+            if let Some(meta) = interp.global_env.get_meta(*spur) {
+                if let Some(doc_val) = meta.get(&Value::keyword("doc")) {
+                    if let Some(docstring) = doc_val.as_str() {
+                        let tests = sema_eval::doctest::parse_doctests(docstring);
+                        if tests.is_empty() {
+                            continue;
+                        }
+
+                        let name = sema_core::resolve(*spur);
+                        let child_env = Env::with_parent(interp.global_env.clone());
+
+                        let results = sema_eval::doctest::run_doctests(docstring, &mut |input| {
+                            sema_eval::eval_string(&interp.ctx, input, &child_env)
+                        });
+
+                        let passed = results.iter().filter(|r| r.passed).count() as i64;
+                        let count = results.len() as i64;
+                        total_passed += passed;
+                        total_tests += count;
+
+                        if verbose {
+                            eprintln!("{name}:");
+                            for r in &results {
+                                if r.passed {
+                                    eprintln!("  ✓ {} => {}", r.input, r.expected);
+                                } else {
+                                    any_failed = true;
+                                    eprintln!(
+                                        "  ✗ {} => expected {}, got {}",
+                                        r.input, r.expected, r.actual
+                                    );
+                                }
+                            }
+                        } else if passed == count {
+                            let dots: String = ".".repeat(count as usize);
+                            eprintln!("{name} {dots} {passed}/{count} ✓");
+                        } else {
+                            any_failed = true;
+                            eprintln!("{name} ... {passed}/{count} ✗");
+                            for r in results.iter().filter(|r| !r.passed) {
+                                eprintln!(
+                                    "  ✗ {} => expected {}, got {}",
+                                    r.input, r.expected, r.actual
+                                );
+                            }
+                        }
+
+                        // Attempt healing if --heal flag and there are failures
+                        if heal && passed < count {
+                            eprintln!("\n  Attempting to heal {name}...");
+                            let heal_expr = format!("(heal! {name})");
+                            match interp.eval_str_in_global(&heal_expr) {
+                                Ok(result) => {
+                                    if let Some(map) = result.as_map_rc() {
+                                        let status = map
+                                            .get(&Value::keyword("status"))
+                                            .and_then(|v| v.as_keyword())
+                                            .unwrap_or_default();
+                                        if status == "healed" {
+                                            total_healed += 1;
+                                            let healed_diff = count - passed;
+                                            total_passed += healed_diff;
+                                            any_failed = false; // may be fixed now
+                                            eprintln!("  ✓ {name} healed!");
+                                        }
+                                    }
+                                }
+                                Err(e) => {
+                                    eprintln!("  ✗ Failed to heal {name}: {e}");
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if total_healed > 0 {
+        eprintln!(
+            "{total_passed}/{total_tests} doctests passed ({total_healed} function(s) healed)"
+        );
+    } else {
+        eprintln!("{total_passed}/{total_tests} doctests passed");
+    }
+    if any_failed || total_passed < total_tests {
+        std::process::exit(1);
+    }
 }
 
 fn run_fmt(

--- a/crates/sema/tests/integration_test.rs
+++ b/crates/sema/tests/integration_test.rs
@@ -13723,3 +13723,799 @@ fn test_db_foreign_keys() {
     assert!(result.is_err());
     interp.eval_str(r#"(db/close "fk")"#).unwrap();
 }
+
+// ── Living Code: docstrings, meta, doc, doctest ──────────────────
+
+#[test]
+fn test_defn_docstring() {
+    let interp = Interpreter::new();
+    let result = interp
+        .eval_str(
+            r#"(begin
+                (defn greet "Says hello to someone." (name)
+                  (string-append "Hello, " name))
+                (greet "World"))"#,
+        )
+        .unwrap();
+    assert_eq!(result, Value::string("Hello, World"));
+}
+
+#[test]
+fn test_defn_no_docstring() {
+    assert_eq!(
+        eval("(begin (defn add (a b) (+ a b)) (add 1 2))"),
+        Value::int(3)
+    );
+}
+
+#[test]
+fn test_defn_docstring_meta() {
+    let interp = Interpreter::new();
+    let result = interp
+        .eval_str(
+            r#"(begin
+                (defn greet "Says hello." (name) name)
+                (meta greet))"#,
+        )
+        .unwrap();
+    let map = result.as_map_rc().expect("meta should return a map");
+    assert_eq!(
+        map.get(&Value::keyword("doc")),
+        Some(&Value::string("Says hello."))
+    );
+    assert_eq!(
+        map.get(&Value::keyword("name")),
+        Some(&Value::string("greet"))
+    );
+    assert_eq!(map.get(&Value::keyword("arity")), Some(&Value::int(1)));
+}
+
+#[test]
+fn test_define_fn_docstring() {
+    let interp = Interpreter::new();
+    let result = interp
+        .eval_str(
+            r#"(begin
+                (define (double x) "Doubles a number." (* x 2))
+                (double 5))"#,
+        )
+        .unwrap();
+    assert_eq!(result, Value::int(10));
+}
+
+#[test]
+fn test_define_fn_docstring_meta() {
+    let interp = Interpreter::new();
+    let result = interp
+        .eval_str(
+            r#"(begin
+                (define (double x) "Doubles a number." (* x 2))
+                (meta double))"#,
+        )
+        .unwrap();
+    let map = result.as_map_rc().expect("meta should return a map");
+    assert_eq!(
+        map.get(&Value::keyword("doc")),
+        Some(&Value::string("Doubles a number."))
+    );
+}
+
+#[test]
+fn test_meta_no_doc() {
+    let interp = Interpreter::new();
+    let result = interp
+        .eval_str("(begin (defn bar (x) x) (meta bar))")
+        .unwrap();
+    let map = result.as_map_rc().expect("meta should return a map");
+    assert_eq!(
+        map.get(&Value::keyword("name")),
+        Some(&Value::string("bar"))
+    );
+    assert!(map.get(&Value::keyword("doc")).is_none());
+}
+
+#[test]
+fn test_meta_native_fn() {
+    let interp = Interpreter::new();
+    let result = interp.eval_str("(meta +)").unwrap();
+    let map = result.as_map_rc().expect("meta should return a map");
+    assert_eq!(
+        map.get(&Value::keyword("type")),
+        Some(&Value::keyword("native-fn"))
+    );
+}
+
+#[test]
+fn test_defmacro_docstring() {
+    let interp = Interpreter::new();
+    let result = interp
+        .eval_str(
+            r#"(begin
+                (defmacro my-when "Conditional execution." (test . body)
+                  `(if ,test (begin ,@body)))
+                (meta my-when))"#,
+        )
+        .unwrap();
+    let map = result.as_map_rc().expect("meta should return a map");
+    assert_eq!(
+        map.get(&Value::keyword("doc")),
+        Some(&Value::string("Conditional execution."))
+    );
+}
+
+#[test]
+fn test_doctest_passing() {
+    let interp = Interpreter::new();
+    let result = interp
+        .eval_str(
+            r#"(begin
+                (defn double
+                  "Doubles a number.
+
+                   >>> (double 5)
+                   10
+
+                   >>> (double 0)
+                   0"
+                  (n) (* n 2))
+                (doctest double))"#,
+        )
+        .unwrap();
+    let map = result.as_map_rc().expect("doctest should return a map");
+    assert_eq!(map.get(&Value::keyword("passed")), Some(&Value::int(2)));
+    assert_eq!(map.get(&Value::keyword("total")), Some(&Value::int(2)));
+}
+
+#[test]
+fn test_doctest_failing() {
+    let interp = Interpreter::new();
+    let result = interp
+        .eval_str(
+            r#"(begin
+                (defn broken
+                  "Always returns wrong answer.
+
+                   >>> (broken 5)
+                   99"
+                  (n) n)
+                (doctest broken))"#,
+        )
+        .unwrap();
+    let map = result.as_map_rc().expect("doctest should return a map");
+    assert_eq!(map.get(&Value::keyword("passed")), Some(&Value::int(0)));
+    assert_eq!(map.get(&Value::keyword("total")), Some(&Value::int(1)));
+}
+
+#[test]
+fn test_doctest_error_expected() {
+    let interp = Interpreter::new();
+    let result = interp
+        .eval_str(
+            r#"(begin
+                (defn safe-div
+                  "Divides safely.
+
+                   >>> (safe-div 10 2)
+                   5
+
+                   >>> (safe-div 1 0)
+                   !! division"
+                  (a b)
+                  (if (= b 0) (error "division by zero") (/ a b)))
+                (doctest safe-div))"#,
+        )
+        .unwrap();
+    let map = result.as_map_rc().expect("doctest should return a map");
+    assert_eq!(map.get(&Value::keyword("passed")), Some(&Value::int(2)));
+    assert_eq!(map.get(&Value::keyword("total")), Some(&Value::int(2)));
+}
+
+#[test]
+fn test_doctest_setup_step() {
+    let interp = Interpreter::new();
+    let result = interp
+        .eval_str(
+            r#"(begin
+                (defn use-x
+                  "Uses a predefined x.
+
+                   >>>! (define x 42)
+                   >>> (use-x x)
+                   42"
+                  (val) val)
+                (doctest use-x))"#,
+        )
+        .unwrap();
+    let map = result.as_map_rc().expect("doctest should return a map");
+    assert_eq!(map.get(&Value::keyword("passed")), Some(&Value::int(2)));
+    assert_eq!(map.get(&Value::keyword("total")), Some(&Value::int(2)));
+}
+
+#[test]
+fn test_doc_search() {
+    let interp = Interpreter::new();
+    let result = interp
+        .eval_str(
+            r#"(begin
+                (defn greet "Says hello." (name) name)
+                (defn farewell "Says goodbye." (name) name)
+                (length (doc/search "greet")))"#,
+        )
+        .unwrap();
+    assert_eq!(result, Value::int(1));
+}
+
+#[test]
+fn test_doc_search_by_docstring() {
+    let interp = Interpreter::new();
+    let result = interp
+        .eval_str(
+            r#"(begin
+                (defn greet "Says hello." (name) name)
+                (defn farewell "Says goodbye." (name) name)
+                (length (doc/search "goodbye")))"#,
+        )
+        .unwrap();
+    assert_eq!(result, Value::int(1));
+}
+
+#[test]
+fn test_source_of_via_meta() {
+    let result = eval_to_string(
+        r#"(begin
+             (defn add "Add two numbers." (a b) (+ a b))
+             (get (meta add) :source))"#,
+    );
+    assert!(result.contains("defn"));
+    assert!(result.contains("add"));
+    assert!(result.contains("Add two numbers."));
+}
+
+#[test]
+fn test_source_of_special_form() {
+    let result = eval_to_string(
+        r#"(begin
+             (defn square (x) (* x x))
+             (source-of square))"#,
+    );
+    assert!(result.contains("defn"));
+    assert!(result.contains("square"));
+    assert!(result.contains("* x x"));
+}
+
+#[test]
+fn test_source_of_define_shorthand() {
+    let result = eval_to_string(
+        r#"(begin
+             (define (cube x) "Cube a number." (* x x x))
+             (source-of cube))"#,
+    );
+    assert!(result.contains("cube"));
+    assert!(result.contains("Cube a number."));
+}
+
+#[test]
+fn test_source_of_nil_for_undefined() {
+    let result = eval_to_string(r#"(source-of nonexistent)"#);
+    assert_eq!(result, "nil");
+}
+
+#[test]
+fn test_source_of_defmacro() {
+    let result = eval_to_string(
+        r#"(begin
+             (defmacro my-when "When macro." (test . body) (list 'if test (cons 'begin body)))
+             (source-of my-when))"#,
+    );
+    assert!(result.contains("defmacro"));
+    assert!(result.contains("my-when"));
+}
+
+#[test]
+fn test_read_source_basic() {
+    let result = eval_to_string(
+        r#"(begin
+             (file/write "/tmp/sema-test-read-source.sema"
+               "(defn greet \"Say hello.\" (name) (string-append \"Hello, \" name))\n(define x 42)")
+             (let ((defs (read-source "/tmp/sema-test-read-source.sema")))
+               (length defs)))"#,
+    );
+    assert_eq!(result, "2");
+}
+
+#[test]
+fn test_read_source_defn_structure() {
+    let result = eval_to_string(
+        r#"(begin
+             (file/write "/tmp/sema-test-rs2.sema"
+               "(defn add \"Add two numbers.\" (a b) (+ a b))")
+             (let ((defs (read-source "/tmp/sema-test-rs2.sema")))
+               (let ((d (first defs)))
+                 (list (get d :type) (get d :name) (get d :doc)))))"#,
+    );
+    assert_eq!(result, "(:defn \"add\" \"Add two numbers.\")");
+}
+
+#[test]
+fn test_read_source_with_directives() {
+    let result = eval_to_string(
+        r#"(begin
+             (file/write "/tmp/sema-test-rs3.sema"
+               ";;@since 1.0.0\n;;@deprecated Use bar\n(defn foo (x) x)")
+             (let ((defs (read-source "/tmp/sema-test-rs3.sema")))
+               (let ((d (first defs)))
+                 (get-in d (list :directives :since)))))"#,
+    );
+    assert_eq!(result, "\"1.0.0\"");
+}
+
+#[test]
+fn test_read_source_non_defn() {
+    let result = eval_to_string(
+        r#"(begin
+             (file/write "/tmp/sema-test-rs4.sema" "(println \"hello\")")
+             (let ((defs (read-source "/tmp/sema-test-rs4.sema")))
+               (get (first defs) :type)))"#,
+    );
+    assert_eq!(result, ":expr");
+}
+
+#[test]
+fn test_read_source_define_shorthand() {
+    let result = eval_to_string(
+        r#"(begin
+             (file/write "/tmp/sema-test-rs5.sema"
+               "(define (square x) \"Square x.\" (* x x))")
+             (let ((defs (read-source "/tmp/sema-test-rs5.sema")))
+               (let ((d (first defs)))
+                 (list (get d :type) (get d :name) (get d :doc)))))"#,
+    );
+    assert_eq!(result, "(:defn \"square\" \"Square x.\")");
+}
+
+#[test]
+fn test_read_source_defmacro() {
+    let result = eval_to_string(
+        r#"(begin
+             (file/write "/tmp/sema-test-rs6.sema"
+               "(defmacro my-when \"When macro.\" (test . body) (list 'if test (cons 'begin body)))")
+             (let ((defs (read-source "/tmp/sema-test-rs6.sema")))
+               (let ((d (first defs)))
+                 (list (get d :type) (get d :name) (get d :doc)))))"#,
+    );
+    assert_eq!(result, "(:defmacro \"my-when\" \"When macro.\")");
+}
+
+#[test]
+fn test_read_source_simple_define() {
+    let result = eval_to_string(
+        r#"(begin
+             (file/write "/tmp/sema-test-rs7.sema" "(define pi 3.14159)")
+             (let ((defs (read-source "/tmp/sema-test-rs7.sema")))
+               (let ((d (first defs)))
+                 (list (get d :type) (get d :name)))))"#,
+    );
+    assert_eq!(result, "(:define \"pi\")");
+}
+
+#[test]
+fn test_ask_no_llm_configured() {
+    let result = eval_to_string(
+        r#"(begin
+             (defn add (a b) (+ a b))
+             (try (ask add "what does this do?")
+                  (catch e (get e :message))))"#,
+    );
+    assert!(result.contains("LLM") || result.contains("llm") || result.contains("provider"));
+}
+
+#[test]
+fn test_ask_code_no_llm_configured() {
+    let result = eval_to_string(
+        r#"(begin
+             (defn add (a b) (+ a b))
+             (try (ask/code add "make this handle strings too")
+                  (catch e (get e :message))))"#,
+    );
+    assert!(result.contains("LLM") || result.contains("llm") || result.contains("provider"));
+}
+
+#[test]
+fn test_ask_arity_error() {
+    let result = eval_to_string(
+        r#"(try (ask "only one arg")
+             (catch e (get e :message)))"#,
+    );
+    assert!(result.contains("arity") || result.contains("2"));
+}
+
+#[test]
+fn test_ask_code_arity_error() {
+    let result = eval_to_string(
+        r#"(try (ask/code "only one arg")
+             (catch e (get e :message)))"#,
+    );
+    assert!(result.contains("arity") || result.contains("2"));
+}
+
+#[test]
+fn test_heal_no_docstring() {
+    let result = eval_to_string(
+        r#"(begin
+             (defn add (a b) (+ a b))
+             (try (heal! add)
+                  (catch e (get e :message))))"#,
+    );
+    assert!(result.contains("no docstring"));
+}
+
+#[test]
+fn test_heal_no_doctests() {
+    let result = eval_to_string(
+        r#"(begin
+             (defn add "Add two numbers." (a b) (+ a b))
+             (try (heal! add)
+                  (catch e (get e :message))))"#,
+    );
+    assert!(result.contains("no doctests"));
+}
+
+#[test]
+fn test_heal_already_passing() {
+    let result = eval_to_string(
+        r#"(begin
+             (defn add
+               "Add two.
+                >>> (add 1 2)
+                3"
+               (a b) (+ a b))
+             (get (heal! add) :status))"#,
+    );
+    assert_eq!(result, ":ok");
+}
+
+#[test]
+fn test_heal_no_llm_configured() {
+    let result = eval_to_string(
+        r#"(begin
+             (defn broken
+               "Always returns wrong.
+                >>> (broken 1)
+                42"
+               (x) 0)
+             (try (heal! broken)
+                  (catch e (get e :message))))"#,
+    );
+    assert!(
+        result.contains("LLM")
+            || result.contains("llm")
+            || result.contains("provider")
+            || result.contains("configured")
+    );
+}
+
+// ── observe! tests ───────────────────────────────────────────────
+
+#[test]
+fn test_observe_basic() {
+    let interp = Interpreter::new();
+    interp
+        .eval_str_in_global(
+            r#"(begin
+                (defn add "Adds two numbers." (a b) (+ a b))
+                (define result nil)
+                (observe! add 3
+                  (fn (log) (set! result (count log)))))"#,
+        )
+        .unwrap();
+    interp.eval_str_in_global("(add 1 2)").unwrap();
+    interp.eval_str_in_global("(add 3 4)").unwrap();
+    interp.eval_str_in_global("(add 5 6)").unwrap();
+    let result = interp.eval_str_in_global("result").unwrap();
+    assert_eq!(result, Value::int(3));
+}
+
+#[test]
+fn test_observe_call_log_structure() {
+    let interp = Interpreter::new();
+    interp
+        .eval_str_in_global(
+            r#"(begin
+                (defn double "Doubles." (x) (* x 2))
+                (define log-data nil)
+                (observe! double 1
+                  (fn (log) (set! log-data (first log)))))"#,
+        )
+        .unwrap();
+    interp.eval_str_in_global("(double 5)").unwrap();
+    let entry = interp.eval_str_in_global("log-data").unwrap();
+    let map = entry.as_map_rc().expect("log entry should be a map");
+    assert_eq!(
+        map.get(&Value::keyword("args")),
+        Some(&Value::list(vec![Value::int(5)]))
+    );
+    assert_eq!(map.get(&Value::keyword("result")), Some(&Value::int(10)));
+    assert!(map.get(&Value::keyword("time-ms")).is_some());
+}
+
+#[test]
+fn test_observe_restores_original() {
+    let interp = Interpreter::new();
+    interp
+        .eval_str_in_global(
+            r#"(begin
+                (defn inc "Increments." (x) (+ x 1))
+                (observe! inc 2 (fn (log) nil)))"#,
+        )
+        .unwrap();
+    interp.eval_str_in_global("(inc 1)").unwrap();
+    interp.eval_str_in_global("(inc 2)").unwrap();
+    let result = interp.eval_str_in_global("(inc 10)").unwrap();
+    assert_eq!(result, Value::int(11));
+}
+
+#[test]
+fn test_observe_function_still_works() {
+    let interp = Interpreter::new();
+    interp
+        .eval_str_in_global(
+            r#"(begin
+                (defn square "Squares." (x) (* x x))
+                (observe! square 2 (fn (log) nil)))"#,
+        )
+        .unwrap();
+    let r = interp.eval_str_in_global("(square 7)").unwrap();
+    assert_eq!(r, Value::int(49));
+}
+
+// ── become! tests ────────────────────────────────────────────────
+
+#[test]
+fn test_become_replaces_function() {
+    let interp = Interpreter::new();
+    let result = interp
+        .eval_str(
+            r#"(begin
+                (defn greet (name) (string-append "Hello, " name))
+                (become! greet (fn (name) (string-append "Hi, " name)))
+                (greet "Alice"))"#,
+        )
+        .unwrap();
+    assert_eq!(result, Value::string("Hi, Alice"));
+}
+
+#[test]
+fn test_become_saves_history() {
+    let interp = Interpreter::new();
+    let result = interp
+        .eval_str(
+            r#"(begin
+                (defn inc1 (x) (+ x 1))
+                (become! inc1 (fn (x) (+ x 2)))
+                (count (history inc1)))"#,
+        )
+        .unwrap();
+    assert_eq!(result, Value::int(1));
+}
+
+#[test]
+fn test_become_doctest_gate() {
+    let interp = Interpreter::new();
+    let result = interp.eval_str(
+        r#"(begin
+            (defn double "Doubles.
+               >>> (double 5)
+               10" (x) (* x 2))
+            (become! double (fn (x) (+ x 1))))"#,
+    );
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("doctest") || err.contains("pass"),
+        "Error should mention doctests: {err}"
+    );
+}
+
+#[test]
+fn test_become_doctest_passes() {
+    let interp = Interpreter::new();
+    let result = interp
+        .eval_str(
+            r#"(begin
+                (defn double "Doubles.
+                   >>> (double 5)
+                   10" (x) (* x 2))
+                (become! double (fn (x) (+ x x)))
+                (double 7))"#,
+        )
+        .unwrap();
+    assert_eq!(result, Value::int(14));
+}
+
+#[test]
+fn test_become_no_doctests_allowed() {
+    let interp = Interpreter::new();
+    let result = interp
+        .eval_str(
+            r#"(begin
+                (defn helper (x) (+ x 1))
+                (become! helper (fn (x) (+ x 10)))
+                (helper 5))"#,
+        )
+        .unwrap();
+    assert_eq!(result, Value::int(15));
+}
+
+// ── history / rollback! tests ────────────────────────────────────
+
+#[test]
+fn test_history_empty() {
+    let interp = Interpreter::new();
+    let result = interp
+        .eval_str("(begin (defn foo (x) x) (history foo))")
+        .unwrap();
+    assert_eq!(result, Value::list(vec![]));
+}
+
+#[test]
+fn test_history_after_become() {
+    let interp = Interpreter::new();
+    let result = interp
+        .eval_str(
+            r#"(begin
+                (defn add1 (x) (+ x 1))
+                (become! add1 (fn (x) (+ x 10)))
+                (become! add1 (fn (x) (+ x 100)))
+                (count (history add1)))"#,
+        )
+        .unwrap();
+    assert_eq!(result, Value::int(2));
+}
+
+#[test]
+fn test_history_entry_has_version() {
+    let interp = Interpreter::new();
+    let result = interp
+        .eval_str(
+            r#"(begin
+                (defn inc (x) (+ x 1))
+                (become! inc (fn (x) (+ x 2)))
+                (get (first (history inc)) :version))"#,
+        )
+        .unwrap();
+    assert_eq!(result, Value::int(1));
+}
+
+#[test]
+fn test_rollback_restores_version() {
+    let interp = Interpreter::new();
+    let result = interp
+        .eval_str(
+            r#"(begin
+                (defn calc (x) (+ x 1))
+                (become! calc (fn (x) (+ x 10)))
+                (become! calc (fn (x) (+ x 100)))
+                (rollback! calc 1)
+                (calc 0))"#,
+        )
+        .unwrap();
+    assert_eq!(result, Value::int(1));
+}
+
+#[test]
+fn test_rollback_invalid_version() {
+    let interp = Interpreter::new();
+    let result = interp.eval_str(
+        r#"(begin
+            (defn foo (x) x)
+            (rollback! foo 5))"#,
+    );
+    assert!(result.is_err());
+}
+
+// ── freeze! tests ────────────────────────────────────────────────
+
+#[test]
+fn test_freeze_prevents_become() {
+    let interp = Interpreter::new();
+    let result = interp.eval_str(
+        r#"(begin
+            (defn stable (x) x)
+            (freeze! stable)
+            (become! stable (fn (x) (+ x 1))))"#,
+    );
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("frozen"), "Error should mention frozen: {err}");
+}
+
+#[test]
+fn test_freeze_prevents_rollback() {
+    let interp = Interpreter::new();
+    let result = interp.eval_str(
+        r#"(begin
+            (defn calc (x) (+ x 1))
+            (become! calc (fn (x) (+ x 10)))
+            (freeze! calc)
+            (rollback! calc 1))"#,
+    );
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("frozen"), "Error should mention frozen: {err}");
+}
+
+#[test]
+fn test_freeze_returns_nil() {
+    let interp = Interpreter::new();
+    let result = interp
+        .eval_str("(begin (defn f (x) x) (freeze! f))")
+        .unwrap();
+    assert_eq!(result, Value::nil());
+}
+
+// ── bench tests ──────────────────────────────────────────────────
+
+#[test]
+fn test_bench_basic() {
+    let interp = Interpreter::new();
+    let result = interp.eval_str("(bench (fn () (+ 1 2)) 100)").unwrap();
+    let map = result.as_map_rc().expect("bench should return a map");
+    assert_eq!(
+        map.get(&Value::keyword("iterations")),
+        Some(&Value::int(100))
+    );
+    assert!(map.get(&Value::keyword("total-ms")).is_some());
+    assert!(map.get(&Value::keyword("mean-ms")).is_some());
+}
+
+#[test]
+fn test_bench_zero_iterations() {
+    let interp = Interpreter::new();
+    let result = interp.eval_str("(bench (fn () nil) 0)").unwrap();
+    let map = result.as_map_rc().expect("bench should return a map");
+    assert_eq!(map.get(&Value::keyword("iterations")), Some(&Value::int(0)));
+    assert_eq!(
+        map.get(&Value::keyword("mean-ms")),
+        Some(&Value::float(0.0))
+    );
+}
+
+#[test]
+fn test_become_observe_history_full_flow() {
+    let interp = Interpreter::new();
+
+    // Define a function
+    interp
+        .eval_str_in_global(r#"(defn calc (x) (+ x 1))"#)
+        .unwrap();
+
+    // become! to v2
+    interp
+        .eval_str_in_global("(become! calc (fn (x) (+ x 10)))")
+        .unwrap();
+    let r = interp.eval_str_in_global("(calc 0)").unwrap();
+    assert_eq!(r, Value::int(10));
+
+    // become! to v3
+    interp
+        .eval_str_in_global("(become! calc (fn (x) (+ x 100)))")
+        .unwrap();
+    let r = interp.eval_str_in_global("(calc 0)").unwrap();
+    assert_eq!(r, Value::int(100));
+
+    // Check history has 2 entries
+    let h = interp.eval_str_in_global("(count (history calc))").unwrap();
+    assert_eq!(h, Value::int(2));
+
+    // Rollback to version 1 (original)
+    interp.eval_str_in_global("(rollback! calc 1)").unwrap();
+    let r = interp.eval_str_in_global("(calc 0)").unwrap();
+    assert_eq!(r, Value::int(1));
+
+    // Freeze
+    interp.eval_str_in_global("(freeze! calc)").unwrap();
+
+    // become! should fail now
+    let result = interp.eval_str_in_global("(become! calc (fn (x) x))");
+    assert!(result.is_err());
+}

--- a/crates/sema/tests/integration_test.rs
+++ b/crates/sema/tests/integration_test.rs
@@ -14519,3 +14519,115 @@ fn test_become_observe_history_full_flow() {
     let result = interp.eval_str_in_global("(become! calc (fn (x) x))");
     assert!(result.is_err());
 }
+
+// ── evolve tests ─────────────────────────────────────────────────
+
+#[test]
+fn test_evolve_missing_name() {
+    let interp = Interpreter::new();
+    let result = interp
+        .eval_str(r#"(evolve :spec '((>>> (+ 1 2) 3)) :fitness (fn (f r) 1) :seed-prompt "test")"#);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains(":name"));
+}
+
+#[test]
+fn test_evolve_missing_spec() {
+    let interp = Interpreter::new();
+    let result =
+        interp.eval_str(r#"(evolve :name "test" :fitness (fn (f r) 1) :seed-prompt "test")"#);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains(":spec"));
+}
+
+#[test]
+fn test_evolve_missing_fitness() {
+    let interp = Interpreter::new();
+    let result =
+        interp.eval_str(r#"(evolve :name "test" :spec '((>>> (+ 1 2) 3)) :seed-prompt "test")"#);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains(":fitness"));
+}
+
+#[test]
+fn test_evolve_missing_seed_prompt() {
+    let interp = Interpreter::new();
+    let result =
+        interp.eval_str(r#"(evolve :name "test" :spec '((>>> (+ 1 2) 3)) :fitness (fn (f r) 1))"#);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains(":seed-prompt"));
+}
+
+#[test]
+fn test_evolve_unknown_option() {
+    let interp = Interpreter::new();
+    let result = interp.eval_str(
+        r#"(evolve :name "t" :spec '((>>> 1 1)) :fitness (fn (f r) 1) :seed-prompt "t" :bogus 1)"#,
+    );
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("bogus"));
+}
+
+#[test]
+fn test_evolve_spec_from_docstring() {
+    let interp = Interpreter::new();
+    let result = interp.eval_str(
+        r#"(begin
+            (defn my-add "Adds.
+                >>> (my-add 1 2)
+                3" (a b) (+ a b))
+            (evolve :name "my-add"
+                    :spec my-add
+                    :fitness (fn (f r) 1)
+                    :seed-prompt "test"
+                    :generations 0
+                    :population 0))"#,
+    );
+    // With 0 generations and 0 population, config parsed OK but no candidates
+    // It will error on "no candidates" which is fine — config parsed OK
+    let is_config_error = result
+        .as_ref()
+        .err()
+        .map(|e| {
+            let s = e.to_string();
+            s.contains(":name")
+                || s.contains(":spec")
+                || s.contains(":fitness")
+                || s.contains(":seed-prompt")
+        })
+        .unwrap_or(false);
+    assert!(!is_config_error, "Should not be a config parsing error");
+}
+
+#[test]
+fn test_evolve_inline_spec_bad_format() {
+    let interp = Interpreter::new();
+    // Spec cases must be (>>> expr expected)
+    let result = interp.eval_str(
+        r#"(evolve :name "t" :spec '((bad 1 2)) :fitness (fn (f r) 1) :seed-prompt "t")"#,
+    );
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains(">>>"));
+}
+
+#[test]
+fn test_evolve_empty_spec() {
+    let interp = Interpreter::new();
+    let result =
+        interp.eval_str(r#"(evolve :name "t" :spec '() :fitness (fn (f r) 1) :seed-prompt "t")"#);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("empty"));
+}
+
+#[test]
+fn test_evolve_spec_fn_no_doctests() {
+    let interp = Interpreter::new();
+    let result = interp.eval_str(
+        r#"(begin
+            (defn nodoc (x) x)
+            (evolve :name "t" :spec nodoc :fitness (fn (f r) 1) :seed-prompt "t"))"#,
+    );
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("docstring") || err.contains("doctest"));
+}

--- a/docs/plans/2026-02-24-living-code-phase1.md
+++ b/docs/plans/2026-02-24-living-code-phase1.md
@@ -1,0 +1,1135 @@
+# Living Code Phase 1: Docstrings & Doctests
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add docstring support to `defn`/`define`/`defmacro`, runtime introspection via `(doc)`/`(meta)`, and a doctest runner that extracts `>>>` examples from docstrings and executes them as tests.
+
+**Architecture:** Docstrings are stored as binding-level metadata on the Env (a parallel `SpurMap<Spur, BTreeMap<Value, Value>>`) alongside the existing bindings map. The `defn`/`define`/`defmacro` special forms detect an optional string literal in docstring position and store it. A new `introspect.rs` stdlib module provides `(doc sym)`, `(meta sym)`, and `(doc/search query)`. A doctest parser extracts `>>>` examples from docstrings, and a runner evaluates them and compares results. CLI gets `sema test --doctests`.
+
+**Tech Stack:** Rust, sema-core (Env), sema-eval (special forms), sema-stdlib (new introspect module), sema (CLI)
+
+**Worktree:** `/Users/helge/code/sema-lisp/.worktrees/living-code` (branch: `feature/living-code`)
+
+---
+
+## Task 1: Add metadata storage to Env
+
+**Files:**
+- Modify: `crates/sema-core/src/value.rs` (Env struct + impl, lines ~1804–1915)
+
+**Step 1: Add metadata field to Env struct**
+
+Add a `metadata` field to `Env` alongside `bindings`. Same pattern: `Rc<RefCell<SpurMap<Spur, BTreeMap<Value, Value>>>>`.
+
+```rust
+// In the Env struct (value.rs ~line 1804):
+pub struct Env {
+    pub bindings: Rc<RefCell<SpurMap<Spur, Value>>>,
+    pub metadata: Rc<RefCell<SpurMap<Spur, std::collections::BTreeMap<Value, Value>>>>,
+    pub parent: Option<Rc<Env>>,
+    pub version: Cell<u64>,
+}
+```
+
+Update `Env::new()`, `Env::with_parent()`, and `Default` impl to initialize `metadata` as empty.
+
+**Step 2: Add metadata accessors**
+
+Add these methods to `impl Env`:
+
+```rust
+/// Set a metadata entry for a binding.
+pub fn set_meta(&self, name: Spur, key: Value, val: Value) {
+    let mut meta = self.metadata.borrow_mut();
+    meta.entry(name).or_default().insert(key, val);
+}
+
+/// Set the full metadata map for a binding.
+pub fn set_meta_map(&self, name: Spur, map: std::collections::BTreeMap<Value, Value>) {
+    self.metadata.borrow_mut().insert(name, map);
+}
+
+/// Get metadata for a binding, searching parent scopes.
+pub fn get_meta(&self, name: Spur) -> Option<std::collections::BTreeMap<Value, Value>> {
+    if let Some(meta) = self.metadata.borrow().get(&name) {
+        Some(meta.clone())
+    } else if let Some(parent) = &self.parent {
+        parent.get_meta(name)
+    } else {
+        None
+    }
+}
+```
+
+**Step 3: Run existing tests to verify nothing broke**
+
+Run: `cargo test -p sema-core`
+Expected: All 140 tests pass. The new field is additive, existing code doesn't touch it.
+
+**Step 4: Commit**
+
+```bash
+git add crates/sema-core/src/value.rs
+git commit -m "feat: add metadata storage to Env for docstrings"
+```
+
+---
+
+## Task 2: Parse docstrings in `defn`/`defun`
+
+**Files:**
+- Modify: `crates/sema-eval/src/special_forms.rs` (eval_defun ~line 411, eval_define ~line 337)
+
+**Step 1: Write failing test**
+
+Add to `crates/sema/tests/integration_test.rs`:
+
+```rust
+#[test]
+fn test_defn_docstring() {
+    let interp = Interpreter::new();
+    // defn with docstring: (defn name "doc" (params) body)
+    interp.eval_str(r#"(defn greet "Says hello to someone." (name) (string-append "Hello, " name))"#).unwrap();
+    let result = interp.eval_str(r#"(greet "World")"#).unwrap();
+    assert_eq!(result, Value::string("Hello, World"));
+    // Verify docstring is stored in metadata
+    let result = interp.eval_str(r#"(meta greet)"#).unwrap();
+    let meta_map = result.as_map_rc().expect("meta should return a map");
+    let doc = meta_map.get(&Value::keyword("doc")).expect("should have :doc");
+    assert_eq!(doc.as_str().unwrap(), "Says hello to someone.");
+}
+
+#[test]
+fn test_defn_no_docstring() {
+    // defn without docstring still works
+    let interp = Interpreter::new();
+    interp.eval_str("(defn add (a b) (+ a b))").unwrap();
+    let result = interp.eval_str("(add 1 2)").unwrap();
+    assert_eq!(result, Value::int(3));
+}
+
+#[test]
+fn test_define_fn_docstring() {
+    let interp = Interpreter::new();
+    // (define (f x) "doc" body)
+    interp.eval_str(r#"(define (double x) "Doubles a number." (* x 2))"#).unwrap();
+    let result = interp.eval_str("(double 5)").unwrap();
+    assert_eq!(result, Value::int(10));
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p sema --test integration_test -- test_defn_docstring`
+Expected: FAIL (either parse error or `meta` function doesn't exist yet)
+
+**Step 3: Modify `eval_defun` to detect docstring**
+
+In `eval_defun` (special_forms.rs ~line 412), detect when `args[1]` is a string (docstring) instead of a list (params):
+
+```rust
+fn eval_defun(args: &[Value], env: &Env, ctx: &EvalContext) -> Result<Trampoline, SemaError> {
+    if args.len() < 3 {
+        return Err(SemaError::arity("defun", "3+", args.len()));
+    }
+    let name_spur = args[0]
+        .as_symbol_spur()
+        .ok_or_else(|| SemaError::type_error("symbol", args[0].type_name()))?;
+
+    // Detect optional docstring: (defn name "doc" (params) body...)
+    let (docstring, params_idx) = if args[1].as_str().is_some() && args.len() >= 4 {
+        (args[1].as_str().map(|s| s.to_string()), 2)
+    } else {
+        (None, 1)
+    };
+
+    let name = args[0].clone();
+    let params = args[params_idx]
+        .as_list_rc()
+        .ok_or_else(|| SemaError::type_error("list", args[params_idx].type_name()))?;
+
+    // Build (name params...) signature list
+    let mut sig = vec![name];
+    sig.extend(params.iter().cloned());
+    // Build transformed args: [(name params...), body...]
+    let mut define_args = vec![Value::list(sig)];
+    define_args.extend_from_slice(&args[params_idx + 1..]);
+    let result = eval_define(&define_args, env, ctx)?;
+
+    // Store docstring as metadata if present
+    if let Some(doc) = docstring {
+        env.set_meta(name_spur, Value::keyword("doc"), Value::string(&doc));
+    }
+
+    Ok(result)
+}
+```
+
+**Step 4: Modify `eval_define` for `(define (f x) "doc" body)` form**
+
+In `eval_define`, in the `(define (f x) body...)` branch (~line 356), detect docstring:
+
+```rust
+// Inside the `else if let Some(sig) = args[0].as_list()` branch:
+// After extracting name_spur and params, before building body:
+
+// Detect optional docstring: (define (f x) "doc" body...)
+let (docstring, body_start) = if args.len() > 2 && args[1].as_str().is_some() {
+    (args[1].as_str().map(|s| s.to_string()), 2)
+} else {
+    (None, 1)
+};
+let body = args[body_start..].to_vec();
+// ... rest of function ...
+// After env.set(name_spur, lambda):
+if let Some(doc) = docstring {
+    env.set_meta(name_spur, Value::keyword("doc"), Value::string(&doc));
+}
+```
+
+**Step 5: Run tests**
+
+Run: `cargo test -p sema --test integration_test -- test_defn`
+Expected: `test_defn_docstring` still fails (needs `meta` function), `test_defn_no_docstring` passes.
+
+**Step 6: Commit**
+
+```bash
+git add crates/sema-eval/src/special_forms.rs
+git commit -m "feat: parse docstrings in defn/define special forms"
+```
+
+---
+
+## Task 3: Parse docstrings in `defmacro`
+
+**Files:**
+- Modify: `crates/sema-eval/src/special_forms.rs` (eval_defmacro)
+
+**Step 1: Add docstring detection to `eval_defmacro`**
+
+Same pattern: if `args[1]` is a string and `args.len() >= 4`, treat it as a docstring, shift params to `args[2]`.
+
+```rust
+fn eval_defmacro(args: &[Value], env: &Env) -> Result<Trampoline, SemaError> {
+    if args.len() < 3 {
+        return Err(SemaError::arity("defmacro", "3+", args.len()));
+    }
+    let name_spur = args[0]
+        .as_symbol_spur()
+        .ok_or_else(|| SemaError::eval("defmacro: name must be a symbol"))?;
+
+    // Detect optional docstring: (defmacro name "doc" (params) body...)
+    let (docstring, params_idx) = if args[1].as_str().is_some() && args.len() >= 4 {
+        (args[1].as_str().map(|s| s.to_string()), 2)
+    } else {
+        (None, 1)
+    };
+
+    let param_list = args[params_idx]
+        .as_list()
+        .ok_or_else(|| SemaError::eval("defmacro: params must be a list"))?;
+    // ... rest unchanged, using params_idx + 1 for body start ...
+    let body = args[params_idx + 1..].to_vec();
+
+    // After env.set(name_spur, mac):
+    if let Some(doc) = docstring {
+        env.set_meta(name_spur, Value::keyword("doc"), Value::string(&doc));
+    }
+    // ...
+}
+```
+
+**Step 2: Run tests**
+
+Run: `cargo test -p sema-eval`
+Expected: All pass.
+
+**Step 3: Commit**
+
+```bash
+git add crates/sema-eval/src/special_forms.rs
+git commit -m "feat: parse docstrings in defmacro"
+```
+
+---
+
+## Task 4: `(doc)` and `(meta)` stdlib functions
+
+**Files:**
+- Create: `crates/sema-stdlib/src/introspect.rs`
+- Modify: `crates/sema-stdlib/src/lib.rs` (add `mod introspect` + register call)
+
+**Step 1: Create `introspect.rs`**
+
+```rust
+use sema_core::{check_arity, intern, resolve, Env, SemaError, Value};
+use crate::register_fn;
+
+pub fn register(env: &Env) {
+    // (meta sym) — returns metadata map for a symbol, or nil
+    register_fn(env, "meta", |args| {
+        check_arity!(args, "meta", 1);
+        let spur = args[0]
+            .as_symbol_spur()
+            .ok_or_else(|| SemaError::type_error("symbol", args[0].type_name()))?;
+        // Look up metadata from the environment
+        // We need env access — this will need to be register_fn_ctx or use the callback
+        Err(SemaError::eval("meta: needs env access — use register_fn_ctx"))
+    });
+}
+```
+
+Wait — `register_fn` doesn't have env access. We need `NativeFn::with_ctx()` which gets `(&EvalContext, &[Value])`. But the EvalContext doesn't carry the env. Let me check what pattern is used for functions that need env access.
+
+**Actually:** The `meta` function needs access to the calling environment to look up metadata. This requires a **special form**, not a stdlib function. Looking at how `eval` special form works — it receives `(args, env, ctx)`.
+
+**Revised approach:** Implement `meta` and `doc` as **special forms** in `sema-eval`, since they need access to the calling env to look up metadata. This is the same pattern as `eval`, `define`, etc.
+
+**Step 1: Add `meta` and `doc` special forms**
+
+In `special_forms.rs`, add to the `SpecialForms` struct:
+
+```rust
+meta: Spur,
+doc: Spur,
+```
+
+Initialize them:
+```rust
+meta: intern("meta"),
+doc: intern("doc"),
+```
+
+Add to `ALL_SPECIAL_FORMS`:
+```rust
+"meta",
+"doc",
+```
+
+Add dispatch in `try_eval_special()`:
+```rust
+} else if head_spur == sf.meta {
+    Some(eval_meta(args, env, ctx))
+} else if head_spur == sf.doc {
+    Some(eval_doc(args, env, ctx))
+}
+```
+
+**Step 2: Implement `eval_meta`**
+
+```rust
+fn eval_meta(args: &[Value], env: &Env, ctx: &EvalContext) -> Result<Trampoline, SemaError> {
+    if args.len() != 1 {
+        return Err(SemaError::arity("meta", "1", args.len()));
+    }
+    let spur = args[0]
+        .as_symbol_spur()
+        .ok_or_else(|| SemaError::type_error("symbol", args[0].type_name()))?;
+
+    // Build metadata map
+    let mut result = std::collections::BTreeMap::new();
+
+    // Add stored metadata (doc, etc.)
+    if let Some(meta) = env.get_meta(spur) {
+        result.extend(meta);
+    }
+
+    // Add name
+    result.insert(Value::keyword("name"), Value::string(&resolve(spur)));
+
+    // Add type and arity info from the value itself
+    if let Some(val) = env.get(spur) {
+        result.insert(Value::keyword("type"), Value::keyword(val.type_name()));
+        if let Some(lambda) = val.as_lambda_rc() {
+            let param_names: Vec<Value> = lambda.params.iter().map(|s| Value::symbol(&resolve(*s))).collect();
+            result.insert(Value::keyword("params"), Value::list(param_names));
+            let arity = lambda.params.len() as i64;
+            result.insert(Value::keyword("arity"), Value::int(arity));
+            if lambda.rest_param.is_some() {
+                result.insert(Value::keyword("variadic?"), Value::bool(true));
+            }
+        }
+    }
+
+    if result.is_empty() {
+        Ok(Trampoline::Value(Value::nil()))
+    } else {
+        let map: hashbrown::HashMap<Value, Value> = result.into_iter().collect();
+        Ok(Trampoline::Value(Value::hashmap(map.into_iter().collect())))
+    }
+}
+```
+
+**Step 3: Implement `eval_doc`**
+
+```rust
+fn eval_doc(args: &[Value], env: &Env, _ctx: &EvalContext) -> Result<Trampoline, SemaError> {
+    if args.len() != 1 {
+        return Err(SemaError::arity("doc", "1", args.len()));
+    }
+    let spur = args[0]
+        .as_symbol_spur()
+        .ok_or_else(|| SemaError::type_error("symbol", args[0].type_name()))?;
+    let name = resolve(spur);
+
+    let mut output = String::new();
+
+    // Function signature
+    if let Some(val) = env.get(spur) {
+        if let Some(lambda) = val.as_lambda_rc() {
+            let params: Vec<String> = lambda.params.iter().map(|s| resolve(*s)).collect();
+            let params_str = params.join(" ");
+            if let Some(rest) = &lambda.rest_param {
+                output.push_str(&format!("{name} : (fn {params_str} . {})\n", resolve(*rest)));
+            } else {
+                output.push_str(&format!("{name} : (fn {params_str})\n"));
+            }
+        } else if val.as_native_fn_rc().is_some() {
+            output.push_str(&format!("{name} : <native function>\n"));
+        } else if val.as_macro_rc().is_some() {
+            output.push_str(&format!("{name} : <macro>\n"));
+        }
+    }
+
+    // Docstring
+    if let Some(meta) = env.get_meta(spur) {
+        if let Some(doc) = meta.get(&Value::keyword("doc")) {
+            if let Some(s) = doc.as_str() {
+                output.push('\n');
+                output.push_str(s);
+                output.push('\n');
+            }
+        }
+    }
+
+    if output.is_empty() {
+        output = format!("No documentation for '{name}'.\n");
+    }
+
+    // Print to stderr (like Python's help()) and return nil
+    eprint!("{output}");
+    Ok(Trampoline::Value(Value::nil()))
+}
+```
+
+**Step 4: Run the tests from Task 2**
+
+Run: `cargo test -p sema --test integration_test -- test_defn_docstring`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/sema-eval/src/special_forms.rs
+git commit -m "feat: add (doc) and (meta) special forms for introspection"
+```
+
+---
+
+## Task 5: `(doc/search)` stdlib function
+
+**Files:**
+- Create: `crates/sema-stdlib/src/introspect.rs`
+- Modify: `crates/sema-stdlib/src/lib.rs`
+
+**Step 1: Create introspect.rs with `doc/search`**
+
+This one CAN be a stdlib function because it uses the EvalContext's callback to access the env indirectly. But actually, it also needs env access to search metadata. So it's better as a special form too.
+
+**Alternative:** Make it a simple function that takes a list of metadata maps (produced by calling `meta` on all names). But that's clunky.
+
+**Simplest approach:** Add `doc/search` as another special form alongside `doc` and `meta`.
+
+```rust
+// In special_forms.rs
+fn eval_doc_search(args: &[Value], env: &Env, _ctx: &EvalContext) -> Result<Trampoline, SemaError> {
+    if args.len() != 1 {
+        return Err(SemaError::arity("doc/search", "1", args.len()));
+    }
+    let query = args[0]
+        .as_str()
+        .ok_or_else(|| SemaError::type_error("string", args[0].type_name()))?
+        .to_lowercase();
+
+    let mut results = Vec::new();
+    for spur in env.all_names() {
+        let name = resolve(spur);
+        let name_lower = name.to_lowercase();
+        let mut matches = name_lower.contains(&query);
+
+        // Also search docstrings
+        if !matches {
+            if let Some(meta) = env.get_meta(spur) {
+                if let Some(doc) = meta.get(&Value::keyword("doc")) {
+                    if let Some(s) = doc.as_str() {
+                        matches = s.to_lowercase().contains(&query);
+                    }
+                }
+            }
+        }
+
+        if matches {
+            let mut entry = std::collections::BTreeMap::new();
+            entry.insert(Value::keyword("name"), Value::string(&name));
+            if let Some(meta) = env.get_meta(spur) {
+                if let Some(doc) = meta.get(&Value::keyword("doc")) {
+                    entry.insert(Value::keyword("doc"), doc.clone());
+                }
+            }
+            results.push(Value::hashmap(entry.into_iter().collect()));
+        }
+    }
+
+    Ok(Trampoline::Value(Value::list(results)))
+}
+```
+
+Add dispatch: `doc/search` uses a Spur for `"doc/search"`.
+
+**Step 2: Write test**
+
+```rust
+#[test]
+fn test_doc_search() {
+    let interp = Interpreter::new();
+    interp.eval_str(r#"(defn greet "Says hello." (name) name)"#).unwrap();
+    interp.eval_str(r#"(defn farewell "Says goodbye." (name) name)"#).unwrap();
+    let result = interp.eval_str(r#"(length (doc/search "greet"))"#).unwrap();
+    assert_eq!(result, Value::int(1));
+}
+```
+
+**Step 3: Run test, verify pass**
+
+Run: `cargo test -p sema --test integration_test -- test_doc_search`
+
+**Step 4: Commit**
+
+```bash
+git add crates/sema-eval/src/special_forms.rs
+git commit -m "feat: add (doc/search) for searching documented functions"
+```
+
+---
+
+## Task 6: Doctest parser
+
+**Files:**
+- Create: `crates/sema-eval/src/doctest.rs`
+- Modify: `crates/sema-eval/src/lib.rs` (add `pub mod doctest`)
+
+**Step 1: Define doctest types and parser**
+
+```rust
+//! Doctest parser and runner.
+//!
+//! Extracts executable examples from docstrings:
+//! - `>>>` lines are expressions to evaluate
+//! - The next non-blank line is the expected result
+//! - `!! substring` means expect an error containing substring
+//! - `>>>!` means evaluate but don't check result (setup)
+
+/// A single doctest example
+#[derive(Debug, Clone)]
+pub struct DocTest {
+    /// The Sema expression to evaluate
+    pub input: String,
+    /// What to expect
+    pub expected: Expected,
+    /// Line number within the docstring (for error reporting)
+    pub line: usize,
+}
+
+/// Expected result of a doctest
+#[derive(Debug, Clone)]
+pub enum Expected {
+    /// Compare return value via equal? (the expected expression as a string)
+    Value(String),
+    /// Expect an error containing this substring
+    Error(String),
+    /// Don't check the result (setup step)
+    Skip,
+}
+
+/// Parse doctests from a docstring.
+pub fn parse_doctests(docstring: &str) -> Vec<DocTest> {
+    let mut tests = Vec::new();
+    let lines: Vec<&str> = docstring.lines().collect();
+    let mut i = 0;
+
+    while i < lines.len() {
+        let trimmed = lines[i].trim();
+
+        if let Some(expr) = trimmed.strip_prefix(">>>!") {
+            // Setup-only: evaluate but don't check
+            let expr = expr.trim().to_string();
+            if !expr.is_empty() {
+                tests.push(DocTest {
+                    input: expr,
+                    expected: Expected::Skip,
+                    line: i + 1,
+                });
+            }
+            i += 1;
+        } else if let Some(expr) = trimmed.strip_prefix(">>>") {
+            let expr = expr.trim().to_string();
+            if expr.is_empty() {
+                i += 1;
+                continue;
+            }
+
+            // Look at next non-blank line for expected result
+            i += 1;
+            while i < lines.len() && lines[i].trim().is_empty() {
+                i += 1;
+            }
+
+            if i < lines.len() {
+                let expected_line = lines[i].trim();
+                if let Some(err_match) = expected_line.strip_prefix("!!") {
+                    tests.push(DocTest {
+                        input: expr,
+                        expected: Expected::Error(err_match.trim().to_string()),
+                        line: i,
+                    });
+                } else if expected_line.starts_with(">>>") {
+                    // No expected value, next line is another test
+                    tests.push(DocTest {
+                        input: expr,
+                        expected: Expected::Skip,
+                        line: i,
+                    });
+                    continue; // Don't increment i, re-process this line
+                } else {
+                    tests.push(DocTest {
+                        input: expr,
+                        expected: Expected::Value(expected_line.to_string()),
+                        line: i + 1,
+                    });
+                    i += 1;
+                }
+            } else {
+                // No expected line — treat as skip
+                tests.push(DocTest {
+                    input: expr,
+                    expected: Expected::Skip,
+                    line: i,
+                });
+            }
+        } else {
+            i += 1;
+        }
+    }
+
+    tests
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_basic() {
+        let doc = r#"Does something.
+
+   >>> (+ 1 2)
+   3
+
+   >>> (string/trim "  hi  ")
+   "hi""#;
+        let tests = parse_doctests(doc);
+        assert_eq!(tests.len(), 2);
+        assert_eq!(tests[0].input, "(+ 1 2)");
+        assert!(matches!(tests[0].expected, Expected::Value(ref s) if s == "3"));
+        assert_eq!(tests[1].input, r#"(string/trim "  hi  ")"#);
+    }
+
+    #[test]
+    fn test_parse_error_expected() {
+        let doc = r#"Fails on bad input.
+
+   >>> (/ 1 0)
+   !! division by zero"#;
+        let tests = parse_doctests(doc);
+        assert_eq!(tests.len(), 1);
+        assert!(matches!(tests[0].expected, Expected::Error(ref s) if s == "division by zero"));
+    }
+
+    #[test]
+    fn test_parse_setup_step() {
+        let doc = r#"Needs setup.
+
+   >>>! (define x 42)
+   >>> x
+   42"#;
+        let tests = parse_doctests(doc);
+        assert_eq!(tests.len(), 2);
+        assert!(matches!(tests[0].expected, Expected::Skip));
+        assert_eq!(tests[1].input, "x");
+    }
+
+    #[test]
+    fn test_parse_empty_docstring() {
+        let tests = parse_doctests("Just a description, no examples.");
+        assert!(tests.is_empty());
+    }
+}
+```
+
+**Step 2: Run unit tests**
+
+Run: `cargo test -p sema-eval -- doctest`
+Expected: All 4 tests pass.
+
+**Step 3: Commit**
+
+```bash
+git add crates/sema-eval/src/doctest.rs crates/sema-eval/src/lib.rs
+git commit -m "feat: doctest parser — extracts >>> examples from docstrings"
+```
+
+---
+
+## Task 7: Doctest runner
+
+**Files:**
+- Modify: `crates/sema-eval/src/doctest.rs` (add runner)
+- Modify: `crates/sema-eval/src/lib.rs` (expose runner via Interpreter)
+
+**Step 1: Add runner function to doctest.rs**
+
+```rust
+use sema_core::{resolve, Value, Env, SemaError};
+
+/// Result of running a single doctest
+#[derive(Debug)]
+pub struct DocTestResult {
+    pub input: String,
+    pub passed: bool,
+    pub expected: String,
+    pub actual: String,
+    pub line: usize,
+}
+
+/// Run all doctests for a given symbol in an environment.
+/// Returns a list of results.
+/// `eval_fn` is a callback that evaluates a Sema expression string and returns the result.
+pub fn run_doctests<F>(
+    docstring: &str,
+    eval_fn: &mut F,
+) -> Vec<DocTestResult>
+where
+    F: FnMut(&str) -> Result<Value, SemaError>,
+{
+    let tests = parse_doctests(docstring);
+    let mut results = Vec::new();
+
+    for test in tests {
+        match &test.expected {
+            Expected::Skip => {
+                // Run but don't check
+                let _ = eval_fn(&test.input);
+                results.push(DocTestResult {
+                    input: test.input,
+                    passed: true,
+                    expected: "(skip)".to_string(),
+                    actual: "(skip)".to_string(),
+                    line: test.line,
+                });
+            }
+            Expected::Value(expected_str) => {
+                match eval_fn(&test.input) {
+                    Ok(actual) => {
+                        // Parse the expected string as a Sema value for comparison
+                        let actual_str = format!("{actual}");
+                        let passed = actual_str.trim() == expected_str.trim();
+                        results.push(DocTestResult {
+                            input: test.input,
+                            passed,
+                            expected: expected_str.clone(),
+                            actual: actual_str,
+                            line: test.line,
+                        });
+                    }
+                    Err(e) => {
+                        results.push(DocTestResult {
+                            input: test.input,
+                            passed: false,
+                            expected: expected_str.clone(),
+                            actual: format!("ERROR: {e}"),
+                            line: test.line,
+                        });
+                    }
+                }
+            }
+            Expected::Error(expected_substring) => {
+                match eval_fn(&test.input) {
+                    Ok(val) => {
+                        results.push(DocTestResult {
+                            input: test.input,
+                            passed: false,
+                            expected: format!("!! {expected_substring}"),
+                            actual: format!("{val}"),
+                            line: test.line,
+                        });
+                    }
+                    Err(e) => {
+                        let err_str = e.to_string().to_lowercase();
+                        let expected_lower = expected_substring.to_lowercase();
+                        let passed = err_str.contains(&expected_lower);
+                        results.push(DocTestResult {
+                            input: test.input,
+                            passed,
+                            expected: format!("!! {expected_substring}"),
+                            actual: format!("!! {e}"),
+                            line: test.line,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    results
+}
+```
+
+**Step 2: Add `run_doctests_for_symbol` to Interpreter**
+
+In `crates/sema-eval/src/lib.rs`, add a method to `Interpreter` (or expose a public helper) that:
+1. Looks up a symbol's metadata for `:doc`
+2. Creates a child env
+3. Runs doctests in that child env using `eval_str`
+
+Check the existing `Interpreter` API first to determine the right pattern.
+
+**Step 3: Write integration test**
+
+```rust
+#[test]
+fn test_doctest_runner_basic() {
+    let interp = Interpreter::new();
+    interp.eval_str(r#"
+        (defn double
+          "Doubles a number.
+
+           >>> (double 5)
+           10
+
+           >>> (double 0)
+           0"
+          (n) (* n 2))
+    "#).unwrap();
+    // Run doctests via eval
+    let result = interp.eval_str(r#"(doctest double)"#).unwrap();
+    // Should return a map with :passed and :total
+    let map = result.as_map_rc().unwrap();
+    assert_eq!(map.get(&Value::keyword("passed")), Some(&Value::int(2)));
+    assert_eq!(map.get(&Value::keyword("total")), Some(&Value::int(2)));
+}
+```
+
+**Step 4: Implement `(doctest sym)` special form**
+
+Add to special_forms.rs:
+
+```rust
+fn eval_doctest(args: &[Value], env: &Env, ctx: &EvalContext) -> Result<Trampoline, SemaError> {
+    if args.len() != 1 {
+        return Err(SemaError::arity("doctest", "1", args.len()));
+    }
+    let spur = args[0]
+        .as_symbol_spur()
+        .ok_or_else(|| SemaError::type_error("symbol", args[0].type_name()))?;
+    let name = resolve(spur);
+
+    // Get docstring from metadata
+    let docstring = env
+        .get_meta(spur)
+        .and_then(|m| m.get(&Value::keyword("doc")).cloned())
+        .and_then(|v| v.as_str().map(|s| s.to_string()))
+        .ok_or_else(|| SemaError::eval(format!("doctest: no docstring for '{name}'")))?;
+
+    // Create child env for isolated evaluation
+    let child_env = Env::with_parent(Rc::new(env.clone()));
+
+    // Run doctests
+    let results = crate::doctest::run_doctests(&docstring, &mut |input| {
+        eval::eval_str_in_env(ctx, input, &child_env)
+    });
+
+    let total = results.len() as i64;
+    let passed = results.iter().filter(|r| r.passed).count() as i64;
+
+    // Print results
+    for r in &results {
+        if r.passed {
+            eprintln!("  ✓ {} => {}", r.input, r.expected);
+        } else {
+            eprintln!("  ✗ {} => expected {}, got {}", r.input, r.expected, r.actual);
+        }
+    }
+
+    // Return summary map
+    let mut map = std::collections::BTreeMap::new();
+    map.insert(Value::keyword("passed"), Value::int(passed));
+    map.insert(Value::keyword("total"), Value::int(total));
+    map.insert(Value::keyword("name"), Value::string(&name));
+    Ok(Trampoline::Value(Value::hashmap(map.into_iter().collect())))
+}
+```
+
+Note: `eval::eval_str_in_env` may not exist yet. Check `crates/sema-eval/src/lib.rs` for the right helper — likely `Interpreter::eval_str` internally calls something usable. The runner may need to be wired through the Interpreter's eval method. Adapt as needed.
+
+**Step 5: Run tests**
+
+Run: `cargo test -p sema --test integration_test -- test_doctest_runner`
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+git add crates/sema-eval/src/doctest.rs crates/sema-eval/src/special_forms.rs crates/sema-eval/src/lib.rs
+git commit -m "feat: doctest runner — (doctest sym) executes examples from docstrings"
+```
+
+---
+
+## Task 8: `sema test --doctests` CLI
+
+**Files:**
+- Modify: `crates/sema/src/main.rs` (add --doctests flag to test/run command)
+
+**Step 1: Add CLI flag**
+
+Check if there's already a `test` subcommand. If not, add a `--doctests` flag to the main CLI or create a `Test` subcommand.
+
+Add a `Test` subcommand:
+
+```rust
+/// Run doctests from source files
+Test {
+    /// Source files to scan for doctests
+    files: Vec<String>,
+    /// Verbose output
+    #[arg(short, long)]
+    verbose: bool,
+},
+```
+
+**Step 2: Implement the test command**
+
+The command should:
+1. Load each file with the interpreter
+2. After loading, iterate all symbols in the env that have `:doc` metadata
+3. For each, extract doctests and run them
+4. Print results and exit with appropriate code
+
+```rust
+Commands::Test { files, verbose } => {
+    let interp = Interpreter::new();
+    let mut total_passed = 0;
+    let mut total_tests = 0;
+    let mut any_failed = false;
+
+    for file in &files {
+        // Load the file (this defines all functions)
+        if let Err(e) = interp.eval_file(file) {
+            eprintln!("Error loading {file}: {e}");
+            any_failed = true;
+            continue;
+        }
+
+        // Find all symbols with docstrings and run their doctests
+        // Use eval to call (doctest sym) for each documented symbol
+        // ... implementation details depend on Interpreter API
+    }
+
+    if any_failed {
+        std::process::exit(1);
+    }
+}
+```
+
+**Step 3: Write a sample .sema file for manual testing**
+
+Create `examples/doctest-demo.sema`:
+
+```lisp
+(defn factorial
+  "Computes factorial of n.
+
+   >>> (factorial 0)
+   1
+
+   >>> (factorial 5)
+   120
+
+   >>> (factorial 1)
+   1"
+  (n)
+  (if (<= n 1) 1 (* n (factorial (- n 1)))))
+
+(defn fibonacci
+  "Returns the nth Fibonacci number.
+
+   >>> (fibonacci 0)
+   0
+
+   >>> (fibonacci 1)
+   1
+
+   >>> (fibonacci 10)
+   55"
+  (n)
+  (if (< n 2) n (+ (fibonacci (- n 1)) (fibonacci (- n 2)))))
+```
+
+**Step 4: Manual test**
+
+Run: `cargo run -- test examples/doctest-demo.sema`
+Expected output:
+```
+factorial:
+  ✓ (factorial 0) => 1
+  ✓ (factorial 5) => 120
+  ✓ (factorial 1) => 1
+fibonacci:
+  ✓ (fibonacci 0) => 0
+  ✓ (fibonacci 1) => 1
+  ✓ (fibonacci 10) => 55
+6/6 doctests passed
+```
+
+**Step 5: Commit**
+
+```bash
+git add crates/sema/src/main.rs examples/doctest-demo.sema
+git commit -m "feat: sema test --doctests CLI command"
+```
+
+---
+
+## Task 9: Dual-eval tests for doc/meta
+
+**Files:**
+- Modify: `crates/sema/tests/integration_test.rs` (tree-walker only tests for doc/meta/doctest — these are I/O-producing special forms, so tree-walker only per AGENTS.md)
+
+**Step 1: Write comprehensive integration tests**
+
+```rust
+#[test]
+fn test_meta_returns_map() {
+    let interp = Interpreter::new();
+    interp.eval_str(r#"(defn foo "A foo fn." (x) x)"#).unwrap();
+    let meta = interp.eval_str("(meta foo)").unwrap();
+    let map = meta.as_map_rc().expect("meta returns a map");
+    assert_eq!(map.get(&Value::keyword("name")), Some(&Value::string("foo")));
+    assert_eq!(map.get(&Value::keyword("arity")), Some(&Value::int(1)));
+    assert!(map.get(&Value::keyword("doc")).is_some());
+}
+
+#[test]
+fn test_meta_no_doc() {
+    let interp = Interpreter::new();
+    interp.eval_str("(defn bar (x) x)").unwrap();
+    let meta = interp.eval_str("(meta bar)").unwrap();
+    let map = meta.as_map_rc().expect("meta returns a map");
+    // Should have name and params but no :doc
+    assert_eq!(map.get(&Value::keyword("name")), Some(&Value::string("bar")));
+    assert!(map.get(&Value::keyword("doc")).is_none());
+}
+
+#[test]
+fn test_meta_undefined_returns_nil() {
+    let interp = Interpreter::new();
+    let result = interp.eval_str("(meta nonexistent)").unwrap();
+    // Should return a map with just :name, or nil — depends on impl
+    // At minimum it should not crash
+    assert!(result.as_map_rc().is_some() || result.is_nil());
+}
+
+#[test]
+fn test_defmacro_docstring() {
+    let interp = Interpreter::new();
+    interp.eval_str(r#"(defmacro my-when "Conditional execution." (test . body) `(if ,test (begin ,@body)))"#).unwrap();
+    let meta = interp.eval_str("(meta my-when)").unwrap();
+    let map = meta.as_map_rc().expect("meta returns a map");
+    let doc = map.get(&Value::keyword("doc")).unwrap();
+    assert_eq!(doc.as_str().unwrap(), "Conditional execution.");
+}
+
+#[test]
+fn test_doctest_failing() {
+    let interp = Interpreter::new();
+    interp.eval_str(r#"
+        (defn broken
+          "Always returns wrong answer.
+
+           >>> (broken 5)
+           99"
+          (n) n)
+    "#).unwrap();
+    let result = interp.eval_str("(doctest broken)").unwrap();
+    let map = result.as_map_rc().unwrap();
+    assert_eq!(map.get(&Value::keyword("passed")), Some(&Value::int(0)));
+    assert_eq!(map.get(&Value::keyword("total")), Some(&Value::int(1)));
+}
+
+#[test]
+fn test_doctest_error_expected() {
+    let interp = Interpreter::new();
+    interp.eval_str(r#"
+        (defn safe-div
+          "Divides safely.
+
+           >>> (safe-div 10 2)
+           5
+
+           >>> (safe-div 1 0)
+           !! division"
+          (a b)
+          (if (= b 0) (error "division by zero") (/ a b)))
+    "#).unwrap();
+    let result = interp.eval_str("(doctest safe-div)").unwrap();
+    let map = result.as_map_rc().unwrap();
+    assert_eq!(map.get(&Value::keyword("passed")), Some(&Value::int(2)));
+}
+```
+
+**Step 2: Run all integration tests**
+
+Run: `cargo test -p sema --test integration_test`
+Expected: All new + existing tests pass.
+
+**Step 3: Run full test suite**
+
+Run: `cargo test --workspace`
+Expected: All 1479+ tests pass.
+
+**Step 4: Commit**
+
+```bash
+git add crates/sema/tests/integration_test.rs
+git commit -m "test: comprehensive integration tests for doc/meta/doctest"
+```
+
+---
+
+## Verification Checklist
+
+Before considering Phase 1 complete:
+
+- [ ] `cargo test --workspace` — all tests pass
+- [ ] `cargo clippy --workspace -- -D warnings` — no warnings
+- [ ] `cargo fmt --all --check` — formatted
+- [ ] `(defn name "doc" (params) body)` stores docstring
+- [ ] `(define (name params) "doc" body)` stores docstring
+- [ ] `(defmacro name "doc" (params) body)` stores docstring
+- [ ] `(meta sym)` returns map with `:name`, `:doc`, `:params`, `:arity`, `:type`
+- [ ] `(doc sym)` prints formatted documentation
+- [ ] `(doc/search "query")` searches names and docstrings
+- [ ] `(doctest sym)` runs `>>>` examples and reports results
+- [ ] `sema test file.sema` runs all doctests in a file
+- [ ] Existing code without docstrings works exactly as before

--- a/docs/plans/2026-02-24-living-code-phase2.md
+++ b/docs/plans/2026-02-24-living-code-phase2.md
@@ -1,0 +1,652 @@
+# Living Code Phase 2: Self-Reading — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Enable Sema programs to read and analyze their own source code with `source-of`, directive comments (`;;@key value`), and `read-source`.
+
+**Architecture:** Three layers — (1) store source text + file/line metadata during `defn`/`define`/`defmacro` evaluation via the existing `set_meta` system, (2) add a directive-aware reader variant to `sema-reader` that captures `;;@` comments, (3) a new `read-source` stdlib function that parses files into structured definition maps.
+
+**Tech Stack:** Rust, existing `sema-reader` lexer/parser, `glob` crate (already a dependency of `sema-stdlib`), `sema-core` metadata system from Phase 1.
+
+---
+
+### Task 1: `source-of` — store source text in metadata during definition
+
+**Files:**
+- Modify: `crates/sema-eval/src/special_forms.rs` (eval_defun, eval_define, eval_defmacro)
+- Modify: `crates/sema-eval/src/special_forms.rs` (eval_meta — add :source, :file, :line to output)
+- Test: `crates/sema/tests/integration_test.rs`
+
+**Context:** When `defn`/`define`/`defmacro` fire, they already have the original AST as `&[Value]` (the args). We reconstruct the source text by formatting the full definition form via `Value::Display`. The EvalContext has `current_file_path()` and we can get the line from the span table via `ctx.lookup_span()`.
+
+**Step 1: Write the failing test**
+
+Add to `crates/sema/tests/integration_test.rs`:
+
+```rust
+#[test]
+fn test_source_of_via_meta() {
+    // source-of should appear in (meta) output
+    let result = eval_to_string(
+        r#"(begin
+             (defn add "Add two numbers." (a b) (+ a b))
+             (get (meta add) :source))"#,
+    );
+    // The source should be the reconstructed defn form
+    assert!(result.contains("defn"));
+    assert!(result.contains("add"));
+    assert!(result.contains("Add two numbers."));
+}
+
+#[test]
+fn test_source_of_define_shorthand() {
+    let result = eval_to_string(
+        r#"(begin
+             (define (square x) "Square a number." (* x x))
+             (get (meta square) :source))"#,
+    );
+    assert!(result.contains("square"));
+    assert!(result.contains("Square a number."));
+}
+
+#[test]
+fn test_meta_includes_line() {
+    // :line should be populated (non-nil) when we can determine it
+    let result = eval_to_string(
+        r#"(begin
+             (defn f (x) x)
+             (get (meta f) :line))"#,
+    );
+    // Should be an integer, not nil
+    assert_ne!(result, "nil");
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p sema --test integration_test -- test_source_of_via_meta test_source_of_define_shorthand test_meta_includes_line`
+Expected: FAIL — `:source` not in metadata, `:line` is nil
+
+**Step 3: Implement source-of storage in eval_defun**
+
+In `eval_defun`, after `env.set_meta(name_spur, Value::keyword("doc"), ...)`, reconstruct and store the source:
+
+```rust
+// Reconstruct source text from the original AST
+let mut source_parts = vec![Value::symbol("defn"), Value::symbol(&resolve(name_spur))];
+if let Some(ref doc) = docstring {
+    source_parts.push(Value::string(doc));
+}
+source_parts.push(args[params_idx].clone()); // param list
+source_parts.extend_from_slice(&args[params_idx + 1..]); // body
+let source_form = Value::list(source_parts);
+env.set_meta(name_spur, Value::keyword("source"), Value::string(&source_form.to_string()));
+```
+
+Do the same in `eval_define` (function shorthand branch) and `eval_defmacro`.
+
+**Step 4: Add :line and :file metadata**
+
+In `eval_defun`, after source storage:
+
+```rust
+// Store file and line from EvalContext
+if let Some(file_path) = ctx.current_file_path() {
+    env.set_meta(name_spur, Value::keyword("file"), Value::string(&file_path.to_string_lossy()));
+}
+// Try to get line from the span table for the name symbol
+if let Some(span) = ctx.lookup_span(args[0].as_ptr()) {
+    env.set_meta(name_spur, Value::keyword("line"), Value::int(span.line as i64));
+}
+```
+
+Same for `eval_define` and `eval_defmacro`.
+
+**Step 5: Update eval_meta to include :source, :file, :line**
+
+In `eval_meta`, after populating the map from existing metadata, also add `:source`, `:file`, `:line` keys from metadata (they'll already be there from set_meta — we just need to make sure the meta map returns them, which it already does since `eval_meta` returns `env.get_meta(spur)` contents).
+
+Review `eval_meta` to confirm it already passes through all metadata keys — if it constructs the map manually, add the new keys.
+
+**Step 6: Add (source-of name) as a convenience special form**
+
+Add `source_of` to `SpecialFormSpurs`, `SpecialFormSpurs::init()`, `SPECIAL_FORM_NAMES`, and `try_eval_special()`. Implementation:
+
+```rust
+fn eval_source_of(args: &[Value], env: &Env) -> Result<Trampoline, SemaError> {
+    if args.len() != 1 {
+        return Err(SemaError::arity("source-of", "1", args.len()));
+    }
+    let spur = args[0]
+        .as_symbol_spur()
+        .ok_or_else(|| SemaError::type_error("symbol", args[0].type_name()))?;
+    let source = env
+        .get_meta(spur)
+        .and_then(|m| m.get(&Value::keyword("source")).cloned())
+        .unwrap_or_else(Value::nil);
+    Ok(Trampoline::Value(source))
+}
+```
+
+**Step 7: Run tests and verify they pass**
+
+Run: `cargo test -p sema --test integration_test -- test_source_of`
+Expected: PASS
+
+**Step 8: Commit**
+
+```bash
+git add crates/sema-eval/src/special_forms.rs crates/sema/tests/integration_test.rs
+git commit -m "feat: source-of — store and retrieve source text, file, line metadata"
+```
+
+---
+
+### Task 2: Directive comment parser in sema-reader
+
+**Files:**
+- Modify: `crates/sema-reader/src/reader.rs` (new public function)
+- Modify: `crates/sema-reader/src/lib.rs` (re-export)
+- Test: `crates/sema-reader/src/reader.rs` (unit tests in `#[cfg(test)]` mod)
+
+**Context:** The lexer already captures `Token::Comment(String)` with the full text including leading `;`. The parser's `skip_trivia()` discards them. We add a new `read_many_with_directives()` that collects `;;@key value` comments and associates them with the next top-level form.
+
+**Step 1: Define the Directive type and write failing tests**
+
+Add to reader.rs tests:
+
+```rust
+#[test]
+fn test_read_directives_basic() {
+    let input = r#";;@since 1.8.0
+;;@deprecated Use bar instead
+(defn foo (x) x)"#;
+    let (exprs, _, directives) = read_many_with_directives(input).unwrap();
+    assert_eq!(exprs.len(), 1);
+    assert_eq!(directives.len(), 1);
+    assert_eq!(directives[0].0, 0); // associated with form index 0
+    assert_eq!(directives[0].1.get("since").unwrap(), "1.8.0");
+    assert_eq!(directives[0].1.get("deprecated").unwrap(), "Use bar instead");
+}
+
+#[test]
+fn test_read_directives_multiple_forms() {
+    let input = r#";;@since 1.0.0
+(defn a () 1)
+
+;;@since 2.0.0
+;;@tags math
+(defn b () 2)
+
+(defn c () 3)"#;
+    let (exprs, _, directives) = read_many_with_directives(input).unwrap();
+    assert_eq!(exprs.len(), 3);
+    assert_eq!(directives.len(), 2);
+    assert_eq!(directives[0].0, 0);
+    assert_eq!(directives[1].0, 1);
+    assert_eq!(directives[1].1.get("tags").unwrap(), "math");
+}
+
+#[test]
+fn test_read_directives_none() {
+    let input = "(+ 1 2)";
+    let (exprs, _, directives) = read_many_with_directives(input).unwrap();
+    assert_eq!(exprs.len(), 1);
+    assert!(directives.is_empty());
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p sema-reader -- test_read_directives`
+Expected: FAIL — function doesn't exist
+
+**Step 3: Implement `read_many_with_directives`**
+
+Add to `reader.rs`:
+
+```rust
+/// Read all s-expressions, returning spans and directive comments.
+///
+/// Directive comments are lines starting with `;;@key value`.
+/// Returns a vec of (form_index, BTreeMap<key, value>) pairs.
+pub fn read_many_with_directives(
+    input: &str,
+) -> Result<(Vec<Value>, SpanMap, Vec<(usize, std::collections::BTreeMap<String, String>)>), SemaError> {
+    let tokens = tokenize(input)?;
+    let mut parser = Parser::new(tokens);
+    let mut exprs = Vec::new();
+    let mut all_directives: Vec<(usize, std::collections::BTreeMap<String, String>)> = Vec::new();
+    let mut pending_directives: std::collections::BTreeMap<String, String> = std::collections::BTreeMap::new();
+
+    loop {
+        // Manually handle trivia to capture directive comments
+        while let Some(t) = parser.tokens.get(parser.pos) {
+            match &t.token {
+                Token::Comment(text) => {
+                    if let Some(directive) = text.strip_prefix(";;@") {
+                        let directive = directive.trim();
+                        if let Some((key, value)) = directive.split_once(' ') {
+                            pending_directives.insert(key.to_string(), value.trim().to_string());
+                        } else {
+                            pending_directives.insert(directive.to_string(), String::new());
+                        }
+                    }
+                    parser.pos += 1;
+                }
+                Token::Newline => {
+                    parser.pos += 1;
+                }
+                _ => break,
+            }
+        }
+        if parser.peek().is_none() {
+            break;
+        }
+        let form_index = exprs.len();
+        exprs.push(parser.parse_expr()?);
+        if !pending_directives.is_empty() {
+            all_directives.push((form_index, std::mem::take(&mut pending_directives)));
+        }
+    }
+
+    Ok((exprs, parser.span_map, all_directives))
+}
+```
+
+**Step 4: Re-export from lib.rs**
+
+Add to `crates/sema-reader/src/lib.rs`:
+```rust
+pub use reader::read_many_with_directives;
+```
+
+**Step 5: Run tests and verify they pass**
+
+Run: `cargo test -p sema-reader -- test_read_directives`
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+git add crates/sema-reader/src/reader.rs crates/sema-reader/src/lib.rs
+git commit -m "feat: directive comment parser (;;@key value) in sema-reader"
+```
+
+---
+
+### Task 3: `read-source` stdlib function
+
+**Files:**
+- Modify: `crates/sema-stdlib/src/io.rs` (add read-source function)
+- Test: `crates/sema/tests/integration_test.rs`
+
+**Context:** `read-source` is a stdlib function (not a special form) because it operates on files, not the calling env. It reads a `.sema` file, parses it with the directive-aware reader, and returns a list of maps describing each top-level definition.
+
+**Step 1: Write failing tests**
+
+Add to `integration_test.rs`:
+
+```rust
+#[test]
+fn test_read_source_basic() {
+    // Write a temp file, then read-source it
+    let result = eval_to_string(
+        r#"(begin
+             (file/write "/tmp/sema-test-read-source.sema"
+               "(defn greet \"Say hello.\" (name) (string-append \"Hello, \" name))\n(define x 42)")
+             (let ((defs (read-source "/tmp/sema-test-read-source.sema")))
+               (length defs)))"#,
+    );
+    assert_eq!(result, "2");
+}
+
+#[test]
+fn test_read_source_defn_structure() {
+    let result = eval_to_string(
+        r#"(begin
+             (file/write "/tmp/sema-test-rs2.sema"
+               "(defn add \"Add two numbers.\" (a b) (+ a b))")
+             (let ((defs (read-source "/tmp/sema-test-rs2.sema")))
+               (let ((d (first defs)))
+                 (list (get d :type) (get d :name) (get d :doc)))))"#,
+    );
+    assert_eq!(result, "(:defn \"add\" \"Add two numbers.\")");
+}
+
+#[test]
+fn test_read_source_with_directives() {
+    let result = eval_to_string(
+        r#"(begin
+             (file/write "/tmp/sema-test-rs3.sema"
+               ";;@since 1.0.0\n;;@deprecated Use bar\n(defn foo (x) x)")
+             (let ((defs (read-source "/tmp/sema-test-rs3.sema")))
+               (let ((d (first defs)))
+                 (get-in d [:directives :since]))))"#,
+    );
+    assert_eq!(result, "\"1.0.0\"");
+}
+
+#[test]
+fn test_read_source_non_defn() {
+    // Non-definition top-level forms should still appear with :type :expr
+    let result = eval_to_string(
+        r#"(begin
+             (file/write "/tmp/sema-test-rs4.sema" "(println \"hello\")")
+             (let ((defs (read-source "/tmp/sema-test-rs4.sema")))
+               (get (first defs) :type)))"#,
+    );
+    assert_eq!(result, ":expr");
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p sema --test integration_test -- test_read_source`
+Expected: FAIL — function doesn't exist
+
+**Step 3: Implement `read-source` in io.rs**
+
+Add to `crates/sema-stdlib/src/io.rs` inside `pub fn register(env, sandbox)`:
+
+```rust
+crate::register_fn_path_gated(env, sandbox, Caps::FS_READ, "read-source", &[0], |args| {
+    check_arity!(args, "read-source", 1);
+    let path_str = args[0]
+        .as_str()
+        .ok_or_else(|| SemaError::type_error("string", args[0].type_name()))?;
+
+    let paths = if path_str.contains('*') {
+        glob::glob(path_str)
+            .map_err(|e| SemaError::eval(format!("read-source: invalid glob: {e}")))?
+            .filter_map(|r| r.ok())
+            .map(|p| p.to_string_lossy().to_string())
+            .collect::<Vec<_>>()
+    } else {
+        vec![path_str.to_string()]
+    };
+
+    let mut all_defs = Vec::new();
+    for path in &paths {
+        let content = std::fs::read_to_string(path)
+            .map_err(|e| SemaError::Io(format!("read-source {path}: {e}")))?;
+        let (exprs, _spans, directives) = sema_reader::read_many_with_directives(&content)?;
+
+        // Build directive lookup: form_index -> BTreeMap
+        let mut dir_map: std::collections::HashMap<usize, &std::collections::BTreeMap<String, String>> =
+            std::collections::HashMap::new();
+        for (idx, dirs) in &directives {
+            dir_map.insert(*idx, dirs);
+        }
+
+        // Track line numbers from source
+        let lines: Vec<&str> = content.lines().collect();
+
+        for (i, expr) in exprs.iter().enumerate() {
+            let mut entry = std::collections::BTreeMap::new();
+            let source_text = expr.to_string();
+
+            // Determine the type and extract structure
+            if let Some(list) = expr.as_list() {
+                if let Some(head) = list.first().and_then(|v| v.as_symbol()) {
+                    match head.as_str() {
+                        "defn" | "defun" if list.len() >= 4 => {
+                            let name = list.get(1).map(|v| v.to_string()).unwrap_or_default();
+                            entry.insert(Value::keyword("type"), Value::keyword("defn"));
+                            entry.insert(Value::keyword("name"), Value::string(&name));
+
+                            // Check for docstring
+                            let (doc, params_idx) = if list.get(2).and_then(|v| v.as_str()).is_some() {
+                                (list[2].as_str().map(|s| s.to_string()), 3)
+                            } else {
+                                (None, 2)
+                            };
+                            if let Some(d) = &doc {
+                                entry.insert(Value::keyword("doc"), Value::string(d));
+                            }
+                            if let Some(params) = list.get(params_idx) {
+                                entry.insert(Value::keyword("params"), params.clone());
+                            }
+                            if list.len() > params_idx + 1 {
+                                entry.insert(
+                                    Value::keyword("body"),
+                                    Value::list(list[params_idx + 1..].to_vec()),
+                                );
+                            }
+                        }
+                        "define" if list.len() >= 3 => {
+                            // (define (f x) body) or (define x val)
+                            if let Some(sig) = list.get(1).and_then(|v| v.as_list()) {
+                                let name = sig.first().map(|v| v.to_string()).unwrap_or_default();
+                                entry.insert(Value::keyword("type"), Value::keyword("defn"));
+                                entry.insert(Value::keyword("name"), Value::string(&name));
+                                entry.insert(Value::keyword("params"), Value::list(sig[1..].to_vec()));
+                                // Check for docstring
+                                let body_start = if list.get(2).and_then(|v| v.as_str()).is_some() {
+                                    if let Some(d) = list[2].as_str() {
+                                        entry.insert(Value::keyword("doc"), Value::string(d));
+                                    }
+                                    3
+                                } else {
+                                    2
+                                };
+                                entry.insert(
+                                    Value::keyword("body"),
+                                    Value::list(list[body_start..].to_vec()),
+                                );
+                            } else {
+                                let name = list.get(1).map(|v| v.to_string()).unwrap_or_default();
+                                entry.insert(Value::keyword("type"), Value::keyword("define"));
+                                entry.insert(Value::keyword("name"), Value::string(&name));
+                            }
+                        }
+                        "defmacro" if list.len() >= 4 => {
+                            let name = list.get(1).map(|v| v.to_string()).unwrap_or_default();
+                            entry.insert(Value::keyword("type"), Value::keyword("defmacro"));
+                            entry.insert(Value::keyword("name"), Value::string(&name));
+                            let (doc, params_idx) = if list.get(2).and_then(|v| v.as_str()).is_some() {
+                                (list[2].as_str().map(|s| s.to_string()), 3)
+                            } else {
+                                (None, 2)
+                            };
+                            if let Some(d) = &doc {
+                                entry.insert(Value::keyword("doc"), Value::string(d));
+                            }
+                            if let Some(params) = list.get(params_idx) {
+                                entry.insert(Value::keyword("params"), params.clone());
+                            }
+                        }
+                        _ => {
+                            entry.insert(Value::keyword("type"), Value::keyword("expr"));
+                        }
+                    }
+                } else {
+                    entry.insert(Value::keyword("type"), Value::keyword("expr"));
+                }
+            } else {
+                entry.insert(Value::keyword("type"), Value::keyword("expr"));
+            }
+
+            entry.insert(Value::keyword("source"), Value::string(&source_text));
+            entry.insert(Value::keyword("file"), Value::string(path));
+
+            // Try to find line number by matching source text in file
+            // (approximate — find first line containing the start of the form)
+            let source_start = source_text.chars().take(40).collect::<String>();
+            let line_num = lines.iter().position(|l| l.contains(&source_start))
+                .map(|n| (n + 1) as i64)
+                .unwrap_or(0);
+            if line_num > 0 {
+                entry.insert(Value::keyword("line"), Value::int(line_num));
+            }
+
+            // Attach directives if any
+            if let Some(dirs) = dir_map.get(&i) {
+                let mut dir_entries = std::collections::BTreeMap::new();
+                for (k, v) in *dirs {
+                    dir_entries.insert(
+                        Value::keyword(k),
+                        Value::string(v),
+                    );
+                }
+                entry.insert(Value::keyword("directives"), Value::map(dir_entries));
+            }
+
+            all_defs.push(Value::map(entry));
+        }
+    }
+
+    Ok(Value::list(all_defs))
+});
+```
+
+**Step 4: Run tests**
+
+Run: `cargo test -p sema --test integration_test -- test_read_source`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/sema-stdlib/src/io.rs crates/sema/tests/integration_test.rs
+git commit -m "feat: read-source stdlib function with directive and glob support"
+```
+
+---
+
+### Task 4: Helper functions — defs-in, undocumented-in
+
+**Files:**
+- Modify: `crates/sema-stdlib/src/io.rs`
+- Test: `crates/sema/tests/integration_test.rs`
+
+**Context:** These are simple wrappers around `read-source` but implemented as native fns for convenience.
+
+**Step 1: Write failing tests**
+
+```rust
+#[test]
+fn test_defs_in() {
+    let result = eval_to_string(
+        r#"(begin
+             (file/write "/tmp/sema-test-defs.sema"
+               "(defn a () 1)\n(defn b () 2)\n(define x 42)")
+             (defs-in "/tmp/sema-test-defs.sema"))"#,
+    );
+    assert!(result.contains("a"));
+    assert!(result.contains("b"));
+    assert!(result.contains("x"));
+}
+
+#[test]
+fn test_undocumented_in() {
+    let result = eval_to_string(
+        r#"(begin
+             (file/write "/tmp/sema-test-undoc.sema"
+               "(defn a \"Documented.\" () 1)\n(defn b () 2)")
+             (undocumented-in "/tmp/sema-test-undoc.sema"))"#,
+    );
+    assert!(!result.contains("a"));
+    assert!(result.contains("b"));
+}
+```
+
+**Step 2: Implement**
+
+These can be simple prelude macros in `crates/sema-eval/src/prelude.rs`, or native fns. Prelude is simplest:
+
+```lisp
+(define (defs-in path)
+  (map (fn (d) (get d :name)) (read-source path)))
+
+(define (undocumented-in path)
+  (map (fn (d) (get d :name))
+    (filter (fn (d) (nil? (get d :doc))) (read-source path))))
+```
+
+Alternatively, implement as native fns calling read-source internally. Prelude approach is recommended (dogfooding).
+
+**Step 3: Run tests**
+
+Run: `cargo test -p sema --test integration_test -- test_defs_in test_undocumented_in`
+
+**Step 4: Commit**
+
+```bash
+git add crates/sema-eval/src/prelude.rs crates/sema/tests/integration_test.rs
+git commit -m "feat: defs-in and undocumented-in prelude helpers"
+```
+
+---
+
+### Task 5: Verification and cleanup
+
+**Step 1: Run full test suite**
+
+```bash
+cargo test
+```
+
+**Step 2: Run lint**
+
+```bash
+make lint
+```
+
+**Step 3: Verify the example file works end-to-end**
+
+Create/update `examples/read-source-demo.sema`:
+
+```lisp
+;; Demo: self-reading capabilities
+
+;;@since 1.12.0
+;;@tags introspection, demo
+(defn greet
+  "Greet someone by name.
+   >>> (greet \"World\")
+   \"Hello, World!\""
+  (name)
+  (string-append "Hello, " name "!"))
+
+(defn add
+  "Add two numbers.
+   >>> (add 1 2)
+   3"
+  (a b)
+  (+ a b))
+
+;; Self-analysis
+(println "=== Source introspection ===")
+(println (source-of greet))
+
+(println "\n=== Read-source analysis ===")
+(let ((defs (read-source "examples/read-source-demo.sema")))
+  (each (fn (d)
+          (println f"${(get d :type)} ${(get d :name)}: ${(or (get d :doc) \"(no doc)\")}"))
+        defs))
+```
+
+Run: `cargo run -- examples/read-source-demo.sema`
+
+**Step 4: Final commit**
+
+```bash
+git add examples/read-source-demo.sema
+git commit -m "feat: Living Code Phase 2 — self-reading capabilities"
+```
+
+---
+
+## Dependency Graph
+
+```
+Task 1 (source-of) ──────┐
+                          ├──→ Task 3 (read-source) ──→ Task 4 (helpers) ──→ Task 5 (verify)
+Task 2 (directives) ─────┘
+```
+
+Tasks 1 and 2 are independent and can be done in parallel.
+Task 3 depends on Task 2 (directive parser).
+Task 4 depends on Task 3.
+Task 5 depends on all.

--- a/docs/plans/2026-02-24-living-code-phase3.md
+++ b/docs/plans/2026-02-24-living-code-phase3.md
@@ -1,0 +1,37 @@
+# Living Code Phase 3: LLM-Powered Introspection — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Enable Sema programs to ask questions about their own code and self-repair failing doctests using LLM integration.
+
+**Architecture:** `ask`, `ask/code`, and `heal!` are special forms in sema-eval. They gather context from env metadata (Phase 1+2), build prompts, and call `llm/complete` by looking it up in the env and invoking via `sema_core::call_callback`. No sema-llm dependency needed — the LLM call goes through the env binding.
+
+**Tech Stack:** Existing sema-eval special forms, sema-core callback system, sema-reader for parsing LLM responses.
+
+---
+
+### Task 1: `(ask target question)` — conversational introspection
+
+Special form that takes a symbol (or string path, or value) and a question string. Gathers context, calls LLM, returns the answer as a string.
+
+### Task 2: `(ask/code target instruction)` — code generation
+
+Like `ask` but system prompt requests ONLY valid Sema code. Parses the response with `sema_reader::read` and returns a Value (executable code).
+
+### Task 3: `(heal! fn)` — auto-repair via doctests
+
+Special form that runs doctests on a function, and if any fail, enters a healing loop: builds a prompt with source + failure info, calls LLM for a fix, parses and evals the candidate in a sandbox, runs doctests against it, and if all pass, replaces the definition.
+
+### Task 4: `sema test --heal` CLI flag
+
+Extends the existing `sema test` command to attempt healing on functions with failing doctests.
+
+---
+
+## Dependency Graph
+
+```
+Task 1 (ask) ──→ Task 2 (ask/code) ──→ Task 3 (heal!) ──→ Task 4 (CLI --heal)
+```
+
+All sequential — each builds on the previous.

--- a/docs/plans/2026-02-24-living-code-phase5.md
+++ b/docs/plans/2026-02-24-living-code-phase5.md
@@ -1,0 +1,835 @@
+# Living Code Phase 5: `evolve` — LLM-Driven Genetic Programming
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Implement `(evolve ...)` — a special form that generates a population of candidate function implementations via LLM, tests them against a spec, and iteratively breeds/mutates the best ones to produce an optimized solution.
+
+**Architecture:** `evolve` is a special form in `sema-eval` because it needs env/ctx for sandbox eval, LLM calls, and fitness callbacks. The evolution logic lives in a new `crates/sema-eval/src/evolve.rs` module. Spec can be either a quoted list of `(>>> expr expected)` forms (inline spec) or a symbol whose docstring contains doctests (symbol spec). The evolution loop is: seed population via LLM -> evaluate in sandbox -> compute fitness -> tournament select -> crossover/mutate via LLM -> repeat.
+
+**Tech Stack:** Rust, sema-eval (special form + evolve module), sema-core (Env, Value), sema-reader (parse LLM responses). Tests: tree-walker only in `integration_test.rs`.
+
+**Worktree:** `/Users/helge/code/sema-lisp/.worktrees/living-code` (branch `feature/living-code`)
+
+---
+
+## Conventions Reference
+
+- Special forms: Spur field in `SpecialFormSpurs`, `intern()` in `init()`, string in `SPECIAL_FORM_NAMES`, dispatch in `try_eval_special()`, handler fn.
+- `call_llm_complete(env, ctx, prompt, system)` — helper in special_forms.rs, looks up `llm/complete` from env.
+- `sema_reader::read(code)` — parse string to Value. `sema_reader::read_many(code)` — parse to Vec<Value>.
+- `eval::eval_value(ctx, &expr, &env)` — evaluate expression. `eval::eval_string(ctx, input, &env)` — parse+eval string.
+- `Env::with_parent(Rc::new(env.clone()))` — sandbox child env.
+- `sema_core::call_callback(ctx, &func, &[args])` — call a Sema function value from Rust.
+- Keyword args in special forms: iterate raw `args` in pairs, check `as_keyword()` on odd positions, `eval::eval_value()` on even positions.
+- Existing doctest runner: `crate::doctest::run_doctests(docstring, &mut eval_fn)` returns `Vec<DocTestResult>`.
+- Code fence stripping pattern (from ask/code): strip ```` ```lisp ````, ```` ``` ```` prefixes/suffixes from LLM responses.
+- Tests: `Interpreter::new()` + `interp.eval_str(...)`. LLM-dependent tests can't run in CI — test the non-LLM parts (spec parsing, config parsing, fitness computation).
+
+---
+
+### Task 1: Create `evolve.rs` module with config parsing
+
+**Files:**
+- Create: `.worktrees/living-code/crates/sema-eval/src/evolve.rs`
+- Modify: `.worktrees/living-code/crates/sema-eval/src/lib.rs`
+
+**Step 1: Create the module file with config and spec types**
+
+Create `crates/sema-eval/src/evolve.rs`:
+
+```rust
+//! LLM-driven genetic programming: `(evolve ...)` implementation.
+
+use std::collections::BTreeMap;
+use std::rc::Rc;
+
+use sema_core::{call_callback, intern, resolve, Env, EvalContext, SemaError, Spur, Value};
+
+use crate::eval;
+
+/// Configuration parsed from `(evolve :name "..." :spec ... ...)` keyword args.
+pub struct EvolveConfig {
+    pub name: Spur,
+    pub name_str: String,
+    pub spec: Spec,
+    pub population: usize,
+    pub generations: usize,
+    pub fitness_fn: Value,
+    pub seed_prompt: String,
+    pub verbose: bool,
+    pub max_attempts: usize,
+}
+
+/// The specification: either inline `(>>> expr expected)` forms or a docstring reference.
+pub enum Spec {
+    /// Inline: list of (>>> expr expected) forms, stored as (input_source, expected_source) pairs.
+    Inline(Vec<SpecCase>),
+    /// Symbol reference: use the docstring's doctests.
+    Docstring(String),
+}
+
+/// A single spec case from inline `(>>> expr expected)`.
+pub struct SpecCase {
+    pub input: String,
+    pub expected: String,
+}
+
+/// A candidate in the population.
+pub struct Candidate {
+    pub source: String,
+    pub fn_value: Option<Value>,
+    pub fitness: f64,
+    pub spec_passed: usize,
+    pub spec_total: usize,
+    pub time_ms: f64,
+    pub error: Option<String>,
+}
+
+/// Parse keyword args from the special form into an EvolveConfig.
+pub fn parse_config(
+    args: &[Value],
+    env: &Env,
+    ctx: &EvalContext,
+) -> Result<EvolveConfig, SemaError> {
+    let mut name: Option<String> = None;
+    let mut spec: Option<Spec> = None;
+    let mut population: usize = 10;
+    let mut generations: usize = 5;
+    let mut fitness_fn: Option<Value> = None;
+    let mut seed_prompt: Option<String> = None;
+    let mut verbose = false;
+    let mut max_attempts: usize = 3;
+
+    let mut i = 0;
+    while i < args.len() {
+        let kw = args[i]
+            .as_keyword()
+            .ok_or_else(|| SemaError::eval(format!("evolve: expected keyword, got {}", args[i])))?;
+        if i + 1 >= args.len() {
+            return Err(SemaError::eval(format!("evolve: missing value for :{kw}")));
+        }
+        let val = eval::eval_value(ctx, &args[i + 1], env)?;
+
+        match kw.as_str() {
+            "name" => {
+                name = Some(
+                    val.as_str()
+                        .ok_or_else(|| SemaError::type_error("string", val.type_name()))?
+                        .to_string(),
+                );
+            }
+            "spec" => {
+                spec = Some(parse_spec(&val, env)?);
+            }
+            "population" => {
+                population = val
+                    .as_int()
+                    .ok_or_else(|| SemaError::type_error("integer", val.type_name()))?
+                    as usize;
+            }
+            "generations" => {
+                generations = val
+                    .as_int()
+                    .ok_or_else(|| SemaError::type_error("integer", val.type_name()))?
+                    as usize;
+            }
+            "fitness" => {
+                fitness_fn = Some(val);
+            }
+            "seed-prompt" => {
+                seed_prompt = Some(
+                    val.as_str()
+                        .ok_or_else(|| SemaError::type_error("string", val.type_name()))?
+                        .to_string(),
+                );
+            }
+            "verbose" => {
+                verbose = val.is_truthy();
+            }
+            "max-attempts" => {
+                max_attempts = val
+                    .as_int()
+                    .ok_or_else(|| SemaError::type_error("integer", val.type_name()))?
+                    as usize;
+            }
+            other => {
+                return Err(SemaError::eval(format!("evolve: unknown option :{other}"))
+                    .with_hint("Valid options: :name :spec :population :generations :fitness :seed-prompt :verbose :max-attempts"));
+            }
+        }
+        i += 2;
+    }
+
+    let name_str = name.ok_or_else(|| SemaError::eval("evolve: :name is required"))?;
+    let name_spur = intern(&name_str);
+
+    Ok(EvolveConfig {
+        name: name_spur,
+        name_str,
+        spec: spec.ok_or_else(|| SemaError::eval("evolve: :spec is required"))?,
+        population,
+        generations,
+        fitness_fn: fitness_fn
+            .ok_or_else(|| SemaError::eval("evolve: :fitness is required"))?,
+        seed_prompt: seed_prompt
+            .ok_or_else(|| SemaError::eval("evolve: :seed-prompt is required"))?,
+        verbose,
+        max_attempts,
+    })
+}
+
+/// Parse the :spec value into a Spec enum.
+fn parse_spec(val: &Value, env: &Env) -> Result<Spec, SemaError> {
+    // If it's a list, treat as inline spec: ((>>> expr expected) ...)
+    if let Some(items) = val.as_list() {
+        let mut cases = Vec::new();
+        for item in items {
+            let form = item
+                .as_list()
+                .ok_or_else(|| SemaError::eval("evolve: each spec case must be a list"))?;
+            if form.len() != 3 {
+                return Err(SemaError::eval(
+                    "evolve: spec case must be (>>> expr expected)",
+                ));
+            }
+            let marker = form[0]
+                .as_symbol()
+                .ok_or_else(|| SemaError::eval("evolve: spec case must start with >>>"))?;
+            if marker != ">>>" {
+                return Err(SemaError::eval(format!(
+                    "evolve: spec case must start with >>>, got {marker}"
+                )));
+            }
+            cases.push(SpecCase {
+                input: form[1].to_string(),
+                expected: form[2].to_string(),
+            });
+        }
+        if cases.is_empty() {
+            return Err(SemaError::eval("evolve: :spec list is empty"));
+        }
+        Ok(Spec::Inline(cases))
+    } else if val.as_lambda_rc().is_some() || val.as_native_fn_rc().is_some() {
+        // It's a function — extract its docstring
+        if let Some(lambda) = val.as_lambda_rc() {
+            if let Some(name_spur) = lambda.name {
+                if let Some(meta) = env.get_meta(name_spur) {
+                    if let Some(doc) = meta.get(&Value::keyword("doc")) {
+                        if let Some(s) = doc.as_str() {
+                            let doctests = crate::doctest::parse_doctests(s);
+                            if doctests.is_empty() {
+                                return Err(SemaError::eval(
+                                    "evolve: function has no doctests in its docstring",
+                                )
+                                .with_hint("Add >>> examples to the docstring"));
+                            }
+                            return Ok(Spec::Docstring(s.to_string()));
+                        }
+                    }
+                }
+                return Err(SemaError::eval(format!(
+                    "evolve: function '{}' has no docstring",
+                    resolve(name_spur)
+                )));
+            }
+        }
+        Err(SemaError::eval("evolve: :spec function must be a named function with doctests"))
+    } else {
+        Err(SemaError::type_error(
+            "list of (>>> ...) forms or a function with doctests",
+            val.type_name(),
+        ))
+    }
+}
+
+/// Run spec cases against a candidate function in a sandbox env.
+/// Returns (passed, total, time_ms).
+pub fn run_spec(
+    config: &EvolveConfig,
+    ctx: &EvalContext,
+    sandbox_env: &Env,
+) -> (usize, usize, f64) {
+    match &config.spec {
+        Spec::Inline(cases) => {
+            let start = std::time::Instant::now();
+            let mut passed = 0;
+            let total = cases.len();
+            for case in cases {
+                match eval::eval_string(ctx, &case.input, sandbox_env) {
+                    Ok(result) => {
+                        let actual = result.to_string();
+                        if actual.trim() == case.expected.trim() {
+                            passed += 1;
+                        }
+                    }
+                    Err(_) => {}
+                }
+            }
+            let time_ms = start.elapsed().as_secs_f64() * 1000.0;
+            (passed, total, time_ms)
+        }
+        Spec::Docstring(docstring) => {
+            let start = std::time::Instant::now();
+            let results = crate::doctest::run_doctests(docstring, &mut |input| {
+                eval::eval_string(ctx, input, sandbox_env)
+            });
+            let time_ms = start.elapsed().as_secs_f64() * 1000.0;
+            let passed = results.iter().filter(|r| r.passed).count();
+            let total = results.len();
+            (passed, total, time_ms)
+        }
+    }
+}
+
+/// Compute fitness by calling the user's fitness function.
+pub fn compute_fitness(
+    fitness_fn: &Value,
+    candidate_fn: &Value,
+    passed: usize,
+    total: usize,
+    time_ms: f64,
+    ctx: &EvalContext,
+) -> f64 {
+    let mut spec_results = BTreeMap::new();
+    spec_results.insert(Value::keyword("passed"), Value::int(passed as i64));
+    spec_results.insert(Value::keyword("total"), Value::int(total as i64));
+    spec_results.insert(Value::keyword("time-ms"), Value::float(time_ms));
+
+    match call_callback(ctx, fitness_fn, &[candidate_fn.clone(), Value::map(spec_results)]) {
+        Ok(val) => val.as_float().or_else(|| val.as_int().map(|i| i as f64)).unwrap_or(0.0),
+        Err(_) => 0.0,
+    }
+}
+
+/// Strip code fences from LLM response.
+pub fn strip_code_fences(response: &str) -> &str {
+    let trimmed = response.trim();
+    let stripped = trimmed
+        .strip_prefix("```lisp")
+        .or_else(|| trimmed.strip_prefix("```sema"))
+        .or_else(|| trimmed.strip_prefix("```"))
+        .unwrap_or(trimmed);
+    stripped.strip_suffix("```").unwrap_or(stripped).trim()
+}
+```
+
+**Step 2: Register the module in lib.rs**
+
+Add `pub mod evolve;` to `crates/sema-eval/src/lib.rs`.
+
+**Step 3: Verify it compiles**
+
+Run: `cargo build -p sema-eval`
+Expected: compiles.
+
+**Step 4: Commit**
+
+```bash
+git add crates/sema-eval/src/evolve.rs crates/sema-eval/src/lib.rs
+git commit -m "feat: add evolve module with config parsing, spec runner, and fitness computation"
+```
+
+---
+
+### Task 2: Write tests for config parsing and spec runner
+
+**Files:**
+- Modify: `.worktrees/living-code/crates/sema/tests/integration_test.rs`
+
+**Step 1: Add tests**
+
+```rust
+// ── evolve tests ─────────────────────────────────────────────────
+
+#[test]
+fn test_evolve_missing_name() {
+    let interp = Interpreter::new();
+    let result = interp.eval_str(
+        r#"(evolve :spec '((>>> (+ 1 2) 3)) :fitness (fn (f r) 1) :seed-prompt "test")"#,
+    );
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains(":name"));
+}
+
+#[test]
+fn test_evolve_missing_spec() {
+    let interp = Interpreter::new();
+    let result = interp.eval_str(
+        r#"(evolve :name "test" :fitness (fn (f r) 1) :seed-prompt "test")"#,
+    );
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains(":spec"));
+}
+
+#[test]
+fn test_evolve_missing_fitness() {
+    let interp = Interpreter::new();
+    let result = interp.eval_str(
+        r#"(evolve :name "test" :spec '((>>> (+ 1 2) 3)) :seed-prompt "test")"#,
+    );
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains(":fitness"));
+}
+
+#[test]
+fn test_evolve_missing_seed_prompt() {
+    let interp = Interpreter::new();
+    let result = interp.eval_str(
+        r#"(evolve :name "test" :spec '((>>> (+ 1 2) 3)) :fitness (fn (f r) 1))"#,
+    );
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains(":seed-prompt"));
+}
+
+#[test]
+fn test_evolve_unknown_option() {
+    let interp = Interpreter::new();
+    let result = interp.eval_str(
+        r#"(evolve :name "t" :spec '((>>> 1 1)) :fitness (fn (f r) 1) :seed-prompt "t" :bogus 1)"#,
+    );
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("bogus"));
+}
+
+#[test]
+fn test_evolve_spec_from_docstring() {
+    // :spec can be a function with doctests
+    let interp = Interpreter::new();
+    let result = interp.eval_str(
+        r#"(begin
+            (defn my-add "Adds.
+               >>> (my-add 1 2)
+               3" (a b) (+ a b))
+            (evolve :name "my-add"
+                    :spec my-add
+                    :fitness (fn (f r) 1)
+                    :seed-prompt "test"
+                    :generations 0
+                    :population 0))"#,
+    );
+    // With 0 generations and 0 population, it should return nil or the best (none)
+    // At minimum it should NOT error on config parsing
+    // It will error on "no candidates" which is fine — config parsed OK
+    let is_config_error = result
+        .as_ref()
+        .err()
+        .map(|e| {
+            let s = e.to_string();
+            s.contains(":name") || s.contains(":spec") || s.contains(":fitness") || s.contains(":seed-prompt")
+        })
+        .unwrap_or(false);
+    assert!(!is_config_error, "Should not be a config parsing error");
+}
+```
+
+**Step 2: Run tests (they will fail because `evolve` special form isn't wired yet)**
+
+Run: `cargo test -p sema-lang --test integration_test -- test_evolve`
+Expected: FAIL (evolve not recognized as special form)
+
+**Step 3: Commit tests**
+
+```bash
+git add crates/sema/tests/integration_test.rs
+git commit -m "test: add evolve config parsing tests"
+```
+
+---
+
+### Task 3: Wire up `evolve` special form and implement the evolution loop
+
+**Files:**
+- Modify: `.worktrees/living-code/crates/sema-eval/src/special_forms.rs`
+
+**Step 1: Add Spur and dispatch**
+
+In `SpecialFormSpurs` struct, in the `// Runtime self-modification` section, add:
+
+```rust
+    evolve: Spur,
+```
+
+In `init()`, in the same section:
+
+```rust
+    evolve: intern("evolve"),
+```
+
+In `SPECIAL_FORM_NAMES`, in the same section:
+
+```rust
+    "evolve",
+```
+
+In `try_eval_special()`, add a dispatch branch before the `} else { None }`:
+
+```rust
+    } else if head_spur == sf.evolve {
+        Some(eval_evolve(args, env, ctx))
+```
+
+**Step 2: Implement `eval_evolve`**
+
+Add before the `parse_params` function:
+
+```rust
+/// (evolve :name "..." :spec ... :fitness fn :seed-prompt "..." ...)
+/// LLM-driven genetic programming.
+fn eval_evolve(args: &[Value], env: &Env, ctx: &EvalContext) -> Result<Trampoline, SemaError> {
+    let config = crate::evolve::parse_config(args, env, ctx)?;
+
+    let system_prompt = "You are writing Sema (a Lisp dialect). Write a function that satisfies \
+                         the given specification. Return ONLY a (fn (params...) body...) expression. \
+                         No markdown, no explanation, no code fences. Just the Sema expression.";
+
+    let crossover_system = "You are writing Sema (a Lisp dialect). You are given two functions that \
+                            solve the same problem. Create a new function that combines the best ideas \
+                            from both. Return ONLY a (fn ...) expression. No markdown, no explanation.";
+
+    let mutate_system = "You are writing Sema (a Lisp dialect). Modify this function to be \
+                         faster or better while still passing all tests. Return ONLY a (fn ...) \
+                         expression. No markdown, no explanation.";
+
+    // Build spec description for prompts
+    let spec_description = match &config.spec {
+        crate::evolve::Spec::Inline(cases) => {
+            let mut desc = String::new();
+            for case in cases {
+                desc.push_str(&format!("  ({}) should return {}\n", case.input, case.expected));
+            }
+            desc
+        }
+        crate::evolve::Spec::Docstring(ds) => {
+            let mut desc = String::new();
+            for test in crate::doctest::parse_doctests(ds) {
+                match &test.expected {
+                    crate::doctest::Expected::Value(v) => {
+                        desc.push_str(&format!("  ({}) should return {}\n", test.input, v));
+                    }
+                    crate::doctest::Expected::Error(e) => {
+                        desc.push_str(&format!("  ({}) should error with: {}\n", test.input, e));
+                    }
+                    crate::doctest::Expected::Skip => {
+                        desc.push_str(&format!("  ({}) — setup step\n", test.input));
+                    }
+                }
+            }
+            desc
+        }
+    };
+
+    let fn_name = &config.name_str;
+
+    // Generation 0: seed population via LLM
+    let mut population: Vec<crate::evolve::Candidate> = Vec::new();
+
+    if config.verbose {
+        eprintln!("evolve: seeding {} candidates for '{fn_name}'...", config.population);
+    }
+
+    for slot in 0..config.population {
+        let prompt = format!(
+            "{}\n\nThe function will be bound as '{fn_name}'. Specification:\n{spec_description}\n\
+             Write a (fn ...) expression that satisfies all the above.",
+            config.seed_prompt
+        );
+        let candidate = generate_candidate(
+            env, ctx, &config, &prompt, system_prompt, slot,
+        );
+        population.push(candidate);
+    }
+
+    // Log generation 0
+    if config.verbose {
+        log_generation(0, &population);
+    }
+
+    // Evolution loop
+    for gen in 1..=config.generations {
+        let mut next_gen: Vec<crate::evolve::Candidate> = Vec::new();
+
+        // Sort by fitness descending
+        population.sort_by(|a, b| b.fitness.partial_cmp(&a.fitness).unwrap_or(std::cmp::Ordering::Equal));
+
+        // Elite count: top 30%
+        let elite_count = std::cmp::max(1, config.population * 30 / 100);
+        for elite in population.iter().take(elite_count) {
+            next_gen.push(crate::evolve::Candidate {
+                source: elite.source.clone(),
+                fn_value: elite.fn_value.clone(),
+                fitness: elite.fitness,
+                spec_passed: elite.spec_passed,
+                spec_total: elite.spec_total,
+                time_ms: elite.time_ms,
+                error: elite.error.clone(),
+            });
+        }
+
+        // Fill remaining slots with crossover/mutation
+        let viable: Vec<&crate::evolve::Candidate> = population.iter().filter(|c| c.fitness > 0.0).collect();
+
+        for slot in elite_count..config.population {
+            let candidate = if viable.len() >= 2 && slot % 5 != 0 {
+                // Crossover: pick two parents weighted by rank
+                let parent_a = &viable[slot % viable.len()];
+                let parent_b = &viable[(slot * 7 + 3) % viable.len()];
+
+                let prompt = format!(
+                    "Parent A (fitness {:.1}):\n{}\n\nParent B (fitness {:.1}):\n{}\n\n\
+                     Specification:\n{spec_description}\n\
+                     Create a new (fn ...) that combines the best ideas from both parents.",
+                    parent_a.fitness, parent_a.source,
+                    parent_b.fitness, parent_b.source,
+                );
+                generate_candidate(env, ctx, &config, &prompt, crossover_system, slot)
+            } else if !viable.is_empty() {
+                // Mutation: modify a single parent
+                let parent = &viable[slot % viable.len()];
+                let prompt = format!(
+                    "Current function (fitness {:.1}):\n{}\n\n\
+                     Specification:\n{spec_description}\n\
+                     Modify this function to be faster or better.",
+                    parent.fitness, parent.source,
+                );
+                generate_candidate(env, ctx, &config, &prompt, mutate_system, slot)
+            } else {
+                // No viable parents — reseed
+                let prompt = format!(
+                    "{}\n\nThe function will be bound as '{fn_name}'. Specification:\n{spec_description}\n\
+                     Write a (fn ...) expression that satisfies all the above.",
+                    config.seed_prompt
+                );
+                generate_candidate(env, ctx, &config, &prompt, system_prompt, slot)
+            };
+            next_gen.push(candidate);
+        }
+
+        population = next_gen;
+
+        if config.verbose {
+            log_generation(gen, &population);
+        }
+    }
+
+    // Return the best candidate
+    population.sort_by(|a, b| b.fitness.partial_cmp(&a.fitness).unwrap_or(std::cmp::Ordering::Equal));
+
+    match population.first() {
+        Some(best) if best.fn_value.is_some() && best.fitness > 0.0 => {
+            let fn_val = best.fn_value.clone().unwrap();
+            if config.verbose {
+                eprintln!(
+                    "evolve: winner for '{}' — fitness {:.1}, {}/{} spec pass, {:.2}ms",
+                    fn_name, best.fitness, best.spec_passed, best.spec_total, best.time_ms
+                );
+            }
+            Ok(Trampoline::Value(fn_val))
+        }
+        _ => Err(SemaError::eval(format!(
+            "evolve: no viable candidate found for '{fn_name}' after {} generations",
+            config.generations
+        ))),
+    }
+}
+
+/// Generate a single candidate: call LLM, parse, eval in sandbox, run spec, compute fitness.
+/// Retries up to config.max_attempts on failure.
+fn generate_candidate(
+    env: &Env,
+    ctx: &EvalContext,
+    config: &crate::evolve::EvolveConfig,
+    prompt: &str,
+    system: &str,
+    _slot: usize,
+) -> crate::evolve::Candidate {
+    for _attempt in 0..config.max_attempts {
+        // Call LLM
+        let response = match call_llm_complete(env, ctx, prompt, system) {
+            Ok(v) => v,
+            Err(e) => {
+                return crate::evolve::Candidate {
+                    source: String::new(),
+                    fn_value: None,
+                    fitness: 0.0,
+                    spec_passed: 0,
+                    spec_total: 0,
+                    time_ms: 0.0,
+                    error: Some(format!("LLM error: {e}")),
+                };
+            }
+        };
+        let response_str = match response.as_str() {
+            Some(s) => s.to_string(),
+            None => continue,
+        };
+        let code = crate::evolve::strip_code_fences(&response_str).to_string();
+
+        // Parse
+        let expr = match sema_reader::read(&code) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+
+        // Eval in sandbox
+        let sandbox_env = Env::with_parent(Rc::new(env.clone()));
+        let fn_value = match eval::eval_value(ctx, &expr, &sandbox_env) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+
+        // Bind the function by name so spec cases can call it
+        sandbox_env.set(config.name, fn_value.clone());
+
+        // Run spec
+        let (passed, total, time_ms) = crate::evolve::run_spec(config, ctx, &sandbox_env);
+
+        // Compute fitness
+        let fitness = crate::evolve::compute_fitness(
+            &config.fitness_fn,
+            &fn_value,
+            passed,
+            total,
+            time_ms,
+            ctx,
+        );
+
+        return crate::evolve::Candidate {
+            source: code,
+            fn_value: Some(fn_value),
+            fitness,
+            spec_passed: passed,
+            spec_total: total,
+            time_ms,
+            error: None,
+        };
+    }
+
+    // Exhausted retries — zero-fitness sentinel
+    crate::evolve::Candidate {
+        source: String::new(),
+        fn_value: None,
+        fitness: 0.0,
+        spec_passed: 0,
+        spec_total: 0,
+        time_ms: 0.0,
+        error: Some("max attempts exhausted".to_string()),
+    }
+}
+
+fn log_generation(gen: usize, population: &[crate::evolve::Candidate]) {
+    let viable = population.iter().filter(|c| c.fitness > 0.0).count();
+    let best = population
+        .iter()
+        .map(|c| c.fitness)
+        .fold(0.0f64, f64::max);
+    eprintln!(
+        "  Generation {gen}: {} candidates, {viable} viable, best fitness: {best:.1}",
+        population.len()
+    );
+}
+```
+
+**Step 3: Verify tests pass**
+
+Run: `cargo test -p sema-lang --test integration_test -- test_evolve`
+Expected: all 6 config parsing tests pass (they test error paths, no LLM needed).
+
+**Step 4: Commit**
+
+```bash
+git add crates/sema-eval/src/special_forms.rs
+git commit -m "feat: implement evolve special form — LLM-driven genetic programming"
+```
+
+---
+
+### Task 4: Add non-LLM integration tests for evolve
+
+The evolve loop requires an LLM, but we can test the spec runner and fitness computation directly by creating a mock scenario where we pre-define the function.
+
+**Files:**
+- Modify: `.worktrees/living-code/crates/sema/tests/integration_test.rs`
+
+**Step 1: Add tests that exercise spec runner indirectly**
+
+```rust
+#[test]
+fn test_evolve_inline_spec_bad_format() {
+    let interp = Interpreter::new();
+    // Spec cases must be (>>> expr expected)
+    let result = interp.eval_str(
+        r#"(evolve :name "t" :spec '((bad 1 2)) :fitness (fn (f r) 1) :seed-prompt "t")"#,
+    );
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains(">>>"));
+}
+
+#[test]
+fn test_evolve_empty_spec() {
+    let interp = Interpreter::new();
+    let result = interp.eval_str(
+        r#"(evolve :name "t" :spec '() :fitness (fn (f r) 1) :seed-prompt "t")"#,
+    );
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("empty"));
+}
+
+#[test]
+fn test_evolve_spec_fn_no_doctests() {
+    let interp = Interpreter::new();
+    let result = interp.eval_str(
+        r#"(begin
+            (defn nodoc (x) x)
+            (evolve :name "t" :spec nodoc :fitness (fn (f r) 1) :seed-prompt "t"))"#,
+    );
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("docstring") || err.contains("doctest"));
+}
+```
+
+**Step 2: Run tests**
+
+Run: `cargo test -p sema-lang --test integration_test -- test_evolve`
+Expected: all 9 tests pass.
+
+**Step 3: Commit**
+
+```bash
+git add crates/sema/tests/integration_test.rs
+git commit -m "test: add evolve spec validation tests"
+```
+
+---
+
+### Task 5: Final verification
+
+**Step 1: Run all living-code tests**
+
+Run: `cargo test -p sema-lang --test integration_test -- test_evolve test_observe test_become test_history test_rollback test_freeze test_bench`
+
+**Step 2: Run full test suite**
+
+Run: `cargo test`
+
+**Step 3: Lint**
+
+Run: `cargo clippy -- -D warnings`
+Run: `cargo fmt --check`
+
+**Step 4: Commit any fixups**
+
+---
+
+## Summary
+
+| Component | Location | Purpose |
+|-----------|----------|---------|
+| `evolve.rs` | `sema-eval/src/evolve.rs` | Config parsing, spec runner, fitness computation, types |
+| `eval_evolve` | `special_forms.rs` | Special form: evolution loop orchestration |
+| `generate_candidate` | `special_forms.rs` | LLM call + parse + sandbox eval + spec + fitness |
+| `log_generation` | `special_forms.rs` | Verbose output per generation |
+
+`:spec` supports two modes:
+- **Inline**: `'((>>> (f 1) 2) (>>> (f 0) 0))` — quoted list of test cases
+- **Symbol**: `my-fn` — reads doctests from the function's docstring

--- a/examples/doctest-demo.sema
+++ b/examples/doctest-demo.sema
@@ -1,0 +1,27 @@
+(defn factorial
+  "Computes factorial of n.
+
+   >>> (factorial 0)
+   1
+
+   >>> (factorial 5)
+   120
+
+   >>> (factorial 1)
+   1"
+  (n)
+  (if (<= n 1) 1 (* n (factorial (- n 1)))))
+
+(defn fibonacci
+  "Returns the nth Fibonacci number.
+
+   >>> (fibonacci 0)
+   0
+
+   >>> (fibonacci 1)
+   1
+
+   >>> (fibonacci 10)
+   55"
+  (n)
+  (if (< n 2) n (+ (fibonacci (- n 1)) (fibonacci (- n 2)))))

--- a/examples/read-source-demo.sema
+++ b/examples/read-source-demo.sema
@@ -1,0 +1,47 @@
+;; Demo: self-reading capabilities (Living Code Phase 2)
+
+;;@since 1.12.0
+;;@tags introspection, demo
+(defn greet
+  "Greet someone by name.
+   >>> (greet \"World\")
+   \"Hello, World!\""
+  (name)
+  (string-append "Hello, " name "!"))
+
+;;@since 1.12.0
+(defn add
+  "Add two numbers.
+   >>> (add 1 2)
+   3
+   >>> (add 0 0)
+   0"
+  (a b)
+  (+ a b))
+
+(define pi 3.14159)
+
+;; === Source introspection ===
+(println "--- source-of ---")
+(println (source-of greet))
+(println)
+
+;; === Meta introspection ===
+(println "--- meta ---")
+(println (meta greet))
+(println)
+
+;; === Read-source: analyze this file ===
+(println "--- read-source ---")
+(let ((defs (read-source "examples/read-source-demo.sema")))
+  (for-each (fn (d)
+          (let ((type (get d :type))
+                (name (or (get d :name) "(anonymous)"))
+                (doc  (or (get d :doc) "(no doc)"))
+                (dirs (get d :directives)))
+            (println f"  ${type} ${name}")
+            (when (not (nil? dirs))
+              (println f"    directives: ${dirs}"))
+            (when (not (= doc "(no doc)"))
+              (println f"    doc: ${doc}"))))
+        defs))

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -76,6 +76,7 @@ export default defineConfig({
             { text: 'Conversations', link: '/docs/llm/conversations' },
             { text: 'Structured Extraction', link: '/docs/llm/extraction' },
             { text: 'Tools & Agents', link: '/docs/llm/tools-agents' },
+            { text: 'Living Code', link: '/docs/llm/living-code' },
             { text: 'Embeddings', link: '/docs/llm/embeddings' },
             { text: 'Vector Store & Math', link: '/docs/llm/vector-store' },
             { text: 'Caching', link: '/docs/llm/caching' },

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -65,6 +65,7 @@ export default defineConfig({
             { text: 'Data Types', link: '/docs/language/data-types' },
             { text: 'Special Forms', link: '/docs/language/special-forms' },
             { text: 'Macros & Modules', link: '/docs/language/macros-modules' },
+            { text: 'Metaprogramming', link: '/docs/language/metaprogramming' },
           ],
         },
         {

--- a/website/docs/cli.md
+++ b/website/docs/cli.md
@@ -596,7 +596,7 @@ The REPL supports tab completion for:
 The REPL automatically detects incomplete expressions (unbalanced parentheses) and continues on the next line:
 
 ```
-sema> (define (factorial n)
+sema> (defn factorial (n)
   ...   (if (= n 0)
   ...     1
   ...     (* n (factorial (- n 1)))))
@@ -655,11 +655,11 @@ When you pass the wrong number of arguments, the error shows what you called:
 
 ```
 Error: Arity error: f expects 1 args, got 3
-  --> <input>:1:18
+  --> <input>:1:17
    |
- 1 | (define (f x) x) (f 1 2 3)
-   |                  ^
-  at f (<input>:1:18)
+ 1 | (defn f (x) x) (f 1 2 3)
+   |                 ^
+  at f (<input>:1:17)
   note: in: (f 1 2 3)
 ```
 

--- a/website/docs/embedding-js.md
+++ b/website/docs/embedding-js.md
@@ -257,7 +257,7 @@ Use `preloadModule` to inject virtual modules that can be imported with `(import
 const interp = new SemaInterpreter();
 
 interp.preloadModule('utils', `
-  (define (double x) (* x 2))
+  (defn double (x) (* x 2))
   (define pi 3.14159)
 `);
 
@@ -274,8 +274,8 @@ Use `(module ...)` with `(export ...)` to control which bindings are visible:
 ```js
 interp.preloadModule('math', `
   (module math (export square cube)
-    (define (square x) (* x x))
-    (define (cube x) (* x x x))
+    (defn square (x) (* x x))
+    (defn cube (x) (* x x x))
     (define internal-helper 42))
 `);
 
@@ -292,7 +292,7 @@ Use `evalGlobal` to build up state across multiple calls — this is the key pat
 ```js
 // Define functions
 interp.evalGlobal(`
-  (define (greet name)
+  (defn greet (name)
     (string/append "Hello, " name "!"))
 `);
 
@@ -327,7 +327,7 @@ The VFS can also be accessed directly from JavaScript, enabling file browser UIs
 const sema = new SemaInterpreter();
 
 // Write files from JS
-sema.writeFile("/lib/math.sema", "(define (square x) (* x x))");
+sema.writeFile("/lib/math.sema", "(defn square (x) (* x x))");
 sema.writeFile("/main.sema", '(import "/lib/math") (square 7)');
 
 // Run the script
@@ -492,7 +492,7 @@ A web application that lets users write Sema scripts to customize behavior. The 
 ```html
 <div id="app">
   <textarea id="script" rows="8" cols="60">
-(define (transform items)
+(defn transform (items)
   (filter (lambda (item) (> (:score item) 50))
     (map (lambda (item)
            (assoc item :label

--- a/website/docs/embedding.md
+++ b/website/docs/embedding.md
@@ -242,7 +242,7 @@ fn make_record(name: &str, age: i64, dept: &str) -> Value {
 ### User Script (`transform.sema`)
 
 ```sema
-(define (transform record)
+(defn transform (record)
   (log (format "Processing: ~a" (:name record)))
   (if (> (:age record) 30)
       (assoc record :senior #t)
@@ -324,15 +324,15 @@ let interp = Interpreter::new();
 
 // All top-level definitions are exported by default
 interp.preload_module("utils", r#"
-    (define (double x) (* x 2))
+    (defn double (x) (* x 2))
     (define pi 3.14159)
 "#)?;
 
 // Use `(module ...)` with `(export ...)` for selective exports
 interp.preload_module("math", r#"
     (module math (export square cube)
-      (define (square x) (* x x))
-      (define (cube x) (* x x x))
+      (defn square (x) (* x x))
+      (defn cube (x) (* x x x))
       (define internal-helper 42))
 "#)?;
 ```

--- a/website/docs/formatter.md
+++ b/website/docs/formatter.md
@@ -92,7 +92,7 @@ The formatter uses a "try flat, then multi-line" strategy. If a form fits within
 (+ 1 2 3)
 
 ;; Too long — breaks with body indentation
-(define (calculate-fibonacci-sequence n)
+(defn calculate-fibonacci-sequence (n)
   (if (< n 2)
     n
     (+ (calculate-fibonacci-sequence (- n 1))

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -54,7 +54,7 @@ sema -p '(map sqr (range 5))' # Evaluate and always print
 
 ```sema
 ;; In the REPL:
-sema> (define (greet name) f"Hello, ${name}!")
+sema> (defn greet (name) f"Hello, ${name}!")
 sema> (greet "world")
 "Hello, world!"
 
@@ -87,7 +87,7 @@ sema> (:name person)
   (println f"${name} is ${age} years old"))
 
 ;; Pattern matching
-(define (describe person)
+(defn describe (person)
   (match person
     ({:keys [name age]} when (> age 40)
       f"${name} is experienced")

--- a/website/docs/internals/evaluator.md
+++ b/website/docs/internals/evaluator.md
@@ -62,7 +62,7 @@ The [IBM 704](http://bitsavers.informatik.uni-stuttgart.de/pdf/ibm/704/24-6661-2
 Consider this tail-recursive loop:
 
 ```sema
-(define (loop n)
+(defn loop (n)
   (if (= n 0)
     "done"
     (loop (- n 1))))

--- a/website/docs/language/macros-modules.md
+++ b/website/docs/language/macros-modules.md
@@ -136,9 +136,9 @@ Define a module with explicit exports.
 ;; math-utils.sema
 (module math-utils
   (export square cube)
-  (define (square x) (* x x))
-  (define (cube x) (* x x x))
-  (define (internal-helper x) x))      ; not exported
+  (defn square (x) (* x x))
+  (defn cube (x) (* x x x))
+  (defn internal-helper (x) x))      ; not exported
 ```
 
 ### `import`

--- a/website/docs/language/metaprogramming.md
+++ b/website/docs/language/metaprogramming.md
@@ -1,0 +1,301 @@
+---
+outline: [2, 3]
+---
+
+# Metaprogramming
+
+Sema treats code as data. Every function carries metadata -- its name, parameters, docstring, source text, and version history. These introspection and runtime modification primitives let you build documentation engines, test runners, profilers, and hot-swapping systems entirely within the language.
+
+None of these features require an LLM. For LLM-powered code intelligence (`ask`, `heal!`, `evolve`), see [Living Code](../llm/living-code.md).
+
+## Docstrings & Doctests
+
+### `defn` with docstrings
+
+`defn` accepts an optional docstring as its second argument (before params). The docstring is stored as metadata and accessible via `doc`, `meta`, and `doctest`.
+
+```sema
+(defn factorial "Compute n!.
+    >>> (factorial 0)
+    1
+    >>> (factorial 5)
+    120"
+  (n)
+  (if (<= n 1) 1 (* n (factorial (- n 1)))))
+```
+
+Doctest syntax:
+
+- `>>> expr` followed by expected result on the next line
+- `!! substring` expects an error containing that substring
+- `>>>!` evaluates but doesn't check the result (setup step)
+
+### `(doc sym)`
+
+Pretty-print documentation for a symbol. Shows name, parameters, docstring, and source.
+
+```sema
+(doc factorial)
+;; factorial (n)
+;;   Compute n!.
+;;   >>> (factorial 0)
+;;   1
+;;   ...
+```
+
+### `(doc/search query)`
+
+Search all defined symbols by name or docstring content. Returns a list of `{:name ... :doc ...}` maps.
+
+```sema
+(doc/search "sort")       ; find all functions mentioning "sort"
+(doc/search "deprecated") ; find deprecated functions
+```
+
+### `(doctest sym)`
+
+Run all doctests from a symbol's docstring. Returns `{:passed n :total n :name "..."}`.
+
+```sema
+(doctest factorial)    ; => {:name "factorial" :passed 2 :total 2}
+```
+
+Failed tests print details to stderr:
+
+```
+  ✓ (factorial 0) => 1
+  ✗ (factorial 5) => expected 120, got 0
+```
+
+### Testing from the CLI
+
+```bash
+sema test src/**/*.sema       # run all doctests in matching files
+```
+
+::: tip
+Treat docstrings as executable specifications. They serve triple duty: documentation for humans, test cases for `doctest`, and context for LLM features like `ask` and `heal!`.
+:::
+
+## Metadata & Introspection
+
+### `(meta sym)`
+
+Return all metadata for a symbol as a map. Includes `:name`, `:type`, `:params`, `:arity`, `:doc`, `:source`, `:variadic?`, and any custom metadata set by directives or `become!`.
+
+```sema
+(meta factorial)
+; => {:arity 1 :doc "Compute n!. ..." :name "factorial" :params (n) :type :lambda}
+
+(meta map)
+; => {:name "map" :type :native-fn}
+```
+
+### `(source-of sym)`
+
+Return the source text of a definition as a string. Returns `nil` for native functions.
+
+```sema
+(source-of factorial)
+; => "(defn factorial \"Compute n!. ...\" (n) (if (<= n 1) 1 (* n (factorial (- n 1)))))"
+```
+
+### Reader directives: `;;@key value`
+
+Attach structured metadata to definitions using directive comments. Place them on the line before a `defn`, `define`, or `defmacro`.
+
+```sema
+;;@since 1.5
+;;@stability stable
+;;@deprecated "Use parse-datetime instead"
+(defn parse-date "Parse a date string." (s) ...)
+```
+
+Directives are captured by the reader and available through `read-source`.
+
+### `(read-source path)`
+
+Read and parse source files, returning structured data for each top-level definition. Supports glob patterns.
+
+```sema
+(read-source "src/utils.sema")
+; => list of {:type :defn :name "..." :doc "..." :params (...) :body (...) :source "..."}
+
+(read-source "src/**/*.sema")  ; glob across directories
+```
+
+::: tip Codebase tooling
+Combine `read-source` with higher-order functions to build custom tooling without leaving Sema:
+
+```sema
+;; Find all deprecated functions
+(->> (read-source "src/**/*.sema")
+     (filter #(get-in % [:directives :deprecated]))
+     (map #(println f"deprecated: ${(:name %)} -- ${(get-in % [:directives :deprecated])}")))
+
+;; Generate a function index
+(->> (read-source "src/**/*.sema")
+     (filter #(= (:type %) :defn))
+     (map #(println f"  ${(:name %)} -- ${(or (:doc %) \"(no doc)\")}")))
+```
+:::
+
+## Runtime Self-Modification
+
+These forms let programs change their own behavior at runtime, with built-in safety through doctests, version history, and freezing.
+
+::: warning
+Runtime self-modification is powerful but requires discipline. Always use doctests as contracts, keep history for rollback, and freeze stable code.
+:::
+
+### `(observe! sym sample-size callback)`
+
+Wrap a function with an invisible logger. After `sample-size` calls, the original function is restored and `callback` is invoked with the call log -- a list of `{:args ... :result ... :time-ms ...}` maps.
+
+```sema
+(defn fib "Fibonacci.
+    >>> (fib 0)
+    0
+    >>> (fib 10)
+    55"
+  (n) (if (<= n 1) n (+ (fib (- n 1)) (fib (- n 2)))))
+
+(observe! fib 100
+  (fn (log)
+    (let ((total-ms (foldl + 0 (map #(get % :time-ms) log)))
+          (unique-args (length (dedup (map #(get % :args) log)))))
+      (println f"100 calls: ${total-ms}ms total, ${unique-args} unique inputs"))))
+
+;; Use fib normally -- after 100 calls, the callback fires and fib is restored.
+```
+
+### `(become! sym new-definition)`
+
+Replace a function's definition at runtime. If the function has doctests, the candidate must pass all of them or the replacement is rejected. Saves the old version to history.
+
+```sema
+;; Upgrade fib to a memoized version
+(become! fib
+  (let ((cache {}))
+    (fn (n)
+      (or (get cache n)
+          (let ((v (if (<= n 1) n (+ (fib (- n 1)) (fib (- n 2))))))
+            (set! cache (assoc cache n v))
+            v)))))
+;; Doctests run automatically -- if they fail, fib is unchanged.
+```
+
+::: danger
+`become!` modifies live program state. Always ensure functions have doctests before using it. The doctest gate is your safety net -- without it, any replacement is accepted unconditionally.
+:::
+
+### `(history sym)`
+
+Return the version history of a binding as a list of `{:version n :value <old-fn> :source "..."}` maps. Each `become!` and `rollback!` creates a history entry.
+
+```sema
+(history fib)
+; => ({:version 1 :value <lambda> :source "(fn (n) ...)"})
+```
+
+### `(rollback! sym version)`
+
+Restore a previous version from history. Creates a new history entry for the current version before rolling back.
+
+```sema
+(rollback! fib 1)   ; restore the original implementation
+(fib 10)            ; => 55 (works, but slow again)
+```
+
+### `(freeze! sym)`
+
+Permanently prevent further `become!` or `rollback!` on a function. Use this to stabilize proven implementations.
+
+```sema
+(freeze! fib)
+(become! fib (fn (n) 0))  ; => Error: 'fib' is frozen and cannot be modified
+```
+
+::: tip The safety lifecycle
+`observe!` to understand behavior, `become!` to upgrade (gated by doctests), `history` to inspect changes, `rollback!` if something goes wrong, `freeze!` once stable.
+:::
+
+## Benchmarking
+
+### `(bench thunk iterations)`
+
+Run a zero-argument function `iterations` times and return timing statistics.
+
+```sema
+(bench (fn () (fib 20)) 1000)
+; => {:iterations 1000 :total-ms 342.5 :mean-ms 0.3425}
+```
+
+## Scenarios
+
+### Hot-Swapping in a Running Server
+
+Replace a handler's implementation without restarting the server:
+
+```sema
+(defn handle-request "Handle API requests.
+    >>> (handle-request {:path \"/health\"})
+    {:status 200 :body \"ok\"}"
+  (req)
+  (cond
+    ((= (:path req) "/health") {:status 200 :body "ok"})
+    (else {:status 404 :body "not found"})))
+
+;; Later, upgrade the handler with new routes
+(become! handle-request
+  (fn (req)
+    (cond
+      ((= (:path req) "/health") {:status 200 :body "ok"})
+      ((= (:path req) "/version") {:status 200 :body "1.1"})
+      (else {:status 404 :body "not found"}))))
+;; Doctests verify /health still works before the swap takes effect.
+```
+
+### Profiling with observe!
+
+Find which inputs are most common and how long they take:
+
+```sema
+(observe! my-parser 500
+  (fn (log)
+    (let ((by-input (group-by #(get % :args) log)))
+      (->> by-input
+           (map (fn ([args calls])
+             {:input args
+              :count (length calls)
+              :avg-ms (/ (foldl + 0 (map #(get % :time-ms) calls))
+                         (length calls))}))
+           (sort-by :count >)
+           (take 10)
+           (for-each println)))))
+```
+
+### Building a Documentation Generator
+
+Generate a stdlib reference from source files:
+
+```sema
+(defn generate-docs (glob-pattern)
+  (let ((defs (read-source glob-pattern)))
+    (for-each
+      (fn (d)
+        (when (= (:type d) :defn)
+          (println f"### `${(:name d)}`\n")
+          (when (:doc d)
+            (println (:doc d))
+            (println))))
+      defs)))
+
+(generate-docs "src/stdlib/**/*.sema")
+```
+
+## Related
+
+- [Special Forms](./special-forms.md) -- full language reference for `defn`, `define`, etc.
+- [Macros & Modules](./macros-modules.md) -- compile-time metaprogramming with `defmacro`
+- [Living Code](../llm/living-code.md) -- LLM-powered features that build on these primitives (`ask`, `heal!`, `evolve`)

--- a/website/docs/language/special-forms.md
+++ b/website/docs/language/special-forms.md
@@ -10,12 +10,14 @@ Special forms are built into the evaluator — they control evaluation order and
 
 ### `define`
 
-Bind a value or define a function.
+Bind a value to a name.
 
 ```sema
 (define x 42)                          ; bind a value
-(define (square x) (* x x))           ; define a function (shorthand)
+(define pi 3.14159)                    ; bind another value
 ```
+
+The Scheme-style function shorthand `(define (f x) ...)` is supported but [`defn`](#defn) is preferred for function definitions.
 
 ### `set!`
 
@@ -68,17 +70,21 @@ Alias for `lambda`.
 (fn (x . rest) rest)                   ; rest parameters with dot notation
 ```
 
-### `defun`
+### `defn`
 
-Define a named function (equivalent to `(define (name params...) body...)`).
+Define a named function.
 
 ```sema
-(defun square (x) (* x x))
-(defun greet (name) f"Hello, ${name}!")
+(defn square (x) (* x x))
+(defn greet (name) f"Hello, ${name}!")
 ```
 
-::: tip Clojure alias
-`defn` is accepted as an alias for `defun`.
+::: tip Preferred style
+Use `defn` for named functions and `define` for value bindings. The Scheme-style `(define (f x) ...)` function shorthand is supported for compatibility but `defn` is the canonical Sema form.
+:::
+
+::: info Alias
+`defun` is accepted as an alias for `defn`.
 :::
 
 ## Conditionals
@@ -247,7 +253,7 @@ Loop construct with tail-call optimization.
 
 ## Destructuring
 
-`let`, `let*`, `define`, and `lambda` all support destructuring patterns in binding positions.
+`let`, `let*`, `define`, `defn`, and `lambda` all support destructuring patterns in binding positions.
 
 ### Vector Destructuring
 
@@ -290,11 +296,11 @@ Explicit key-pattern pairs:
 ### Destructuring in Function Parameters
 
 ```sema
-(define (sum-pair [a b])
+(defn sum-pair ([a b])
   (+ a b))
 (sum-pair '(3 4))                       ; => 7
 
-(define (greet {:keys [name title]})
+(defn greet ({:keys [name title]})
   (format "Hello ~a ~a" title name))
 (greet {:name "Smith" :title "Dr."})    ; => "Hello Dr. Smith"
 ```

--- a/website/docs/llm/index.md
+++ b/website/docs/llm/index.md
@@ -38,6 +38,10 @@ Persistent, immutable conversation state with automatic LLM round-trips.
 
 Define tools the LLM can invoke, and build agents with system prompts, tools, and multi-turn loops.
 
+### [Living Code](./living-code.md)
+
+Self-aware programs: docstrings as specs, conversational introspection (`ask`), auto-repair (`heal!`), runtime self-modification (`become!`/`rollback!`/`freeze!`), and LLM-driven genetic programming (`evolve`).
+
 ### [Embeddings & Similarity](./embeddings.md)
 
 Generate embeddings (as bytevectors), compute cosine similarity, and access embedding dimensions.

--- a/website/docs/llm/index.md
+++ b/website/docs/llm/index.md
@@ -40,7 +40,7 @@ Define tools the LLM can invoke, and build agents with system prompts, tools, an
 
 ### [Living Code](./living-code.md)
 
-Self-aware programs: docstrings as specs, conversational introspection (`ask`), auto-repair (`heal!`), runtime self-modification (`become!`/`rollback!`/`freeze!`), and LLM-driven genetic programming (`evolve`).
+LLM-powered code intelligence: conversational introspection (`ask`, `ask/code`), auto-repair (`heal!`), and genetic programming (`evolve`). Builds on the [Metaprogramming](../language/metaprogramming.md) primitives.
 
 ### [Embeddings & Similarity](./embeddings.md)
 

--- a/website/docs/llm/living-code.md
+++ b/website/docs/llm/living-code.md
@@ -1,0 +1,472 @@
+---
+outline: [2, 3]
+---
+
+# Living Code
+
+Sema programs can inspect, test, and rewrite themselves at runtime. Living Code is a set of special forms and stdlib functions that turn code into a conversational, self-aware medium -- programs that document themselves, answer questions about their own behavior, heal their own bugs, and evolve toward better solutions.
+
+::: warning
+Living Code features can change program behavior at runtime. Use doctests as contracts, `history`/`rollback!` for reversibility, and `freeze!` to stabilize proven code.
+:::
+
+### Quick Taste
+
+```sema
+(defn factorial "Compute n!.
+    >>> (factorial 0)
+    1
+    >>> (factorial 5)
+    120"
+  (n)
+  (if (<= n 1) 1 (* n (factorial (- n 1)))))
+
+;; Inspect
+(doc factorial)                ; pretty-print docs + source
+(source-of factorial)          ; => "(fn (n) (if (<= n 1) 1 ...))"
+(doctest factorial)            ; => {:passed 2 :total 2 :name "factorial"}
+
+;; Converse
+(ask factorial "Is this tail-recursive?")
+
+;; Upgrade
+(become! factorial
+  (fn (n) (let loop ((i n) (acc 1))
+    (if (<= i 1) acc (loop (- i 1) (* acc i))))))
+
+;; Review
+(history factorial)            ; => ({:version 1 :value <lambda> :source "..."})
+```
+
+## Docstrings & Doctests
+
+### `defn` with docstrings
+
+`defn` accepts an optional docstring as its second argument (before params). The docstring is stored as metadata and used by `doc`, `doctest`, `ask`, and `heal!`. The Scheme-style `define` also supports docstrings: `(define (f x) "docstring" body...)`.
+
+```sema
+(defn factorial "Compute n!.
+    >>> (factorial 0)
+    1
+    >>> (factorial 5)
+    120"
+  (n)
+  (if (<= n 1) 1 (* n (factorial (- n 1)))))
+```
+
+Doctest syntax:
+
+- `>>> expr` followed by expected result on the next line
+- `!! substring` expects an error containing substring
+- `>>>!` evaluates but doesn't check (setup)
+
+### `(doc sym)`
+
+Pretty-print documentation for a symbol. Shows name, parameters, docstring, and source.
+
+```sema
+(doc factorial)
+```
+
+### `(doc/search query)`
+
+Search all defined symbols by name or docstring content. Returns a list of `{:name ... :doc ...}` maps.
+
+```sema
+(doc/search "sort")    ; find all functions mentioning "sort"
+```
+
+### `(doctest sym)`
+
+Run all doctests from a symbol's docstring. Returns `{:passed n :total n :name "..."}`.
+
+```sema
+(doctest factorial)    ; => {:name "factorial" :passed 2 :total 2}
+```
+
+### `(meta sym)`
+
+Return all metadata for a symbol as a map. Includes `:name`, `:type`, `:params`, `:arity`, `:doc`, `:source`, `:variadic?`, and any custom metadata.
+
+```sema
+(meta factorial)
+; => {:arity 1 :doc "Compute n!. ..." :name "factorial" :params (n) :type :lambda}
+```
+
+### Testing from the CLI
+
+```bash
+sema test src/**/*.sema       # run all doctests in matching files
+sema test --heal src/lib.sema # run doctests, auto-heal failures with LLM
+```
+
+::: tip
+Treat docstrings as specifications: concise purpose + concrete examples. The LLM reads them during `ask`, `heal!`, and `evolve`.
+:::
+
+## Source Introspection
+
+### `(source-of sym)`
+
+Return the source text of a definition as a string.
+
+```sema
+(source-of factorial)  ; => "(fn (n) (if (<= n 1) 1 (* n (factorial (- n 1)))))"
+```
+
+### Reader directives: `;;@key value`
+
+Attach structured metadata to definitions using directive comments. Place them on the line before a `defn`, `define`, or `defmacro`.
+
+```sema
+;;@since 1.5
+;;@stability stable
+;;@author helge
+(defn parse-date "Parse a date string." (s) ...)
+```
+
+Directives are captured by the reader and available through `read-source`.
+
+### `(read-source path)`
+
+Read and parse source files, returning structured data for each top-level definition. Supports glob patterns.
+
+```sema
+(read-source "src/**/*.sema")
+; => list of {:type :defn :name "..." :doc "..." :params (...) :body (...) :directives {...} :source "..."}
+```
+
+::: tip
+Combine `read-source` with higher-order functions to build custom tooling:
+```sema
+;; Find all deprecated functions
+(->> (read-source "src/**/*.sema")
+     (filter #(get-in % [:directives :deprecated]))
+     (map :name))
+```
+:::
+
+## Conversational Introspection
+
+These forms require an LLM provider to be configured.
+
+### `(ask target question)`
+
+Ask a natural-language question about any value. The LLM receives the value's source, metadata, and docstring as context.
+
+```sema
+(ask factorial "Will this blow the stack for large inputs?")
+; => "Yes, this implementation is not tail-recursive. For n > ~10000,
+;     you'll hit a stack overflow. Consider using an accumulator pattern..."
+
+(ask {:host "db.prod" :password "hunter2"} "Any security concerns?")
+; => "The password is hardcoded in plain text..."
+```
+
+### `(ask/code target instruction)`
+
+Like `ask`, but the LLM returns a Sema code expression that can be evaluated.
+
+```sema
+(ask/code factorial "Make this tail-recursive")
+; => "(fn (n) (let loop ((i n) (acc 1)) (if (<= i 1) acc (loop (- i 1) (* acc i)))))"
+```
+
+### `(heal! sym)`
+
+Auto-repair a function by running its doctests. If any fail, the LLM is asked to rewrite the function to pass them. The process repeats (up to 5 attempts) until all doctests pass or attempts are exhausted.
+
+```sema
+;; A parser that only handles one format
+(defn parse-date "Parse various date formats.
+    >>> (parse-date \"2024-01-15\")
+    \"2024-01-15\"
+    >>> (parse-date \"Jan 15, 2024\")
+    \"2024-01-15\"
+    >>> (parse-date \"15/01/2024\")
+    \"2024-01-15\""
+  (s) s)  ; naive: just returns the string
+
+(heal! parse-date)
+;; The LLM iteratively rewrites parse-date until all 3 doctests pass.
+;; On success, the new implementation replaces the old one.
+```
+
+::: warning
+`heal!` modifies the function in place. Use `(source-of sym)` after healing to inspect the new implementation, and `(history sym)` to see previous versions.
+:::
+
+## Runtime Self-Modification
+
+### `(observe! sym sample-size callback)`
+
+Wrap a function with an invisible logger. After `sample-size` calls, the original function is restored and `callback` is invoked with the call log (a list of `{:args ... :result ... :time-ms ...}` maps).
+
+```sema
+(defn fib "Fibonacci.
+    >>> (fib 0)
+    0
+    >>> (fib 10)
+    55"
+  (n) (if (<= n 1) n (+ (fib (- n 1)) (fib (- n 2)))))
+
+(observe! fib 100
+  (fn (log)
+    (let ((total-ms (foldl + 0 (map #(get % :time-ms) log)))
+          (unique-args (length (dedup (map #(get % :args) log)))))
+      (println f"100 calls: ${total-ms}ms total, ${unique-args} unique inputs"))))
+
+;; Now use fib normally — after 100 calls, the callback fires and fib is restored.
+```
+
+### `(become! sym new-definition)`
+
+Replace a function's definition at runtime. If the function has doctests, the candidate must pass all of them or the replacement is rejected. Saves the old version to history.
+
+```sema
+;; Upgrade fib to a memoized version
+(become! fib
+  (let ((cache {}))
+    (fn (n)
+      (or (get cache n)
+          (let ((v (if (<= n 1) n (+ (fib (- n 1)) (fib (- n 2))))))
+            (set! cache (assoc cache n v))
+            v)))))
+;; Doctests run automatically — if they fail, fib is unchanged.
+```
+
+::: danger
+`become!` is powerful but dangerous. Always ensure functions have doctests before using it in production. The doctest gate is your safety net.
+:::
+
+### `(history sym)`
+
+Return the version history of a binding as a list of `{:version n :value <old-fn> :source "..."}` maps. Each `become!` and `rollback!` creates a history entry.
+
+```sema
+(history fib)
+; => ({:version 1 :value <lambda> :source "(fn (n) ...)"})
+```
+
+### `(rollback! sym version)`
+
+Restore a previous version from history. Creates a new history entry for the current version before rolling back.
+
+```sema
+(rollback! fib 1)   ; restore the original implementation
+(fib 10)            ; => 55 (works, but slow again)
+```
+
+### `(freeze! sym)`
+
+Permanently prevent further `become!` or `rollback!` on a function. Use this to stabilize proven implementations.
+
+```sema
+(freeze! fib)
+(become! fib (fn (n) 0))  ; => Error: 'fib' is frozen and cannot be modified
+```
+
+::: tip
+The safety workflow: `observe!` to understand behavior, `become!` to upgrade (gated by doctests), `history` to inspect changes, `rollback!` if something goes wrong, `freeze!` once stable.
+:::
+
+## Genetic Programming
+
+### `(evolve :name ... :spec ... :fitness fn :seed-prompt ...)`
+
+Generate a population of candidate function implementations via LLM, test them against a specification, and iteratively breed and mutate the best ones to produce an optimized solution.
+
+**Required parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `:name` | string | Name for the evolved function |
+| `:spec` | list or function | Test specification (see below) |
+| `:fitness` | function | `(fn (candidate results) score)` -- higher is better |
+| `:seed-prompt` | string | Description of what the function should do |
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `:population` | integer | 10 | Number of candidates per generation |
+| `:generations` | integer | 5 | Number of evolution rounds |
+| `:max-attempts` | integer | 3 | LLM retries per candidate |
+| `:verbose` | boolean | `#f` | Print progress to stderr |
+
+**Spec modes:**
+
+Inline spec -- a quoted list of `(>>> expr expected)` forms:
+
+```sema
+(evolve
+  :name "fast-square"
+  :spec '((>>> (fast-square 0) 0)
+          (>>> (fast-square 5) 25)
+          (>>> (fast-square -3) 9))
+  :fitness (fn (f results)
+    (if (= (get results :passed) (get results :total))
+        (/ 1000.0 (max 0.01 (get results :time-ms)))
+        0))
+  :seed-prompt "Write a function that squares a number."
+  :population 5
+  :generations 3
+  :verbose #t)
+```
+
+Docstring spec -- pass a function whose docstring contains doctests:
+
+```sema
+(defn my-sort "Sort a list.
+    >>> (my-sort '(3 1 2))
+    (1 2 3)
+    >>> (my-sort '())
+    ()
+    >>> (my-sort '(1))
+    (1)"
+  (lst) lst)  ; placeholder
+
+(evolve
+  :name "my-sort"
+  :spec my-sort
+  :fitness (fn (f results)
+    (* (get results :passed)
+       (/ 100.0 (max 0.1 (get results :time-ms)))))
+  :seed-prompt "Write an efficient sorting function in Sema.")
+```
+
+**The evolution loop:**
+
+1. **Seed** -- LLM generates `:population` candidates from the seed prompt
+2. **Evaluate** -- each candidate is parsed, evaluated in a sandbox, tested against the spec, and scored by the fitness function
+3. **Select** -- top 30% survive as elites
+4. **Breed** -- remaining slots filled by crossover (combine two parents) or mutation (improve one parent) via LLM
+5. **Repeat** for `:generations` rounds
+6. **Return** the best candidate as a function value
+
+**Fitness function:**
+
+The fitness function receives two arguments: the candidate function value and a results map `{:passed n :total n :time-ms f}`. Return a number -- higher is better.
+
+```sema
+;; Correctness only
+(fn (f results) (get results :passed))
+
+;; Correctness + speed
+(fn (f results)
+  (if (= (get results :passed) (get results :total))
+      (/ 1000.0 (max 0.01 (get results :time-ms)))
+      0))
+
+;; Multi-objective: 70% correctness, 30% speed
+(fn (f results)
+  (+ (* 0.7 (/ (get results :passed) (max 1 (get results :total))))
+     (* 0.3 (/ 10.0 (max 0.01 (get results :time-ms))))))
+```
+
+::: tip
+Start with correctness-only fitness. Once `evolve` reliably produces correct candidates, add performance objectives.
+:::
+
+## Putting It Together
+
+### Scenario 1: Self-Healing Parser
+
+A date parser that handles ISO format but breaks on other inputs. Define the full specification as doctests, then let the system heal itself:
+
+```sema
+(defn parse-date "Parse date strings into ISO format.
+    >>> (parse-date \"2024-01-15\")
+    \"2024-01-15\"
+    >>> (parse-date \"Jan 15, 2024\")
+    \"2024-01-15\"
+    >>> (parse-date \"15/01/2024\")
+    \"2024-01-15\""
+  (s) s)
+
+;; Check what fails
+(doctest parse-date)     ; => {:passed 1 :total 3 :name "parse-date"}
+
+;; Auto-repair
+(heal! parse-date)
+
+;; Verify
+(doctest parse-date)     ; => {:passed 3 :total 3 :name "parse-date"}
+
+;; Inspect what changed
+(source-of parse-date)
+
+;; Lock it down
+(freeze! parse-date)
+```
+
+### Scenario 2: Adaptive Memoization
+
+A function that's expensive for repeated calls. Use `observe!` to collect usage data, then let the LLM decide how to optimize:
+
+```sema
+(defn compute "Expensive computation.
+    >>> (compute 1)
+    42
+    >>> (compute 2)
+    84"
+  (x) (begin (for-each (fn (_) nil) (range 10000)) (* x 42)))
+
+;; Observe usage patterns
+(observe! compute 50
+  (fn (log)
+    (let ((unique (length (dedup (map #(get % :args) log))))
+          (total  (length log)))
+      (when (< unique (/ total 2))
+        ;; Many repeated calls — ask for memoization
+        (let ((suggestion (ask/code compute "Add memoization")))
+          (println f"Suggested:\n${suggestion}"))))))
+
+;; ... use compute normally ...
+;; After 50 calls, the callback fires with the analysis
+```
+
+### Scenario 3: Evolving for Performance
+
+Use `evolve` to find the fastest implementation of a function, then benchmark and freeze the winner:
+
+```sema
+(define best-fib
+  (evolve
+    :name "fib"
+    :spec '((>>> (fib 0) 0)
+            (>>> (fib 1) 1)
+            (>>> (fib 10) 55)
+            (>>> (fib 20) 6765))
+    :fitness (fn (f results)
+      (if (= (get results :passed) (get results :total))
+          (/ 1000.0 (max 0.01 (get results :time-ms)))
+          0))
+    :seed-prompt "Write a fast Fibonacci function. Consider memoization or iteration."
+    :population 8
+    :generations 3
+    :verbose #t))
+
+;; Benchmark the winner
+(bench (fn () (best-fib 30)) 1000)
+```
+
+## Best Practices
+
+1. **Doctests are contracts.** Every function that participates in `become!`, `heal!`, or `evolve` should have doctests. They are the safety net that prevents regressions.
+
+2. **Keep targets small.** Don't `ask` or `heal!` an entire module. Target individual functions with clear specifications.
+
+3. **Use history and rollback.** Before `become!`, know that you can always `(rollback! sym 1)` to get back. Check `(history sym)` to see what changed.
+
+4. **Freeze stable code.** Once a function is battle-tested, `(freeze! sym)` prevents accidental modification.
+
+5. **Start with `ask` before `ask/code`.** Use `ask` to understand the problem, `ask/code` to generate a solution, and `become!` to apply it -- not all at once.
+
+6. **Use `observe!` before optimizing.** Measure before you modify. Let the data tell you what to optimize.
+
+## Related
+
+- [Completion & Chat](./completion.md) -- LLM provider configuration needed for `ask`, `heal!`, and `evolve`
+- [Tools & Agents](./tools-agents.md) -- structured LLM interactions
+- [Special Forms](../language/special-forms.md) -- full language reference

--- a/website/docs/llm/living-code.md
+++ b/website/docs/llm/living-code.md
@@ -4,10 +4,12 @@ outline: [2, 3]
 
 # Living Code
 
-Sema programs can inspect, test, and rewrite themselves at runtime. Living Code is a set of special forms and stdlib functions that turn code into a conversational, self-aware medium -- programs that document themselves, answer questions about their own behavior, heal their own bugs, and evolve toward better solutions.
+Living Code extends Sema's [metaprogramming primitives](../language/metaprogramming.md) with LLM intelligence -- programs that answer questions about themselves, repair their own bugs, and evolve toward better solutions.
 
-::: warning
-Living Code features can change program behavior at runtime. Use doctests as contracts, `history`/`rollback!` for reversibility, and `freeze!` to stabilize proven code.
+These features require an LLM provider to be configured. See [Completion & Chat](./completion.md) for setup.
+
+::: tip Prerequisites
+Living Code builds on docstrings, doctests, `source-of`, `become!`, and `history`. If you're not familiar with those, read [Metaprogramming](../language/metaprogramming.md) first.
 :::
 
 ### Quick Taste
@@ -21,134 +23,21 @@ Living Code features can change program behavior at runtime. Use doctests as con
   (n)
   (if (<= n 1) 1 (* n (factorial (- n 1)))))
 
-;; Inspect
-(doc factorial)                ; pretty-print docs + source
-(source-of factorial)          ; => "(fn (n) (if (<= n 1) 1 ...))"
-(doctest factorial)            ; => {:passed 2 :total 2 :name "factorial"}
-
-;; Converse
+;; Ask questions about any value
 (ask factorial "Is this tail-recursive?")
 
-;; Upgrade
-(become! factorial
-  (fn (n) (let loop ((i n) (acc 1))
-    (if (<= i 1) acc (loop (- i 1) (* acc i))))))
+;; Get code suggestions
+(ask/code factorial "Make this tail-recursive")
 
-;; Review
-(history factorial)            ; => ({:version 1 :value <lambda> :source "..."})
+;; Auto-repair: LLM rewrites until all doctests pass
+(heal! parse-date)
+
+;; Evolve: breed candidates via LLM, scored by fitness
+(evolve :name "fast-sort" :spec '((>>> (fast-sort '(3 1 2)) (1 2 3)))
+        :fitness (fn (f r) (get r :passed)) :seed-prompt "Write a sort function.")
 ```
-
-## Docstrings & Doctests
-
-### `defn` with docstrings
-
-`defn` accepts an optional docstring as its second argument (before params). The docstring is stored as metadata and used by `doc`, `doctest`, `ask`, and `heal!`. The Scheme-style `define` also supports docstrings: `(define (f x) "docstring" body...)`.
-
-```sema
-(defn factorial "Compute n!.
-    >>> (factorial 0)
-    1
-    >>> (factorial 5)
-    120"
-  (n)
-  (if (<= n 1) 1 (* n (factorial (- n 1)))))
-```
-
-Doctest syntax:
-
-- `>>> expr` followed by expected result on the next line
-- `!! substring` expects an error containing substring
-- `>>>!` evaluates but doesn't check (setup)
-
-### `(doc sym)`
-
-Pretty-print documentation for a symbol. Shows name, parameters, docstring, and source.
-
-```sema
-(doc factorial)
-```
-
-### `(doc/search query)`
-
-Search all defined symbols by name or docstring content. Returns a list of `{:name ... :doc ...}` maps.
-
-```sema
-(doc/search "sort")    ; find all functions mentioning "sort"
-```
-
-### `(doctest sym)`
-
-Run all doctests from a symbol's docstring. Returns `{:passed n :total n :name "..."}`.
-
-```sema
-(doctest factorial)    ; => {:name "factorial" :passed 2 :total 2}
-```
-
-### `(meta sym)`
-
-Return all metadata for a symbol as a map. Includes `:name`, `:type`, `:params`, `:arity`, `:doc`, `:source`, `:variadic?`, and any custom metadata.
-
-```sema
-(meta factorial)
-; => {:arity 1 :doc "Compute n!. ..." :name "factorial" :params (n) :type :lambda}
-```
-
-### Testing from the CLI
-
-```bash
-sema test src/**/*.sema       # run all doctests in matching files
-sema test --heal src/lib.sema # run doctests, auto-heal failures with LLM
-```
-
-::: tip
-Treat docstrings as specifications: concise purpose + concrete examples. The LLM reads them during `ask`, `heal!`, and `evolve`.
-:::
-
-## Source Introspection
-
-### `(source-of sym)`
-
-Return the source text of a definition as a string.
-
-```sema
-(source-of factorial)  ; => "(fn (n) (if (<= n 1) 1 (* n (factorial (- n 1)))))"
-```
-
-### Reader directives: `;;@key value`
-
-Attach structured metadata to definitions using directive comments. Place them on the line before a `defn`, `define`, or `defmacro`.
-
-```sema
-;;@since 1.5
-;;@stability stable
-;;@author helge
-(defn parse-date "Parse a date string." (s) ...)
-```
-
-Directives are captured by the reader and available through `read-source`.
-
-### `(read-source path)`
-
-Read and parse source files, returning structured data for each top-level definition. Supports glob patterns.
-
-```sema
-(read-source "src/**/*.sema")
-; => list of {:type :defn :name "..." :doc "..." :params (...) :body (...) :directives {...} :source "..."}
-```
-
-::: tip
-Combine `read-source` with higher-order functions to build custom tooling:
-```sema
-;; Find all deprecated functions
-(->> (read-source "src/**/*.sema")
-     (filter #(get-in % [:directives :deprecated]))
-     (map :name))
-```
-:::
 
 ## Conversational Introspection
-
-These forms require an LLM provider to be configured.
 
 ### `(ask target question)`
 
@@ -163,14 +52,20 @@ Ask a natural-language question about any value. The LLM receives the value's so
 ; => "The password is hardcoded in plain text..."
 ```
 
+`ask` works on any value -- functions, maps, lists, strings. For functions, it automatically includes source code, parameters, and docstring in the LLM context.
+
 ### `(ask/code target instruction)`
 
-Like `ask`, but the LLM returns a Sema code expression that can be evaluated.
+Like `ask`, but the LLM returns a Sema code expression that can be evaluated or applied with [`become!`](../language/metaprogramming.md#become-sym-new-definition).
 
 ```sema
 (ask/code factorial "Make this tail-recursive")
 ; => "(fn (n) (let loop ((i n) (acc 1)) (if (<= i 1) acc (loop (- i 1) (* acc i)))))"
 ```
+
+::: warning
+`ask/code` returns a string containing code, not an evaluated result. Inspect it before applying with `become!`.
+:::
 
 ### `(heal! sym)`
 
@@ -192,82 +87,16 @@ Auto-repair a function by running its doctests. If any fail, the LLM is asked to
 ;; On success, the new implementation replaces the old one.
 ```
 
-::: warning
-`heal!` modifies the function in place. Use `(source-of sym)` after healing to inspect the new implementation, and `(history sym)` to see previous versions.
-:::
+`heal!` uses the doctest gate from `become!` -- each candidate must pass all doctests. The old version is saved to [`history`](../language/metaprogramming.md#history-sym).
 
-## Runtime Self-Modification
+You can also heal from the CLI:
 
-### `(observe! sym sample-size callback)`
-
-Wrap a function with an invisible logger. After `sample-size` calls, the original function is restored and `callback` is invoked with the call log (a list of `{:args ... :result ... :time-ms ...}` maps).
-
-```sema
-(defn fib "Fibonacci.
-    >>> (fib 0)
-    0
-    >>> (fib 10)
-    55"
-  (n) (if (<= n 1) n (+ (fib (- n 1)) (fib (- n 2)))))
-
-(observe! fib 100
-  (fn (log)
-    (let ((total-ms (foldl + 0 (map #(get % :time-ms) log)))
-          (unique-args (length (dedup (map #(get % :args) log)))))
-      (println f"100 calls: ${total-ms}ms total, ${unique-args} unique inputs"))))
-
-;; Now use fib normally — after 100 calls, the callback fires and fib is restored.
-```
-
-### `(become! sym new-definition)`
-
-Replace a function's definition at runtime. If the function has doctests, the candidate must pass all of them or the replacement is rejected. Saves the old version to history.
-
-```sema
-;; Upgrade fib to a memoized version
-(become! fib
-  (let ((cache {}))
-    (fn (n)
-      (or (get cache n)
-          (let ((v (if (<= n 1) n (+ (fib (- n 1)) (fib (- n 2))))))
-            (set! cache (assoc cache n v))
-            v)))))
-;; Doctests run automatically — if they fail, fib is unchanged.
-```
-
-::: danger
-`become!` is powerful but dangerous. Always ensure functions have doctests before using it in production. The doctest gate is your safety net.
-:::
-
-### `(history sym)`
-
-Return the version history of a binding as a list of `{:version n :value <old-fn> :source "..."}` maps. Each `become!` and `rollback!` creates a history entry.
-
-```sema
-(history fib)
-; => ({:version 1 :value <lambda> :source "(fn (n) ...)"})
-```
-
-### `(rollback! sym version)`
-
-Restore a previous version from history. Creates a new history entry for the current version before rolling back.
-
-```sema
-(rollback! fib 1)   ; restore the original implementation
-(fib 10)            ; => 55 (works, but slow again)
-```
-
-### `(freeze! sym)`
-
-Permanently prevent further `become!` or `rollback!` on a function. Use this to stabilize proven implementations.
-
-```sema
-(freeze! fib)
-(become! fib (fn (n) 0))  ; => Error: 'fib' is frozen and cannot be modified
+```bash
+sema test --heal src/lib.sema   # run doctests, auto-heal failures
 ```
 
 ::: tip
-The safety workflow: `observe!` to understand behavior, `become!` to upgrade (gated by doctests), `history` to inspect changes, `rollback!` if something goes wrong, `freeze!` once stable.
+`heal!` works best with small, well-specified functions. Write tight doctests that cover edge cases -- the LLM uses them as both the specification and the acceptance criteria.
 :::
 
 ## Genetic Programming
@@ -368,11 +197,11 @@ The fitness function receives two arguments: the candidate function value and a 
 Start with correctness-only fitness. Once `evolve` reliably produces correct candidates, add performance objectives.
 :::
 
-## Putting It Together
+## Scenarios
 
-### Scenario 1: Self-Healing Parser
+### Self-Healing Parser
 
-A date parser that handles ISO format but breaks on other inputs. Define the full specification as doctests, then let the system heal itself:
+Define the full specification as doctests, then let the system heal itself:
 
 ```sema
 (defn parse-date "Parse date strings into ISO format.
@@ -384,25 +213,16 @@ A date parser that handles ISO format but breaks on other inputs. Define the ful
     \"2024-01-15\""
   (s) s)
 
-;; Check what fails
-(doctest parse-date)     ; => {:passed 1 :total 3 :name "parse-date"}
-
-;; Auto-repair
-(heal! parse-date)
-
-;; Verify
-(doctest parse-date)     ; => {:passed 3 :total 3 :name "parse-date"}
-
-;; Inspect what changed
-(source-of parse-date)
-
-;; Lock it down
-(freeze! parse-date)
+(doctest parse-date)     ; => {:passed 1 :total 3}
+(heal! parse-date)       ; LLM fixes it
+(doctest parse-date)     ; => {:passed 3 :total 3}
+(source-of parse-date)   ; inspect the new implementation
+(freeze! parse-date)     ; lock it down
 ```
 
-### Scenario 2: Adaptive Memoization
+### Observe, Ask, Upgrade
 
-A function that's expensive for repeated calls. Use `observe!` to collect usage data, then let the LLM decide how to optimize:
+Use [`observe!`](../language/metaprogramming.md#observe-sym-sample-size-callback) to collect usage data, then let the LLM decide how to optimize:
 
 ```sema
 (defn compute "Expensive computation.
@@ -418,17 +238,14 @@ A function that's expensive for repeated calls. Use `observe!` to collect usage 
     (let ((unique (length (dedup (map #(get % :args) log))))
           (total  (length log)))
       (when (< unique (/ total 2))
-        ;; Many repeated calls — ask for memoization
+        ;; Many repeated calls -- ask for memoization
         (let ((suggestion (ask/code compute "Add memoization")))
           (println f"Suggested:\n${suggestion}"))))))
-
-;; ... use compute normally ...
-;; After 50 calls, the callback fires with the analysis
 ```
 
-### Scenario 3: Evolving for Performance
+### Evolving for Performance
 
-Use `evolve` to find the fastest implementation of a function, then benchmark and freeze the winner:
+Use `evolve` to find the fastest implementation, then benchmark and freeze:
 
 ```sema
 (define best-fib
@@ -453,20 +270,18 @@ Use `evolve` to find the fastest implementation of a function, then benchmark an
 
 ## Best Practices
 
-1. **Doctests are contracts.** Every function that participates in `become!`, `heal!`, or `evolve` should have doctests. They are the safety net that prevents regressions.
+1. **Doctests are contracts.** Every function that participates in `heal!` or `evolve` needs doctests. They are what the LLM tries to satisfy.
 
 2. **Keep targets small.** Don't `ask` or `heal!` an entire module. Target individual functions with clear specifications.
 
-3. **Use history and rollback.** Before `become!`, know that you can always `(rollback! sym 1)` to get back. Check `(history sym)` to see what changed.
+3. **Inspect before applying.** Use `ask` to understand, `ask/code` to generate, review the output, then `become!` to apply.
 
-4. **Freeze stable code.** Once a function is battle-tested, `(freeze! sym)` prevents accidental modification.
+4. **Use `observe!` before optimizing.** Measure before you modify. Let the data tell you what to optimize.
 
-5. **Start with `ask` before `ask/code`.** Use `ask` to understand the problem, `ask/code` to generate a solution, and `become!` to apply it -- not all at once.
-
-6. **Use `observe!` before optimizing.** Measure before you modify. Let the data tell you what to optimize.
+5. **Freeze after healing.** Once `heal!` or `evolve` produces a good result, `(freeze! sym)` prevents accidental modification.
 
 ## Related
 
-- [Completion & Chat](./completion.md) -- LLM provider configuration needed for `ask`, `heal!`, and `evolve`
+- [Metaprogramming](../language/metaprogramming.md) -- docstrings, doctests, introspection, `become!`/`rollback!`/`freeze!` (no LLM needed)
+- [Completion & Chat](./completion.md) -- LLM provider setup
 - [Tools & Agents](./tools-agents.md) -- structured LLM interactions
-- [Special Forms](../language/special-forms.md) -- full language reference

--- a/website/docs/llm/prompts.md
+++ b/website/docs/llm/prompts.md
@@ -21,7 +21,7 @@ The core idea: build small prompt pieces, compose them together, fill in templat
 
 ;; Compose, fill, and send
 (define p (prompt/concat safety domain task))
-(define ready (prompt/fill p {:code "(define (f x) (+ x 1))"}))
+(define ready (prompt/fill p {:code "(defn f (x) (+ x 1))"}))
 (llm/send ready {:max-tokens 300})
 ```
 

--- a/website/docs/packages.md
+++ b/website/docs/packages.md
@@ -406,10 +406,10 @@ Edit the generated `package.sema` to define your package's API:
 
 ```sema
 ;; package.sema — package entrypoint
-(defun parse-row (line)
+(defn parse-row (line)
   (map string/trim (string/split line ",")))
 
-(defun parse-csv (text)
+(defn parse-csv (text)
   (map parse-row (string/split text "\n")))
 ```
 
@@ -424,7 +424,7 @@ This fetches the package and adds it to your `sema.toml` automatically. Then use
 ```sema
 (import "http-helpers")
 
-(defun fetch-csv (url)
+(defn fetch-csv (url)
   (parse-csv (:body (http-helpers/get url))))
 ```
 

--- a/website/docs/stdlib/context.md
+++ b/website/docs/stdlib/context.md
@@ -212,7 +212,7 @@ Hidden context is **not** included in log output.
 ### Pipeline breadcrumbs
 
 ```sema
-(define (process-document doc)
+(defn process-document (doc)
   (context/push :steps "parse")
   (let ((parsed (parse doc)))
     (context/push :steps "validate")

--- a/website/docs/stdlib/csv.md
+++ b/website/docs/stdlib/csv.md
@@ -205,6 +205,6 @@ Compute an HMAC-SHA256 message authentication code. Returns a 64-character hex s
 
 ```sema
 ;; Verify a webhook signature from a provider
-(define (verify-webhook payload secret signature)
+(defn verify-webhook (payload secret signature)
   (equal? (hash/hmac-sha256 secret payload) signature))
 ```

--- a/website/docs/stdlib/http-json.md
+++ b/website/docs/stdlib/http-json.md
@@ -220,7 +220,7 @@ Network errors (DNS failure, connection refused, timeout) throw a `SemaError::Io
 #### Paginated API Requests
 
 ```sema
-(define (fetch-all-pages base-url)
+(defn fetch-all-pages (base-url)
   (let loop ((page 1) (results '()))
     (define resp (http/get (format "~a?page=~a" base-url page)))
     (define data (json/decode (:body resp)))

--- a/website/docs/stdlib/records.md
+++ b/website/docs/stdlib/records.md
@@ -69,7 +69,7 @@ The constructor is positional — its arity must match exactly:
 Sema records are immutable. To "update" a record, construct a new one:
 
 ```sema
-(define (move-point p dx dy)
+(defn move-point (p dx dy)
   (make-point (+ (point-x p) dx)
               (+ (point-y p) dy)))
 
@@ -167,7 +167,7 @@ Records can contain any values, including other records:
 Records don't have a dedicated pattern form, but you can use binding patterns with `when` guards:
 
 ```sema
-(define (describe v)
+(defn describe (v)
   (match v
     (p when (point? p)
        (string/append "point("
@@ -184,7 +184,7 @@ Records don't have a dedicated pattern form, but you can use binding patterns wi
 You can also match on `type`:
 
 ```sema
-(define (record-type-name v)
+(defn record-type-name (v)
   (match (type v)
     (:point "a point")
     (:person "a person")
@@ -201,7 +201,7 @@ Use records to represent values that have been validated:
   email?
   (value email-value))
 
-(define (parse-email s)
+(defn parse-email (s)
   (if (regex/match? #".+@.+\..+" s)
       (make-email s)
       (error "invalid email")))
@@ -245,7 +245,7 @@ Use records to represent values that have been validated:
 Records are **not JSON-encodable** directly. If you need to serialize a record, convert it to a map first:
 
 ```sema
-(define (point->map p)
+(defn point->map (p)
   {:x (point-x p) :y (point-y p)})
 
 (json/encode (point->map (make-point 1 2)))

--- a/website/docs/stdlib/regex.md
+++ b/website/docs/stdlib/regex.md
@@ -190,7 +190,7 @@ Use regex when you need character classes, repetition, alternation, or capture g
 ### Validate an identifier
 
 ```sema
-(define (identifier? s)
+(defn identifier? (s)
   (regex/match? #"^[A-Za-z_][A-Za-z0-9_]*$" s))
 
 (identifier? "foo_1")   ; => #t
@@ -200,7 +200,7 @@ Use regex when you need character classes, repetition, alternation, or capture g
 ### Extract a number from text
 
 ```sema
-(define (extract-first-int s)
+(defn extract-first-int (s)
   (let ((m (regex/match #"\d+" s)))
     (if (nil? m)
         nil
@@ -219,7 +219,7 @@ Use regex when you need character classes, repetition, alternation, or capture g
 ### Parse key-value pairs
 
 ```sema
-(define (parse-kv line)
+(defn parse-kv (line)
   (let ((m (regex/match #"^(\w+)\s*=\s*(.+)$" line)))
     (if (nil? m)
         nil

--- a/website/docs/stdlib/terminal.md
+++ b/website/docs/stdlib/terminal.md
@@ -312,10 +312,10 @@ Multiple spinners can run concurrently — each gets a unique ID:
 ### Colored Log Levels
 
 ```sema
-(define (log-error msg)   (println (term/style "✗ ERROR" :bold :red) " " msg))
-(define (log-warn msg)    (println (term/style "⚠ WARN " :bold :yellow) " " msg))
-(define (log-info msg)    (println (term/style "ℹ INFO " :bold :blue) " " msg))
-(define (log-success msg) (println (term/style "✔ OK   " :bold :green) " " msg))
+(defn log-error (msg)   (println (term/style "✗ ERROR" :bold :red) " " msg))
+(defn log-warn (msg)    (println (term/style "⚠ WARN " :bold :yellow) " " msg))
+(defn log-info (msg)    (println (term/style "ℹ INFO " :bold :blue) " " msg))
+(defn log-success (msg) (println (term/style "✔ OK   " :bold :green) " " msg))
 
 (log-error "Connection refused")
 (log-warn "Retrying in 5s")
@@ -326,7 +326,7 @@ Multiple spinners can run concurrently — each gets a unique ID:
 ### CLI Status Output
 
 ```sema
-(define (print-step label detail)
+(defn print-step (label detail)
   (println (term/style label :bold :cyan) " " (term/dim detail)))
 
 (print-step "Compile" "src/main.sema")
@@ -351,7 +351,7 @@ Multiple spinners can run concurrently — each gets a unique ID:
 ### Conditional Styling
 
 ```sema
-(define (color-status code)
+(defn color-status (code)
   (cond
     ((< code 300) (term/green (number/to-string code)))
     ((< code 400) (term/yellow (number/to-string code)))

--- a/website/docs/stdlib/vectors.md
+++ b/website/docs/stdlib/vectors.md
@@ -195,7 +195,7 @@ Note: `tail` is a **list**, not a vector.
 `match` supports vector patterns:
 
 ```sema
-(define (describe-point p)
+(defn describe-point (p)
   (match p
     ([0 0] "origin")
     ([x 0] (string/append "on x-axis at " (number/to-string x)))
@@ -213,7 +213,7 @@ Note: `tail` is a **list**, not a vector.
 Vectors are great for fixed-arity return values:
 
 ```sema
-(define (min-max xs)
+(defn min-max (xs)
   [(list/min xs) (list/max xs)])
 
 (min-max '(3 1 4 1 5))

--- a/website/docs/stdlib/web-server.md
+++ b/website/docs/stdlib/web-server.md
@@ -9,7 +9,7 @@ Sema includes a built-in HTTP server powered by [axum](https://github.com/tokio-
 ## Quick Start
 
 ```sema
-(define (handler req)
+(defn handler (req)
   (http/ok {:message "Hello from Sema!"}))
 
 (http/serve handler {:port 3000})
@@ -68,7 +68,7 @@ Use `:param` syntax to capture path segments. Extracted values appear in the req
 ;; Route: [:get "/users/:id" handle-user]
 ;; Request: GET /users/42
 
-(define (handle-user req)
+(defn handle-user (req)
   (let ((id (:id (:params req))))
     (http/ok {:user-id id})))
 ; => {"user-id":"42"}
@@ -273,7 +273,7 @@ Middleware in Sema is just function composition — a function that takes a hand
 
 ```sema
 ;; Logging middleware
-(define (with-logging handler)
+(defn with-logging (handler)
   (fn (req)
     (let ((resp (handler req)))
       (println (:method req) (:path req) "->" (:status resp))
@@ -282,7 +282,7 @@ Middleware in Sema is just function composition — a function that takes a hand
 
 ```sema
 ;; CORS middleware
-(define (with-cors handler)
+(defn with-cors (handler)
   (fn (req)
     (let ((resp (handler req)))
       (assoc resp :headers
@@ -293,7 +293,7 @@ Middleware in Sema is just function composition — a function that takes a hand
 
 ```sema
 ;; Auth middleware
-(define (with-auth handler)
+(defn with-auth (handler)
   (fn (req)
     (let ((token (get (:headers req) "authorization")))
       (if token
@@ -332,7 +332,7 @@ Or use the threading macro for a cleaner pipeline:
 Return a Server-Sent Events stream. Takes a handler function that receives a `send` callback.
 
 ```sema
-(define (handle-events req)
+(defn handle-events (req)
   (http/stream
     (fn (send)
       (send "connected")
@@ -364,7 +364,7 @@ data: update 2
 SSE is particularly useful for streaming LLM completions to the browser:
 
 ```sema
-(define (handle-chat req)
+(defn handle-chat (req)
   (http/stream
     (fn (send)
       (let ((prompt (:prompt (:json req))))
@@ -380,7 +380,7 @@ SSE is particularly useful for streaming LLM completions to the browser:
 Handle bidirectional WebSocket connections. Takes a handler function that receives a connection map with `:send`, `:recv`, and `:close` functions.
 
 ```sema
-(define (handle-ws conn)
+(defn handle-ws (conn)
   (let ((msg ((:recv conn))))
     (when msg
       ((:send conn) (string/append "echo: " msg))
@@ -412,11 +412,11 @@ Use the `:ws` method in the router:
 ```sema
 (define clients (atom '()))
 
-(define (broadcast msg)
+(defn broadcast (msg)
   (for-each (fn (send) (send msg))
             @clients))
 
-(define (handle-ws conn)
+(defn handle-ws (conn)
   ;; Add this client's send function to the list
   (swap! clients (fn (lst) (cons (:send conn) lst)))
   ;; Read loop
@@ -442,41 +442,41 @@ A JSON API with CRUD operations, middleware, and error handling.
 (define db (atom {}))
 (define next-id (atom 0))
 
-(define (gen-id)
+(defn gen-id ()
   (swap! next-id (fn (n) (+ n 1)))
   @next-id)
 
 ;; Handlers
-(define (list-users _)
+(defn list-users (_)
   (http/ok (vals @db)))
 
-(define (get-user req)
+(defn get-user (req)
   (let ((id (:id (:params req)))
         (user (get @db id)))
     (if user
       (http/ok user)
       (http/not-found {:error "User not found"}))))
 
-(define (create-user req)
+(defn create-user (req)
   (let ((data (:json req))
         (id   (str (gen-id)))
         (user (assoc data :id id)))
     (swap! db (fn (d) (assoc d id user)))
     (http/created user)))
 
-(define (delete-user req)
+(defn delete-user (req)
   (let ((id (:id (:params req))))
     (swap! db (fn (d) (dissoc d id)))
     (http/no-content)))
 
 ;; Middleware
-(define (with-json-errors handler)
+(defn with-json-errors (handler)
   (fn (req)
     (let ((resp (handler req)))
       (if (map? resp) resp
         (http/error 500 {:error "Internal server error"})))))
 
-(define (with-cors handler)
+(defn with-cors (handler)
   (fn (req)
     (let ((resp (handler req)))
       (assoc resp :headers
@@ -505,13 +505,13 @@ A JSON API with CRUD operations, middleware, and error handling.
 An API endpoint that uses Sema's built-in LLM primitives to generate responses.
 
 ```sema
-(define (handle-summarize req)
+(defn handle-summarize (req)
   (let ((text (:text (:json req))))
     (if text
       (http/ok {:summary (llm/chat (str "Summarize this:\n\n" text))})
       (http/error 400 {:error "Missing 'text' field"}))))
 
-(define (handle-extract req)
+(defn handle-extract (req)
   (let ((text (:text (:json req))))
     (http/ok (llm/extract text {:name "string"
                                  :date "string"
@@ -530,16 +530,16 @@ An API endpoint that uses Sema's built-in LLM primitives to generate responses.
 Serve dynamic HTML pages.
 
 ```sema
-(define (page title body)
+(defn page (title body)
   (http/html
     (str "<!DOCTYPE html><html><head><title>" title "</title>"
          "<style>body{font-family:sans-serif;max-width:800px;margin:0 auto;padding:2rem}</style>"
          "</head><body>" body "</body></html>")))
 
-(define (handle-home _)
+(defn handle-home (_)
   (page "Home" "<h1>Welcome</h1><p>Built with Sema.</p>"))
 
-(define (handle-greet req)
+(defn handle-greet (req)
   (let ((name (or (:name (:params req)) "world")))
     (page "Greeting" (str "<h1>Hello, " name "!</h1>"))))
 


### PR DESCRIPTION
## Summary
- Implements Living Code phases 1-4: docstrings, doctests, introspection (`become!`/`rollback!`), and self-modification
- Adds `evolve` special form for LLM-driven genetic programming
- Documentation: Living Code guide and metaprogramming reference pages
- Makes `defn` the canonical function definition form

## Test plan
- [ ] Verify docstrings attach correctly to functions
- [ ] Test doctests run and validate
- [ ] Test `become!`/`rollback!` recursive doctest validation and source metadata sync
- [ ] Test `evolve` with an LLM provider configured