### PR TITLE
MCP server mode: expose deftool definitions as MCP tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2781,6 +2781,7 @@ dependencies = [
  "sema-fmt",
  "sema-llm",
  "sema-lsp",
+ "sema-mcp",
  "sema-notebook",
  "sema-reader",
  "sema-stdlib",
@@ -2826,6 +2827,16 @@ dependencies = [
  "serde_json",
  "tokio",
  "tower-lsp",
+]
+
+[[package]]
+name = "sema-mcp"
+version = "1.13.0"
+dependencies = [
+ "sema-core",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/sema-lsp",
     "crates/sema-dap",
     "crates/sema-notebook",
+    "crates/sema-mcp",
 ]
 exclude = ["pkg"]
 resolver = "2"
@@ -34,6 +35,7 @@ sema-fmt = { version = "=1.13.0", path = "crates/sema-fmt" }
 sema-lsp = { version = "=1.13.0", path = "crates/sema-lsp" }
 sema-dap = { version = "=1.13.0", path = "crates/sema-dap" }
 sema-notebook = { version = "=1.13.0", path = "crates/sema-notebook" }
+sema-mcp = { version = "=1.13.0", path = "crates/sema-mcp" }
 
 tower-lsp = "0.20"
 dashmap = "6"

--- a/crates/sema-mcp/Cargo.toml
+++ b/crates/sema-mcp/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "sema-mcp"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "MCP (Model Context Protocol) server for Sema"
+
+[dependencies]
+sema-core.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true

--- a/crates/sema-mcp/src/lib.rs
+++ b/crates/sema-mcp/src/lib.rs
@@ -1,0 +1,348 @@
+//! MCP (Model Context Protocol) server for Sema.
+//!
+//! Exposes all `deftool` definitions from a Sema script as MCP tools,
+//! communicating via JSON-RPC 2.0 over stdio.
+
+use sema_core::{call_callback, json_to_value, value_to_json_lossy, EvalContext, Value};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::io::{self, BufRead, Write};
+use std::rc::Rc;
+
+/// A discovered tool from the Sema environment.
+pub struct McpTool {
+    pub name: String,
+    pub description: String,
+    pub parameters: Value,
+    pub handler: Value,
+}
+
+/// Scan an environment for all `ToolDef` values and return them.
+pub fn discover_tools(env: &sema_core::Env) -> Vec<McpTool> {
+    let mut tools = Vec::new();
+    let names = env.all_names();
+    for spur in names {
+        if let Some(val) = env.get(spur) {
+            if let Some(td) = val.as_tool_def_rc() {
+                tools.push(McpTool {
+                    name: td.name.clone(),
+                    description: td.description.clone(),
+                    parameters: td.parameters.clone(),
+                    handler: td.handler.clone(),
+                });
+            }
+        }
+    }
+    tools
+}
+
+/// Convert a Sema parameter schema to JSON Schema (same logic as sema-llm).
+fn sema_params_to_json_schema(val: &Value) -> serde_json::Value {
+    if let Some(map) = val.as_map_rc() {
+        let mut properties = serde_json::Map::new();
+        let mut required = Vec::new();
+        for (k, v) in map.iter() {
+            let key = k
+                .as_keyword()
+                .or_else(|| k.as_str().map(|s| s.to_string()))
+                .unwrap_or_else(|| k.to_string());
+            let prop = if let Some(inner) = v.as_map_rc() {
+                let mut prop_obj = serde_json::Map::new();
+                if let Some(t) = inner.get(&Value::keyword("type")) {
+                    let type_str = t
+                        .as_keyword()
+                        .or_else(|| t.as_str().map(|s| s.to_string()))
+                        .unwrap_or_else(|| "string".to_string());
+                    prop_obj.insert("type".to_string(), serde_json::Value::String(type_str));
+                }
+                if let Some(d) = inner.get(&Value::keyword("description")) {
+                    let desc = d
+                        .as_str()
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| d.to_string());
+                    prop_obj.insert("description".to_string(), serde_json::Value::String(desc));
+                }
+                if let Some(e) = inner.get(&Value::keyword("enum")) {
+                    if let Some(items) = e.as_seq() {
+                        let vals: Vec<serde_json::Value> = items
+                            .iter()
+                            .map(|v| {
+                                serde_json::Value::String(
+                                    v.as_str()
+                                        .map(|s| s.to_string())
+                                        .or_else(|| v.as_keyword())
+                                        .unwrap_or_else(|| v.to_string()),
+                                )
+                            })
+                            .collect();
+                        prop_obj.insert("enum".to_string(), serde_json::Value::Array(vals));
+                    }
+                }
+                let optional = inner
+                    .get(&Value::keyword("optional"))
+                    .map(|v| v.is_truthy())
+                    .unwrap_or(false);
+                if !optional {
+                    required.push(serde_json::Value::String(key.clone()));
+                }
+                serde_json::Value::Object(prop_obj)
+            } else {
+                required.push(serde_json::Value::String(key.clone()));
+                serde_json::json!({"type": "string"})
+            };
+            properties.insert(key, prop);
+        }
+        serde_json::json!({
+            "type": "object",
+            "properties": properties,
+            "required": required
+        })
+    } else {
+        serde_json::json!({"type": "object", "properties": {}})
+    }
+}
+
+// ── JSON-RPC types ──────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct JsonRpcRequest {
+    #[allow(dead_code)]
+    jsonrpc: String,
+    id: Option<serde_json::Value>,
+    method: String,
+    #[serde(default)]
+    params: serde_json::Value,
+}
+
+#[derive(Serialize)]
+struct JsonRpcResponse {
+    jsonrpc: String,
+    id: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<JsonRpcError>,
+}
+
+#[derive(Serialize)]
+struct JsonRpcError {
+    code: i64,
+    message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<serde_json::Value>,
+}
+
+impl JsonRpcResponse {
+    fn success(id: serde_json::Value, result: serde_json::Value) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            id,
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    fn error(id: serde_json::Value, code: i64, message: impl Into<String>) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            id,
+            result: None,
+            error: Some(JsonRpcError {
+                code,
+                message: message.into(),
+                data: None,
+            }),
+        }
+    }
+}
+
+// ── MCP Server ──────────────────────────────────────────────────────
+
+/// Run the MCP server over stdio with the given discovered tools and eval context.
+pub fn run_server(
+    tools: Vec<McpTool>,
+    ctx: &EvalContext,
+    env: &Rc<sema_core::Env>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    let reader = stdin.lock();
+    let mut writer = stdout.lock();
+
+    // Build tool list response once
+    let tools_list: Vec<serde_json::Value> = tools
+        .iter()
+        .map(|t| {
+            serde_json::json!({
+                "name": t.name,
+                "description": t.description,
+                "inputSchema": sema_params_to_json_schema(&t.parameters),
+            })
+        })
+        .collect();
+
+    // Build a lookup map for tool handlers
+    let tool_map: BTreeMap<String, &McpTool> = tools.iter().map(|t| (t.name.clone(), t)).collect();
+
+    for line in reader.lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => break,
+        };
+
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let req: JsonRpcRequest = match serde_json::from_str(line) {
+            Ok(r) => r,
+            Err(e) => {
+                let resp = JsonRpcResponse::error(
+                    serde_json::Value::Null,
+                    -32700,
+                    format!("Parse error: {e}"),
+                );
+                write_response(&mut writer, &resp)?;
+                continue;
+            }
+        };
+
+        // Notifications (no id) don't get responses
+        if req.id.is_none() {
+            // Handle notifications/initialized silently
+            continue;
+        }
+
+        let id = req.id.unwrap_or(serde_json::Value::Null);
+
+        let resp = match req.method.as_str() {
+            "initialize" => JsonRpcResponse::success(
+                id,
+                serde_json::json!({
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {
+                        "tools": {}
+                    },
+                    "serverInfo": {
+                        "name": "sema-mcp",
+                        "version": env!("CARGO_PKG_VERSION")
+                    }
+                }),
+            ),
+            "ping" => JsonRpcResponse::success(id, serde_json::json!({})),
+            "tools/list" => JsonRpcResponse::success(
+                id,
+                serde_json::json!({
+                    "tools": tools_list
+                }),
+            ),
+            "tools/call" => handle_tool_call(id, &req.params, &tool_map, ctx, env),
+            _ => JsonRpcResponse::error(id, -32601, format!("Method not found: {}", req.method)),
+        };
+
+        write_response(&mut writer, &resp)?;
+    }
+
+    Ok(())
+}
+
+fn handle_tool_call(
+    id: serde_json::Value,
+    params: &serde_json::Value,
+    tool_map: &BTreeMap<String, &McpTool>,
+    ctx: &EvalContext,
+    _env: &Rc<sema_core::Env>,
+) -> JsonRpcResponse {
+    let tool_name = params.get("name").and_then(|v| v.as_str()).unwrap_or("");
+
+    let tool = match tool_map.get(tool_name) {
+        Some(t) => t,
+        None => {
+            return JsonRpcResponse::error(id, -32602, format!("Unknown tool: {tool_name}"));
+        }
+    };
+
+    // Extract arguments from params.arguments
+    let arguments = params
+        .get("arguments")
+        .cloned()
+        .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
+
+    // Build argument list in parameter order
+    let args = build_args_from_params(&tool.parameters, &arguments);
+
+    // Call the handler
+    match call_callback(ctx, &tool.handler, &args) {
+        Ok(result) => {
+            let result_str = match result.as_str() {
+                Some(s) => s.to_string(),
+                None => {
+                    // Convert to JSON and then to string
+                    let json = value_to_json_lossy(&result);
+                    match json {
+                        serde_json::Value::String(s) => s,
+                        other => other.to_string(),
+                    }
+                }
+            };
+            JsonRpcResponse::success(
+                id,
+                serde_json::json!({
+                    "content": [{
+                        "type": "text",
+                        "text": result_str
+                    }]
+                }),
+            )
+        }
+        Err(e) => JsonRpcResponse::success(
+            id,
+            serde_json::json!({
+                "content": [{
+                    "type": "text",
+                    "text": format!("Error: {e}")
+                }],
+                "isError": true
+            }),
+        ),
+    }
+}
+
+/// Build positional args from JSON arguments object, ordered by parameter definition.
+fn build_args_from_params(params: &Value, arguments: &serde_json::Value) -> Vec<Value> {
+    let args_obj = arguments.as_object();
+    if let Some(map) = params.as_map_rc() {
+        map.keys()
+            .map(|k| {
+                let key = k
+                    .as_keyword()
+                    .or_else(|| k.as_str().map(|s| s.to_string()))
+                    .unwrap_or_else(|| k.to_string());
+                match args_obj.and_then(|obj| obj.get(&key)) {
+                    Some(v) => json_to_value(v),
+                    None => Value::nil(),
+                }
+            })
+            .collect()
+    } else if let Some(obj) = args_obj {
+        // No schema — pass all values as a map
+        let mut map = BTreeMap::new();
+        for (k, v) in obj {
+            map.insert(Value::keyword(k), json_to_value(v));
+        }
+        vec![Value::map(map)]
+    } else {
+        vec![]
+    }
+}
+
+fn write_response(
+    writer: &mut impl Write,
+    resp: &JsonRpcResponse,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let json = serde_json::to_string(resp)?;
+    writeln!(writer, "{json}")?;
+    writer.flush()?;
+    Ok(())
+}

--- a/crates/sema-mcp/tests/mcp_test.rs
+++ b/crates/sema-mcp/tests/mcp_test.rs
@@ -46,7 +46,7 @@ fn test_mcp_server_initialize_and_list_tools() {
     .unwrap();
 
     let mut child = Command::new(sema_bin())
-        .args(["serve", "--no-llm", tool_file.to_str().unwrap()])
+        .args(["mcp", "--no-llm", tool_file.to_str().unwrap()])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -160,7 +160,7 @@ fn test_mcp_server_with_compiled_bytecode() {
 
     // Serve the compiled bytecode
     let mut child = Command::new(sema_bin())
-        .args(["serve", "--no-llm", bytecode_file.to_str().unwrap()])
+        .args(["mcp", "--no-llm", bytecode_file.to_str().unwrap()])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -227,7 +227,7 @@ fn test_mcp_server_unknown_tool() {
     std::fs::write(&tool_file, "(define x 42)\n").unwrap();
 
     let mut child = Command::new(sema_bin())
-        .args(["serve", "--no-llm", tool_file.to_str().unwrap()])
+        .args(["mcp", "--no-llm", tool_file.to_str().unwrap()])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/crates/sema-mcp/tests/mcp_test.rs
+++ b/crates/sema-mcp/tests/mcp_test.rs
@@ -1,0 +1,173 @@
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Command, Stdio};
+
+fn sema_bin() -> String {
+    let mut path = std::env::current_exe()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    path.push("sema");
+    path.to_string_lossy().to_string()
+}
+
+fn send_and_recv(
+    stdin: &mut impl Write,
+    stdout: &mut impl BufRead,
+    request: &serde_json::Value,
+) -> serde_json::Value {
+    let req_str = serde_json::to_string(request).unwrap();
+    writeln!(stdin, "{req_str}").unwrap();
+    stdin.flush().unwrap();
+
+    let mut line = String::new();
+    stdout.read_line(&mut line).unwrap();
+    serde_json::from_str(line.trim()).unwrap()
+}
+
+#[test]
+fn test_mcp_server_initialize_and_list_tools() {
+    // Write a temp sema file with a deftool
+    let dir = std::env::temp_dir().join("sema-mcp-test");
+    std::fs::create_dir_all(&dir).unwrap();
+    let tool_file = dir.join("tools.sema");
+    std::fs::write(
+        &tool_file,
+        r#"
+(deftool greet
+  "Greet someone by name"
+  {:name {:type :string :description "The name to greet"}}
+  (lambda (name)
+    (string-append "Hello, " name "!")))
+"#,
+    )
+    .unwrap();
+
+    let mut child = Command::new(sema_bin())
+        .args(["serve", "--no-llm", tool_file.to_str().unwrap()])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to start sema serve");
+
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+
+    // 1. Initialize
+    let resp = send_and_recv(
+        &mut stdin,
+        &mut stdout,
+        &serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "test", "version": "0.1.0"}
+            }
+        }),
+    );
+    assert_eq!(resp["result"]["protocolVersion"], "2024-11-05");
+    assert!(resp["result"]["capabilities"]["tools"].is_object());
+
+    // 2. Send initialized notification (no response expected)
+    let notif = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/initialized"
+    });
+    writeln!(stdin, "{}", serde_json::to_string(&notif).unwrap()).unwrap();
+    stdin.flush().unwrap();
+
+    // 3. List tools
+    let resp = send_and_recv(
+        &mut stdin,
+        &mut stdout,
+        &serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+            "params": {}
+        }),
+    );
+    let tools = resp["result"]["tools"].as_array().unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0]["name"], "greet");
+    assert_eq!(tools[0]["description"], "Greet someone by name");
+    assert!(tools[0]["inputSchema"]["properties"]["name"].is_object());
+
+    // 4. Call a tool
+    let resp = send_and_recv(
+        &mut stdin,
+        &mut stdout,
+        &serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "greet",
+                "arguments": {"name": "World"}
+            }
+        }),
+    );
+    let content = resp["result"]["content"].as_array().unwrap();
+    assert_eq!(content[0]["type"], "text");
+    assert_eq!(content[0]["text"], "Hello, World!");
+
+    // Clean up
+    drop(stdin);
+    child.kill().ok();
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn test_mcp_server_unknown_tool() {
+    let dir = std::env::temp_dir().join("sema-mcp-test-2");
+    std::fs::create_dir_all(&dir).unwrap();
+    let tool_file = dir.join("empty.sema");
+    std::fs::write(&tool_file, "(define x 42)\n").unwrap();
+
+    let mut child = Command::new(sema_bin())
+        .args(["serve", "--no-llm", tool_file.to_str().unwrap()])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to start sema serve");
+
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+
+    // Initialize first
+    send_and_recv(
+        &mut stdin,
+        &mut stdout,
+        &serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {}
+        }),
+    );
+
+    // Call a non-existent tool
+    let resp = send_and_recv(
+        &mut stdin,
+        &mut stdout,
+        &serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": "nonexistent", "arguments": {}}
+        }),
+    );
+    assert!(resp["error"].is_object());
+    assert_eq!(resp["error"]["code"], -32602);
+
+    drop(stdin);
+    child.kill().ok();
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/crates/sema-mcp/tests/mcp_test.rs
+++ b/crates/sema-mcp/tests/mcp_test.rs
@@ -124,6 +124,102 @@ fn test_mcp_server_initialize_and_list_tools() {
 }
 
 #[test]
+fn test_mcp_server_with_compiled_bytecode() {
+    // Compile a .sema file to .semac, then serve it
+    let dir = std::env::temp_dir().join("sema-mcp-test-semac");
+    std::fs::create_dir_all(&dir).unwrap();
+    let source_file = dir.join("tools.sema");
+    let bytecode_file = dir.join("tools.semac");
+    std::fs::write(
+        &source_file,
+        r#"
+(deftool reverse-text
+  "Reverse a string"
+  {:text {:type :string :description "Text to reverse"}}
+  (lambda (text)
+    (list->string (reverse (string->list text)))))
+"#,
+    )
+    .unwrap();
+
+    // Compile to bytecode
+    let compile_output = Command::new(sema_bin())
+        .args([
+            "compile",
+            source_file.to_str().unwrap(),
+            "-o",
+            bytecode_file.to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to compile");
+    assert!(
+        compile_output.status.success(),
+        "compile failed: {}",
+        String::from_utf8_lossy(&compile_output.stderr)
+    );
+
+    // Serve the compiled bytecode
+    let mut child = Command::new(sema_bin())
+        .args(["serve", "--no-llm", bytecode_file.to_str().unwrap()])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to start sema serve with .semac");
+
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+
+    // Initialize
+    send_and_recv(
+        &mut stdin,
+        &mut stdout,
+        &serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {}
+        }),
+    );
+
+    // List tools — should find the compiled tool
+    let resp = send_and_recv(
+        &mut stdin,
+        &mut stdout,
+        &serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+            "params": {}
+        }),
+    );
+    let tools = resp["result"]["tools"].as_array().unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0]["name"], "reverse-text");
+
+    // Call the tool
+    let resp = send_and_recv(
+        &mut stdin,
+        &mut stdout,
+        &serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "reverse-text",
+                "arguments": {"text": "hello"}
+            }
+        }),
+    );
+    let content = resp["result"]["content"].as_array().unwrap();
+    assert_eq!(content[0]["text"], "olleh");
+
+    drop(stdin);
+    child.kill().ok();
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
 fn test_mcp_server_unknown_tool() {
     let dir = std::env::temp_dir().join("sema-mcp-test-2");
     std::fs::create_dir_all(&dir).unwrap();

--- a/crates/sema/Cargo.toml
+++ b/crates/sema/Cargo.toml
@@ -29,6 +29,7 @@ sema-fmt.workspace = true
 sema-lsp.workspace = true
 sema-dap.workspace = true
 sema-notebook.workspace = true
+sema-mcp.workspace = true
 tokio.workspace = true
 rustyline.workspace = true
 glob.workspace = true

--- a/crates/sema/src/main.rs
+++ b/crates/sema/src/main.rs
@@ -388,7 +388,7 @@ enum Commands {
         command: NotebookCommands,
     },
     /// Start an MCP (Model Context Protocol) server exposing deftool definitions
-    Serve {
+    Mcp {
         /// Sema file(s) to load (tools are discovered after evaluation)
         #[arg(required = true)]
         files: Vec<String>,
@@ -724,12 +724,12 @@ fn main() {
             Commands::Notebook { command } => {
                 run_notebook_command(command);
             }
-            Commands::Serve {
+            Commands::Mcp {
                 files,
                 no_llm,
-                sandbox: serve_sandbox,
+                sandbox: mcp_sandbox,
             } => {
-                run_mcp_server(files, no_llm, serve_sandbox);
+                run_mcp_server(files, no_llm, mcp_sandbox);
             }
             Commands::Eval {
                 stdin,
@@ -1440,8 +1440,8 @@ fn try_run_embedded() -> Option<i32> {
 
     sema_core::vfs::init_vfs(arch.files);
 
-    // Check for --serve flag: run as MCP server instead of normal execution
-    let serve_mode = std::env::args().any(|a| a == "--serve");
+    // Check for --mcp flag: run as MCP server instead of normal execution
+    let mcp_mode = std::env::args().any(|a| a == "--mcp");
 
     let sandbox = sema_core::Sandbox::allow_all();
     let interpreter = Interpreter::new_with_sandbox(&sandbox);
@@ -1456,7 +1456,7 @@ fn try_run_embedded() -> Option<i32> {
         }
     }
 
-    if serve_mode {
+    if mcp_mode {
         let tools = sema_mcp::discover_tools(&interpreter.global_env);
         eprintln!(
             "Sema MCP server starting on stdio ({} tool{} discovered)",

--- a/crates/sema/src/main.rs
+++ b/crates/sema/src/main.rs
@@ -1030,23 +1030,35 @@ fn run_mcp_server(files: Vec<String>, no_llm: bool, sandbox_arg: Option<String>)
         interpreter.eval_str_in_global("(llm/auto-configure)").ok();
     }
 
-    // Load all specified files to define tools
+    // Load all specified files to define tools (supports .sema and .semac)
     for file in &files {
         let path = std::path::Path::new(file);
         if !path.exists() {
             eprintln!("Error: file not found: {file}");
             std::process::exit(1);
         }
-        let source = std::fs::read_to_string(path).unwrap_or_else(|e| {
-            eprintln!("Error reading {file}: {e}");
-            std::process::exit(1);
-        });
         if let Ok(canonical) = path.canonicalize() {
             interpreter.ctx.push_file_path(canonical);
         }
-        if let Err(e) = interpreter.eval_str_in_global(&source) {
-            eprintln!("Error evaluating {file}: {e}");
-            std::process::exit(1);
+        let is_bytecode = path.extension().is_some_and(|ext| ext == "semac");
+        if is_bytecode {
+            let bytes = std::fs::read(path).unwrap_or_else(|e| {
+                eprintln!("Error reading {file}: {e}");
+                std::process::exit(1);
+            });
+            if let Err(e) = run_bytecode_bytes(&interpreter, &bytes) {
+                eprintln!("Error evaluating {file}: {e}");
+                std::process::exit(1);
+            }
+        } else {
+            let source = std::fs::read_to_string(path).unwrap_or_else(|e| {
+                eprintln!("Error reading {file}: {e}");
+                std::process::exit(1);
+            });
+            if let Err(e) = interpreter.eval_str_in_global(&source) {
+                eprintln!("Error evaluating {file}: {e}");
+                std::process::exit(1);
+            }
         }
     }
 
@@ -1428,18 +1440,39 @@ fn try_run_embedded() -> Option<i32> {
 
     sema_core::vfs::init_vfs(arch.files);
 
+    // Check for --serve flag: run as MCP server instead of normal execution
+    let serve_mode = std::env::args().any(|a| a == "--serve");
+
     let sandbox = sema_core::Sandbox::allow_all();
     let interpreter = Interpreter::new_with_sandbox(&sandbox);
 
     let _ = interpreter.eval_str("(llm/auto-configure)");
 
     match run_bytecode_bytes(&interpreter, &bytecode) {
-        Ok(_) => Some(0),
+        Ok(_) => {}
         Err(e) => {
             print_error(&e);
-            Some(1)
+            return Some(1);
         }
     }
+
+    if serve_mode {
+        let tools = sema_mcp::discover_tools(&interpreter.global_env);
+        eprintln!(
+            "Sema MCP server starting on stdio ({} tool{} discovered)",
+            tools.len(),
+            if tools.len() == 1 { "" } else { "s" }
+        );
+        for tool in &tools {
+            eprintln!("  - {}: {}", tool.name, tool.description);
+        }
+        if let Err(e) = sema_mcp::run_server(tools, &interpreter.ctx, &interpreter.global_env) {
+            eprintln!("MCP server error: {e}");
+            return Some(1);
+        }
+    }
+
+    Some(0)
 }
 
 fn run_build(

--- a/crates/sema/src/main.rs
+++ b/crates/sema/src/main.rs
@@ -387,6 +387,20 @@ enum Commands {
         #[command(subcommand)]
         command: NotebookCommands,
     },
+    /// Start an MCP (Model Context Protocol) server exposing deftool definitions
+    Serve {
+        /// Sema file(s) to load (tools are discovered after evaluation)
+        #[arg(required = true)]
+        files: Vec<String>,
+
+        /// Disable LLM features
+        #[arg(long)]
+        no_llm: bool,
+
+        /// Sandbox mode (e.g., "strict", "all", or comma-separated capabilities)
+        #[arg(long)]
+        sandbox: Option<String>,
+    },
     /// Evaluate code and return results (designed for machine consumption by editors/LSP)
     Eval {
         /// Read program from stdin instead of --expr
@@ -710,6 +724,13 @@ fn main() {
             Commands::Notebook { command } => {
                 run_notebook_command(command);
             }
+            Commands::Serve {
+                files,
+                no_llm,
+                sandbox: serve_sandbox,
+            } => {
+                run_mcp_server(files, no_llm, serve_sandbox);
+            }
             Commands::Eval {
                 stdin,
                 expr,
@@ -991,6 +1012,59 @@ fn run_notebook_command(command: NotebookCommands) {
             }
             eprintln!("Created notebook: {file}");
         }
+    }
+}
+
+fn run_mcp_server(files: Vec<String>, no_llm: bool, sandbox_arg: Option<String>) {
+    let sandbox = match &sandbox_arg {
+        Some(value) => sema_core::Sandbox::parse_cli(value).unwrap_or_else(|e| {
+            eprintln!("Error: {e}");
+            std::process::exit(1);
+        }),
+        None => sema_core::Sandbox::allow_all(),
+    };
+
+    let interpreter = Interpreter::new_with_sandbox(&sandbox);
+
+    if !no_llm {
+        interpreter.eval_str_in_global("(llm/auto-configure)").ok();
+    }
+
+    // Load all specified files to define tools
+    for file in &files {
+        let path = std::path::Path::new(file);
+        if !path.exists() {
+            eprintln!("Error: file not found: {file}");
+            std::process::exit(1);
+        }
+        let source = std::fs::read_to_string(path).unwrap_or_else(|e| {
+            eprintln!("Error reading {file}: {e}");
+            std::process::exit(1);
+        });
+        if let Ok(canonical) = path.canonicalize() {
+            interpreter.ctx.push_file_path(canonical);
+        }
+        if let Err(e) = interpreter.eval_str_in_global(&source) {
+            eprintln!("Error evaluating {file}: {e}");
+            std::process::exit(1);
+        }
+    }
+
+    // Discover all deftool definitions
+    let tools = sema_mcp::discover_tools(&interpreter.global_env);
+
+    eprintln!(
+        "Sema MCP server starting on stdio ({} tool{} discovered)",
+        tools.len(),
+        if tools.len() == 1 { "" } else { "s" }
+    );
+    for tool in &tools {
+        eprintln!("  - {}: {}", tool.name, tool.description);
+    }
+
+    if let Err(e) = sema_mcp::run_server(tools, &interpreter.ctx, &interpreter.global_env) {
+        eprintln!("MCP server error: {e}");
+        std::process::exit(1);
     }
 }
 

--- a/examples/mcp-tools.sema
+++ b/examples/mcp-tools.sema
@@ -1,7 +1,7 @@
 ;; mcp-tools.sema — Example tools for use with `sema serve`
 ;;
 ;; Start the MCP server:
-;;   sema serve examples/mcp-tools.sema
+;;   sema mcp examples/mcp-tools.sema
 ;;
 ;; Then connect from Claude Desktop, Cursor, or any MCP client.
 

--- a/examples/mcp-tools.sema
+++ b/examples/mcp-tools.sema
@@ -1,0 +1,36 @@
+;; mcp-tools.sema — Example tools for use with `sema serve`
+;;
+;; Start the MCP server:
+;;   sema serve examples/mcp-tools.sema
+;;
+;; Then connect from Claude Desktop, Cursor, or any MCP client.
+
+(deftool greet
+  "Greet someone by name"
+  {:name {:type :string :description "The person's name"}}
+  (lambda (name)
+    (string-append "Hello, " name "!")))
+
+(deftool calculate
+  "Evaluate a simple arithmetic expression (a op b)"
+  {:expression {:type :string :description "A math expression like '2 + 3'"}}
+  (lambda (expr)
+    (let ((parts (string/split expr " ")))
+      (if (= (length parts) 3)
+        (let ((a  (string/to-number (nth parts 0)))
+              (op (nth parts 1))
+              (b  (string/to-number (nth parts 2))))
+          (cond
+            ((= op "+") (number/to-string (+ a b)))
+            ((= op "-") (number/to-string (- a b)))
+            ((= op "*") (number/to-string (* a b)))
+            ((= op "/") (number/to-string (/ a b)))
+            (else       (string-append "Unknown operator: " op))))
+        (string-append "Expected 'a op b', got: " expr)))))
+
+(deftool word-count
+  "Count words in a text"
+  {:text {:type :string :description "The text to count words in"}}
+  (lambda (text)
+    (let ((words (string/split text " ")))
+      (number/to-string (length words)))))

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -54,6 +54,7 @@ export default defineConfig({
             { text: 'Editor Support', link: '/docs/editors' },
             { text: 'Language Server (LSP)', link: '/docs/lsp' },
             { text: 'Notebook', link: '/docs/notebook' },
+            { text: 'Model Context Protocol (MCP)', link: '/docs/mcp' },
             { text: 'Embedding in Rust', link: '/docs/embedding' },
             { text: 'Embedding in JavaScript', link: '/docs/embedding-js' },
             { text: 'Packages', link: '/docs/packages' },

--- a/website/docs/cli.md
+++ b/website/docs/cli.md
@@ -407,6 +407,39 @@ sema lsp
 
 Provides diagnostics, completion, hover, go-to-definition, and code lenses. See the [LSP documentation](/docs/lsp.html) for full feature details and editor setup instructions.
 
+### `sema mcp`
+
+Start a Model Context Protocol (MCP) server. Evaluates the specified file(s), discovers all `deftool` definitions, and exposes them as MCP tools over stdio.
+
+```
+sema mcp [OPTIONS] <FILES>...
+```
+
+| Flag                 | Description                                                     |
+| -------------------- | --------------------------------------------------------------- |
+| `--no-llm`           | Disable LLM auto-configuration                                 |
+| `--sandbox <MODE>`   | Sandbox mode (`strict`, `all`, or comma-separated capabilities) |
+
+```bash
+# Serve tools from a source file
+sema mcp tools.sema
+
+# Serve compiled bytecode (faster startup)
+sema mcp tools.semac
+
+# Multiple files
+sema mcp math-tools.sema string-tools.sema
+```
+
+Standalone binaries built with `sema build` also support MCP via the `--mcp` flag:
+
+```bash
+sema build tools.sema -o my-tools
+./my-tools --mcp
+```
+
+See the [MCP documentation](/docs/mcp.html) for full details and client setup instructions.
+
 ## Examples
 
 ```bash

--- a/website/docs/mcp.md
+++ b/website/docs/mcp.md
@@ -1,0 +1,164 @@
+---
+outline: [2, 3]
+---
+
+# Model Context Protocol (MCP)
+
+Sema includes a built-in [Model Context Protocol](https://modelcontextprotocol.io/) server that exposes [`deftool`](/docs/llm/tools-agents.html) definitions as MCP tools. Any Sema script with tool definitions can be instantly deployed as an MCP server compatible with Claude Desktop, Cursor, and other MCP clients. The server communicates over stdio using the MCP JSON-RPC protocol.
+
+```bash
+sema mcp tools.sema
+```
+
+## Defining Tools
+
+MCP tools are defined using Sema's `deftool` special form. Each tool has a name, description, parameter schema, and handler function:
+
+```sema
+(deftool greet
+  "Greet someone by name"
+  {:name {:type :string :description "The person's name"}}
+  (lambda (name)
+    (string-append "Hello, " name "!")))
+
+(deftool calculate
+  "Evaluate a simple arithmetic expression (a op b)"
+  {:expression {:type :string :description "A math expression like '2 + 3'"}}
+  (lambda (expr)
+    (let ((parts (string/split expr " ")))
+      (if (= (length parts) 3)
+        (let ((a  (string/to-number (nth parts 0)))
+              (op (nth parts 1))
+              (b  (string/to-number (nth parts 2))))
+          (cond
+            ((= op "+") (number/to-string (+ a b)))
+            ((= op "-") (number/to-string (- a b)))
+            ((= op "*") (number/to-string (* a b)))
+            ((= op "/") (number/to-string (/ a b)))
+            (else       (string-append "Unknown operator: " op))))
+        (string-append "Expected 'a op b', got: " expr)))))
+```
+
+The parameter schema maps directly to [JSON Schema](https://json-schema.org/) for MCP clients. Each parameter supports `:type`, `:description`, `:enum`, and `:optional` keys. Parameters are required by default unless `:optional #t` is set.
+
+See [Tools & Agents](/docs/llm/tools-agents.html) for full `deftool` documentation.
+
+## Running the Server
+
+### From source files
+
+```bash
+sema mcp tools.sema
+```
+
+Multiple files can be loaded — all `deftool` definitions across all files are discovered:
+
+```bash
+sema mcp math-tools.sema string-tools.sema file-tools.sema
+```
+
+### From compiled bytecode
+
+Pre-compiled `.semac` files work too, for faster startup:
+
+```bash
+sema compile tools.sema        # produces tools.semac
+sema mcp tools.semac
+```
+
+### From standalone binaries
+
+Standalone executables built with [`sema build`](/docs/cli.html#sema-build) support the `--mcp` flag. The binary runs its embedded script to define tools, then starts the MCP server:
+
+```bash
+sema build tools.sema -o my-tools
+./my-tools --mcp
+```
+
+This makes it possible to distribute a single binary that works both as a CLI tool and an MCP server.
+
+## Client Setup
+
+### Claude Desktop
+
+Add to your Claude Desktop configuration (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+```json
+{
+  "mcpServers": {
+    "my-tools": {
+      "command": "sema",
+      "args": ["mcp", "path/to/tools.sema"]
+    }
+  }
+}
+```
+
+Or with a standalone binary:
+
+```json
+{
+  "mcpServers": {
+    "my-tools": {
+      "command": "./my-tools",
+      "args": ["--mcp"]
+    }
+  }
+}
+```
+
+### Cursor
+
+Add to your Cursor MCP settings (`.cursor/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "my-tools": {
+      "command": "sema",
+      "args": ["mcp", "path/to/tools.sema"]
+    }
+  }
+}
+```
+
+### Claude Code
+
+Add to your Claude Code MCP settings (`.claude/settings.json`):
+
+```json
+{
+  "mcpServers": {
+    "my-tools": {
+      "command": "sema",
+      "args": ["mcp", "path/to/tools.sema"]
+    }
+  }
+}
+```
+
+## Options
+
+| Flag                 | Description                                                     |
+| -------------------- | --------------------------------------------------------------- |
+| `--no-llm`           | Disable LLM auto-configuration (faster startup if tools don't use LLM) |
+| `--sandbox <MODE>`   | Sandbox mode (`strict`, `all`, or comma-separated capabilities) |
+
+```bash
+# Fast startup for tools that don't call LLMs
+sema mcp --no-llm tools.sema
+
+# Restrict tool capabilities
+sema mcp --sandbox=no-shell,no-network tools.sema
+```
+
+## How It Works
+
+1. Sema evaluates the specified file(s), executing all top-level expressions
+2. The environment is scanned for all `ToolDef` values (created by `deftool`)
+3. Parameter schemas are converted to JSON Schema for the MCP protocol
+4. The server starts on stdio, handling `initialize`, `tools/list`, and `tools/call` requests
+5. When a tool is called, the JSON arguments are converted to Sema values and passed to the handler function
+6. The handler's return value is converted back to a text response for the MCP client
+
+Tool handlers run in the same interpreter context, so they can share state, access the filesystem, make HTTP requests, or call LLM APIs — whatever the tool needs.


### PR DESCRIPTION
## Summary
- Adds `sema mcp` command that exposes `deftool` definitions as MCP tools via stdio
- Supports `--mcp` flag on compiled binaries and `.semac` files
- Documentation and CLI reference updates

## Test plan
- [ ] Verify `sema mcp` starts and responds to MCP protocol messages
- [ ] Test with a `.sema` file containing `deftool` definitions
- [ ] Test `--mcp` flag on compiled `.semac` binaries