### PR TITLE
[SMOKE TEST — DO NOT MERGE] Validate PGO in release CI

### DIFF
--- a/.github/pgo-setup.yml
+++ b/.github/pgo-setup.yml
@@ -24,6 +24,13 @@
       echo "PGO: target '$PGO_TARGETS' != host '$HOST' — skipping (cross-compile or non-build job); plain LTO build."
       exit 0
     fi
+    # This step runs BEFORE dist's own "Install dependencies" step, so the build
+    # deps it declares (apt: libudev-dev) aren't present yet — install them here
+    # or the instrumented build fails on libudev-sys.
+    if [ "$(uname)" = "Linux" ]; then
+      sudo apt-get update -qq && sudo apt-get install -y -qq libudev-dev pkg-config
+      if [ $? -ne 0 ]; then echo "PGO: apt build deps failed — skipping."; exit 0; fi
+    fi
     rustup component add llvm-tools-preview
     if [ $? -ne 0 ]; then echo "PGO: llvm-tools unavailable — skipping."; exit 0; fi
     PROFILE=dist ./scripts/pgo-build.sh --profile-only

--- a/.github/pgo-setup.yml
+++ b/.github/pgo-setup.yml
@@ -1,0 +1,35 @@
+# Profile-Guided Optimization setup for release builds.
+#
+# Injected into the `build-local-artifacts` job (right after checkout, before
+# `dist build`) via `github-build-setup` in dist-workspace.toml. After editing
+# THIS file you must run `dist generate` to re-bake it into
+# .github/workflows/release.yml, then commit both.
+#
+# Behavior: on a runner whose host matches the target being built, it
+# instruments, trains, and merges a PGO profile, then exports
+# RUSTFLAGS=-Cprofile-use so the subsequent `dist build` produces a PGO binary
+# (measured ~25% faster on 1BRC; see docs/performance-roadmap.md). On
+# cross-compiled targets (instrumented binary can't run) it skips and falls back
+# to a normal LTO build. PGO is FAIL-SAFE: any error skips PGO rather than
+# failing the release — worst case is a non-PGO build.
+- name: "PGO: generate profile (native targets only)"
+  shell: bash
+  env:
+    PGO_TARGETS: ${{ join(matrix.targets, ' ') }}
+  run: |
+    set +e
+    HOST="$(rustc -vV | sed -n 's/^host: //p')"
+    # Local build jobs build exactly one target; global/installer jobs have none.
+    if [ "$PGO_TARGETS" != "$HOST" ]; then
+      echo "PGO: target '$PGO_TARGETS' != host '$HOST' — skipping (cross-compile or non-build job); plain LTO build."
+      exit 0
+    fi
+    rustup component add llvm-tools-preview
+    if [ $? -ne 0 ]; then echo "PGO: llvm-tools unavailable — skipping."; exit 0; fi
+    PROFILE=dist ./scripts/pgo-build.sh --profile-only
+    if [ $? -ne 0 ] || [ ! -f target/pgo/merged.profdata ]; then
+      echo "PGO: profile generation failed — skipping; plain LTO build."
+      exit 0
+    fi
+    echo "RUSTFLAGS=-Cprofile-use=$(pwd)/target/pgo/merged.profdata -Cllvm-args=-pgo-warn-missing-function" >> "$GITHUB_ENV"
+    echo "PGO: profile ready ($(du -h target/pgo/merged.profdata | cut -f1)); dist build will consume it."

--- a/.github/pgo-setup.yml
+++ b/.github/pgo-setup.yml
@@ -24,6 +24,13 @@
       echo "PGO: target '$PGO_TARGETS' != host '$HOST' — skipping (cross-compile or non-build job); plain LTO build."
       exit 0
     fi
+    # PGO only on Linux/macOS. Windows git-bash yields POSIX paths (/d/a/...) that
+    # the native MSVC rustc rejects in -Cprofile-use, and that failure lands in
+    # dist build (not fail-safe). Windows ships a plain LTO build.
+    case "$(uname -s)" in
+      Linux|Darwin) ;;
+      *) echo "PGO: $(uname -s) unsupported for PGO here — skipping; plain LTO build."; exit 0 ;;
+    esac
     # This step runs BEFORE dist's own "Install dependencies" step, so the build
     # deps it declares (apt: libudev-dev) aren't present yet — install them here
     # or the instrumented build fails on libudev-sys.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,6 +148,10 @@ jobs:
         shell: "bash"
         env:
           "PGO_TARGETS": "${{ join(matrix.targets, ' ') }}"
+      - uses: swatinem/rust-cache@v2
+        with:
+          key: ${{ join(matrix.targets, '-') }}
+          cache-provider: ${{ matrix.cache_provider }}
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,13 @@ jobs:
             echo "PGO: target '$PGO_TARGETS' != host '$HOST' — skipping (cross-compile or non-build job); plain LTO build."
             exit 0
           fi
+          # This step runs BEFORE dist's own "Install dependencies" step, so the build
+          # deps it declares (apt: libudev-dev) aren't present yet — install them here
+          # or the instrumented build fails on libudev-sys.
+          if [ "$(uname)" = "Linux" ]; then
+            sudo apt-get update -qq && sudo apt-get install -y -qq libudev-dev pkg-config
+            if [ $? -ne 0 ]; then echo "PGO: apt build deps failed — skipping."; exit 0; fi
+          fi
           rustup component add llvm-tools-preview
           if [ $? -ne 0 ]; then echo "PGO: llvm-tools unavailable — skipping."; exit 0; fi
           PROFILE=dist ./scripts/pgo-build.sh --profile-only

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,27 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           fi
+      - name: "PGO: generate profile (native targets only)"
+        run: |
+          set +e
+          HOST="$(rustc -vV | sed -n 's/^host: //p')"
+          # Local build jobs build exactly one target; global/installer jobs have none.
+          if [ "$PGO_TARGETS" != "$HOST" ]; then
+            echo "PGO: target '$PGO_TARGETS' != host '$HOST' — skipping (cross-compile or non-build job); plain LTO build."
+            exit 0
+          fi
+          rustup component add llvm-tools-preview
+          if [ $? -ne 0 ]; then echo "PGO: llvm-tools unavailable — skipping."; exit 0; fi
+          PROFILE=dist ./scripts/pgo-build.sh --profile-only
+          if [ $? -ne 0 ] || [ ! -f target/pgo/merged.profdata ]; then
+            echo "PGO: profile generation failed — skipping; plain LTO build."
+            exit 0
+          fi
+          echo "RUSTFLAGS=-Cprofile-use=$(pwd)/target/pgo/merged.profdata -Cllvm-args=-pgo-warn-missing-function" >> "$GITHUB_ENV"
+          echo "PGO: profile ready ($(du -h target/pgo/merged.profdata | cut -f1)); dist build will consume it."
+        shell: "bash"
+        env:
+          "PGO_TARGETS": "${{ join(matrix.targets, ' ') }}"
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,13 @@ jobs:
             echo "PGO: target '$PGO_TARGETS' != host '$HOST' — skipping (cross-compile or non-build job); plain LTO build."
             exit 0
           fi
+          # PGO only on Linux/macOS. Windows git-bash yields POSIX paths (/d/a/...) that
+          # the native MSVC rustc rejects in -Cprofile-use, and that failure lands in
+          # dist build (not fail-safe). Windows ships a plain LTO build.
+          case "$(uname -s)" in
+            Linux|Darwin) ;;
+            *) echo "PGO: $(uname -s) unsupported for PGO here — skipping; plain LTO build."; exit 0 ;;
+          esac
           # This step runs BEFORE dist's own "Install dependencies" step, so the build
           # deps it declares (apt: libudev-dev) aren't present yet — install them here
           # or the instrumented build fails on libudev-sys.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 1.19.2
+
+Performance release. No language or behavior changes — purely faster, fully backward compatible. The headline is **profile-guided optimization** of the distributed binaries.
+
+### Performance
+
+- **PGO'd release binaries.** The cargo-dist GitHub-release binaries and Homebrew bottle are now built with profile-guided optimization (instrument → train on the benchmark suite + a 1BRC sample → rebuild). Measured **~25–29% faster on the 1BRC workload** and **−11% to −40% across the compute benchmarks** (higher-order-fold −40%, tak −32%, deriv/hashmap −22%). Wired into CI via dist's `github-build-setup` on native runners; it falls back to a plain build on cross-compiled targets and is fail-safe (a PGO failure never fails the release). Run it yourself with `make build-pgo`. Note: `cargo install` builds get fat LTO but not PGO (PGO needs the training step).
+- **Fat LTO** for release/dist profiles (`lto = "fat"`): measured 3–9% on its own, independent of PGO.
+- **Inline string opcodes.** `string-length`, `string-ref`, and `string-append` (2-arg) now compile to dedicated VM opcodes instead of routing through the generic `CallGlobal` → hash-lookup → native-fn path. Semantics are identical (char-indexed, same errors, redefinition still falls back); a win for code that uses them in hot loops.
+- **`#[inline(always)]`** added to the `type_name`/`as_str` value accessors used in the VM dispatch loop.
+
+Bytecode is unchanged at `format_version` 4 (the new opcodes are additive and single-byte); `.semac` files remain version-pinned as before.
+
 ## 1.19.1
 
 Dependency-hygiene patch release. No functional changes — this exists so the cargo-dist GitHub-release binaries and the Homebrew bottle (which build from the committed `Cargo.lock`, unlike `cargo install`, which re-resolves) embed the security-patched `tar` crate.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2888,7 +2888,7 @@ dependencies = [
 
 [[package]]
 name = "sema-core"
-version = "1.19.1"
+version = "1.19.2"
 dependencies = [
  "hashbrown 0.17.1",
  "lasso",
@@ -2899,7 +2899,7 @@ dependencies = [
 
 [[package]]
 name = "sema-dap"
-version = "1.19.1"
+version = "1.19.2"
 dependencies = [
  "sema-core",
  "sema-eval",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "sema-docs"
-version = "1.19.1"
+version = "1.19.2"
 dependencies = [
  "clap",
  "serde",
@@ -2922,7 +2922,7 @@ dependencies = [
 
 [[package]]
 name = "sema-eval"
-version = "1.19.1"
+version = "1.19.2"
 dependencies = [
  "sema-core",
  "sema-llm",
@@ -2933,7 +2933,7 @@ dependencies = [
 
 [[package]]
 name = "sema-fmt"
-version = "1.19.1"
+version = "1.19.2"
 dependencies = [
  "sema-core",
  "sema-reader",
@@ -2941,7 +2941,7 @@ dependencies = [
 
 [[package]]
 name = "sema-lang"
-version = "1.19.1"
+version = "1.19.2"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2985,7 +2985,7 @@ dependencies = [
 
 [[package]]
 name = "sema-llm"
-version = "1.19.1"
+version = "1.19.2"
 dependencies = [
  "base64",
  "futures",
@@ -3000,7 +3000,7 @@ dependencies = [
 
 [[package]]
 name = "sema-lsp"
-version = "1.19.1"
+version = "1.19.2"
 dependencies = [
  "sema-core",
  "sema-docs",
@@ -3016,7 +3016,7 @@ dependencies = [
 
 [[package]]
 name = "sema-mcp"
-version = "1.19.1"
+version = "1.19.2"
 dependencies = [
  "crc32fast",
  "sema-core",
@@ -3032,7 +3032,7 @@ dependencies = [
 
 [[package]]
 name = "sema-notebook"
-version = "1.19.1"
+version = "1.19.2"
 dependencies = [
  "axum",
  "chrono",
@@ -3046,7 +3046,7 @@ dependencies = [
 
 [[package]]
 name = "sema-reader"
-version = "1.19.1"
+version = "1.19.2"
 dependencies = [
  "proptest",
  "sema-core",
@@ -3054,7 +3054,7 @@ dependencies = [
 
 [[package]]
 name = "sema-stdlib"
-version = "1.19.1"
+version = "1.19.2"
 dependencies = [
  "axum",
  "base64",
@@ -3089,7 +3089,7 @@ dependencies = [
 
 [[package]]
 name = "sema-vm"
-version = "1.19.1"
+version = "1.19.2"
 dependencies = [
  "hashbrown 0.17.1",
  "lasso",
@@ -3099,7 +3099,7 @@ dependencies = [
 
 [[package]]
 name = "sema-wasm"
-version = "1.19.1"
+version = "1.19.2"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,25 +19,25 @@ exclude = ["pkg"]
 resolver = "2"
 
 [workspace.package]
-version = "1.19.1"
+version = "1.19.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/HelgeSverre/sema"
 homepage = "https://sema-lang.com"
 
 [workspace.dependencies]
-sema-core = { version = "=1.19.1", path = "crates/sema-core" }
-sema-reader = { version = "=1.19.1", path = "crates/sema-reader" }
-sema-eval = { version = "=1.19.1", path = "crates/sema-eval" }
-sema-llm = { version = "=1.19.1", path = "crates/sema-llm" }
-sema-stdlib = { version = "=1.19.1", path = "crates/sema-stdlib" }
-sema-vm = { version = "=1.19.1", path = "crates/sema-vm" }
-sema-fmt = { version = "=1.19.1", path = "crates/sema-fmt" }
-sema-lsp = { version = "=1.19.1", path = "crates/sema-lsp" }
-sema-dap = { version = "=1.19.1", path = "crates/sema-dap" }
-sema-notebook = { version = "=1.19.1", path = "crates/sema-notebook" }
-sema-docs = { version = "=1.19.1", path = "crates/sema-docs" }
-sema-mcp = { version = "=1.19.1", path = "crates/sema-mcp" }
+sema-core = { version = "=1.19.2", path = "crates/sema-core" }
+sema-reader = { version = "=1.19.2", path = "crates/sema-reader" }
+sema-eval = { version = "=1.19.2", path = "crates/sema-eval" }
+sema-llm = { version = "=1.19.2", path = "crates/sema-llm" }
+sema-stdlib = { version = "=1.19.2", path = "crates/sema-stdlib" }
+sema-vm = { version = "=1.19.2", path = "crates/sema-vm" }
+sema-fmt = { version = "=1.19.2", path = "crates/sema-fmt" }
+sema-lsp = { version = "=1.19.2", path = "crates/sema-lsp" }
+sema-dap = { version = "=1.19.2", path = "crates/sema-dap" }
+sema-notebook = { version = "=1.19.2", path = "crates/sema-notebook" }
+sema-docs = { version = "=1.19.2", path = "crates/sema-docs" }
+sema-mcp = { version = "=1.19.2", path = "crates/sema-mcp" }
 
 tower-lsp = "0.20"
 dashmap = "6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ debug = "line-tables-only"
 
 [profile.release]
 opt-level = 3
-lto = "thin"
+lto = "fat"
 codegen-units = 1
 panic = "abort"
 strip = "debuginfo"
@@ -108,4 +108,4 @@ strip = "none"
 # The profile that 'dist' will build with
 [profile.dist]
 inherits = "release"
-lto = "thin"
+lto = "fat"

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,18 @@
-.PHONY: all build release install uninstall test test-lsp test-embedding-bench test-http test-llm check clippy fmt fmt-check clean run lint lint-links docs docs-check update-pricing examples smoke-bytecode test-providers fuzz fuzz-reader fuzz-eval setup bench-1m bench-10m bench-100m site-dev site-build site-preview site-deploy deploy coverage coverage-html bench bench-vm bench-save bench-suite bench-closure bench-numeric bench-compare bench-baseline profile profile-vm ts-setup ts-generate ts-test ts-playground js-lib-build js-lib-dev
+.PHONY: all build release build-pgo pgo-profile install uninstall test test-lsp test-embedding-bench test-http test-llm check clippy fmt fmt-check clean run lint lint-links docs docs-check update-pricing examples smoke-bytecode test-providers fuzz fuzz-reader fuzz-eval setup bench-1m bench-10m bench-100m site-dev site-build site-preview site-deploy deploy coverage coverage-html bench bench-vm bench-save bench-suite bench-closure bench-numeric bench-compare bench-baseline profile profile-vm ts-setup ts-generate ts-test ts-playground js-lib-build js-lib-dev
 build:
 	cargo build
 
 release:
 	cargo build --release
+
+# PGO build (instrument -> train -> rebuild). ~25% faster on 1BRC; see
+# docs/performance-roadmap.md. `make pgo-profile` emits only the .profdata
+# (target/pgo/merged.profdata) that CI consumes via -Cprofile-use.
+build-pgo:
+	./scripts/pgo-build.sh
+
+pgo-profile:
+	./scripts/pgo-build.sh --profile-only
 
 install:
 	cargo install --path crates/sema

--- a/crates/sema-core/src/value.rs
+++ b/crates/sema-core/src/value.rs
@@ -1042,6 +1042,7 @@ impl Value {
 
     // -- Typed accessors (ergonomic, avoid full view match) --
 
+    #[inline(always)]
     pub fn type_name(&self) -> &'static str {
         if !is_boxed(self.0) {
             return "float";
@@ -1242,6 +1243,7 @@ impl Value {
         }
     }
 
+    #[inline(always)]
     pub fn as_str(&self) -> Option<&str> {
         if is_boxed(self.0) && get_tag(self.0) == TAG_STRING {
             Some(unsafe { self.borrow_ref::<String>() })

--- a/crates/sema-vm/src/compiler.rs
+++ b/crates/sema-vm/src/compiler.rs
@@ -650,6 +650,12 @@ impl Compiler {
             ("mod", 2) | ("modulo", 2) => Op::Mod,
             // Indexed access
             ("nth", 2) => Op::Nth,
+            // String operations (legacy Scheme names, Decision #24).
+            // string-append is N-ary in stdlib; only the 2-arg case is
+            // intrinsified (mirrors the Append precedent) — N-ary stays generic.
+            ("string-length", 1) => Op::StringLength,
+            ("string-ref", 2) => Op::StringRef,
+            ("string-append", 2) => Op::StringAppend,
             _ => return Ok(false),
         };
 

--- a/crates/sema-vm/src/disasm.rs
+++ b/crates/sema-vm/src/disasm.rs
@@ -95,6 +95,9 @@ fn op_name(op: Op) -> &'static str {
         Op::ContainsQ => "CONTAINS_Q",
         Op::Mod => "MOD",
         Op::Nth => "NTH",
+        Op::StringLength => "STRING_LENGTH",
+        Op::StringRef => "STRING_REF",
+        Op::StringAppend => "STRING_APPEND",
     }
 }
 
@@ -241,7 +244,7 @@ pub fn disassemble(chunk: &Chunk, name: Option<&str>) -> String {
 }
 
 fn op_from_u8(byte: u8) -> Option<Op> {
-    const MAX_OP: u8 = Op::Nth as u8;
+    const MAX_OP: u8 = Op::StringAppend as u8;
     if byte > MAX_OP {
         return None;
     }
@@ -441,6 +444,9 @@ mod tests {
         e.emit_op(Op::Length);
         e.emit_op(Op::Get);
         e.emit_op(Op::ContainsQ);
+        e.emit_op(Op::StringLength);
+        e.emit_op(Op::StringRef);
+        e.emit_op(Op::StringAppend);
         e.emit_op(Op::Return);
         let chunk = e.into_chunk();
         let output = disassemble(&chunk, Some("zero_ops"));
@@ -458,6 +464,9 @@ mod tests {
         assert!(output.contains("LENGTH"));
         assert!(output.contains("GET"));
         assert!(output.contains("CONTAINS_Q"));
+        assert!(output.contains("STRING_LENGTH"));
+        assert!(output.contains("STRING_REF"));
+        assert!(output.contains("STRING_APPEND"));
     }
 
     #[test]

--- a/crates/sema-vm/src/opcodes.rs
+++ b/crates/sema-vm/src/opcodes.rs
@@ -104,6 +104,11 @@ pub enum Op {
 
     // Vector/list indexed access (fast path for nth)
     Nth, // pop collection, pop index → push element
+
+    // Inline string intrinsics (bypass CallGlobal overhead)
+    StringLength, // pop string, push char count as int (1-arg only)
+    StringRef,    // pop index, pop string → push char at index
+    StringAppend, // pop two values, push concatenated string (2-arg only)
 }
 
 impl Op {
@@ -180,6 +185,9 @@ impl Op {
             63 => Some(Op::ContainsQ),
             64 => Some(Op::Mod),
             65 => Some(Op::Nth),
+            66 => Some(Op::StringLength),
+            67 => Some(Op::StringRef),
+            68 => Some(Op::StringAppend),
             _ => None,
         }
     }
@@ -256,14 +264,16 @@ impl Op {
             },
             // binary ops — 2 pops, 1 push
             Add | Sub | Mul | Div | Eq | Lt | Gt | Le | Ge | AddInt | SubInt | MulInt | LtInt
-            | EqInt | Cons | Append | Get | ContainsQ | Mod | Nth => StackEffect {
-                pops: 2,
-                pushes: 1,
-                exits_frame: false,
-            },
+            | EqInt | Cons | Append | Get | ContainsQ | Mod | Nth | StringRef | StringAppend => {
+                StackEffect {
+                    pops: 2,
+                    pushes: 1,
+                    exits_frame: false,
+                }
+            }
             // unary ops — 1 pop, 1 push
             Negate | Not | Car | Cdr | Length | IsNull | IsPair | IsList | IsNumber | IsString
-            | IsSymbol => StackEffect {
+            | IsSymbol | StringLength => StackEffect {
                 pops: 1,
                 pushes: 1,
                 exits_frame: false,
@@ -358,6 +368,9 @@ const _: () = {
             Op::ContainsQ => {}
             Op::Mod => {}
             Op::Nth => {}
+            Op::StringLength => {}
+            Op::StringRef => {}
+            Op::StringAppend => {}
         }
     }
 };
@@ -431,6 +444,9 @@ pub mod op {
     pub const CONTAINS_Q: u8 = Op::ContainsQ as u8;
     pub const MOD: u8 = Op::Mod as u8;
     pub const NTH: u8 = Op::Nth as u8;
+    pub const STRING_LENGTH: u8 = Op::StringLength as u8;
+    pub const STRING_REF: u8 = Op::StringRef as u8;
+    pub const STRING_APPEND: u8 = Op::StringAppend as u8;
 
     // Instruction sizes (opcode byte + operand bytes)
     /// Size of a bare opcode with no operands: 1

--- a/crates/sema-vm/src/vm.rs
+++ b/crates/sema-vm/src/vm.rs
@@ -2035,6 +2035,61 @@ impl VM {
                         }
                     }
 
+                    // --- String intrinsics (semantics mirror sema-stdlib/src/string.rs) ---
+                    op::STRING_LENGTH => {
+                        let val = unsafe { pop_unchecked(&mut self.stack) };
+                        if let Some(s) = val.as_str() {
+                            self.stack.push(Value::int(s.chars().count() as i64));
+                        } else {
+                            let err = SemaError::type_error("string", val.type_name());
+                            handle_err!(self, fi, pc, err, pc - op::SIZE_OP, 'dispatch);
+                        }
+                    }
+                    op::STRING_REF => {
+                        let idx_val = unsafe { pop_unchecked(&mut self.stack) };
+                        let str_val = unsafe { pop_unchecked(&mut self.stack) };
+                        let Some(s) = str_val.as_str() else {
+                            let err = SemaError::type_error("string", str_val.type_name());
+                            handle_err!(self, fi, pc, err, pc - op::SIZE_OP, 'dispatch);
+                        };
+                        let Some(idx_signed) = idx_val.as_int() else {
+                            let err = SemaError::type_error("int", idx_val.type_name());
+                            handle_err!(self, fi, pc, err, pc - op::SIZE_OP, 'dispatch);
+                        };
+                        if idx_signed < 0 {
+                            let err = SemaError::eval(format!(
+                                "string-ref: index {idx_signed} must be non-negative"
+                            ));
+                            handle_err!(self, fi, pc, err, pc - op::SIZE_OP, 'dispatch);
+                        }
+                        let idx = idx_signed as usize;
+                        match s.chars().nth(idx) {
+                            Some(c) => self.stack.push(Value::char(c)),
+                            None => {
+                                let len = s.chars().count();
+                                let err = SemaError::eval(format!(
+                                    "string-ref: index {idx} out of bounds (string length {len})"
+                                ))
+                                .with_hint("indices are 0-based");
+                                handle_err!(self, fi, pc, err, pc - op::SIZE_OP, 'dispatch);
+                            }
+                        }
+                    }
+                    op::STRING_APPEND => {
+                        use std::fmt::Write;
+                        let b = unsafe { pop_unchecked(&mut self.stack) };
+                        let a = unsafe { pop_unchecked(&mut self.stack) };
+                        let mut result = String::new();
+                        for arg in [&a, &b] {
+                            if let Some(s) = arg.as_str() {
+                                result.push_str(s);
+                            } else {
+                                write!(&mut result, "{}", arg).unwrap();
+                            }
+                        }
+                        self.stack.push(Value::string(&result));
+                    }
+
                     _ => {
                         return Err(SemaError::eval(format!("VM: invalid opcode {}", op)));
                     }

--- a/crates/sema/tests/dual_eval_test.rs
+++ b/crates/sema/tests/dual_eval_test.rs
@@ -1406,3 +1406,39 @@ dual_eval_tests! {
         r#"(try (map (fn (x) (error "boom")) (list 1)) (catch e :caught))"#
         => Value::keyword("caught"),
 }
+
+// ============================================================
+// Inlined string intrinsics (StringLength / StringRef / StringAppend opcodes)
+// ============================================================
+
+dual_eval_tests! {
+    // string-length: char count, not byte count.
+    string_length_basic: r#"(string-length "hello")"# => Value::int(5),
+    string_length_empty: r#"(string-length "")"# => Value::int(0),
+    // Multi-byte chars count as one each (char-indexed, not byte-indexed).
+    string_length_unicode: r#"(string-length "héllo")"# => Value::int(5),
+
+    // string-ref: 0-based char indexing, returns a char.
+    string_ref_first: r#"(string-ref "abc" 0)"# => Value::char('a'),
+    string_ref_middle: r#"(string-ref "abc" 1)"# => Value::char('b'),
+    string_ref_last: r#"(string-ref "abc" 2)"# => Value::char('c'),
+    string_ref_unicode: r#"(string-ref "héllo" 1)"# => Value::char('é'),
+
+    // string-append: 2-arg case (intrinsic); concatenation.
+    string_append_basic: r#"(string-append "a" "bc")"# => Value::string("abc"),
+    string_append_empty: r#"(string-append "" "x")"# => Value::string("x"),
+    // Non-string arg is coerced via Display (matches stdlib semantics).
+    string_append_coerce_num: r#"(string-append "n=" 42)"# => Value::string("n=42"),
+    // N-ary string-append stays on the generic path and must still work.
+    string_append_nary: r#"(string-append "a" "b" "c" "d")"# => Value::string("abcd"),
+}
+
+dual_eval_error_tests! {
+    // string-length on a non-string errors like the stdlib version.
+    string_length_wrong_type: "(string-length 42)" => "expected string",
+    // string-ref bounds / type / sign checks.
+    string_ref_out_of_bounds: r#"(string-ref "abc" 5)"# => "out of bounds",
+    string_ref_negative: r#"(string-ref "abc" -1)"# => "must be non-negative",
+    string_ref_non_string: "(string-ref 42 0)" => "expected string",
+    string_ref_non_int: r#"(string-ref "abc" "x")"# => "expected int",
+}

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -15,6 +15,9 @@ tap = "helgesverre/homebrew-tap"
 publish-jobs = ["homebrew"]
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+# PGO: instrument+train+profile-use on native targets before `dist build`.
+# Steps live in .github/pgo-setup.yml; run `dist generate` after editing them.
+github-build-setup = "../pgo-setup.yml"
 
 # System dependencies — libudev is required by `serialport` (transitively libudev-sys) on Linux.
 [dist.dependencies.apt]

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -7,6 +7,8 @@ members = ["cargo:."]
 cargo-dist-version = "0.30.4"
 # CI backends to support
 ci = "github"
+# TEMP (smoke-test branch only): run the full build matrix on PRs to validate PGO.
+pr-run-mode = "upload"
 # The installers to generate for each app
 installers = ["shell", "powershell", "homebrew"]
 # A GitHub repo to push Homebrew formulas to

--- a/docs/performance-roadmap.md
+++ b/docs/performance-roadmap.md
@@ -43,9 +43,11 @@ The biggest single win. Instead of `CallGlobal("car")` → hash lookup → Nativ
 
 **Done** (map/collection, Feb 2026): `append` (2-arg), `get` (2-arg), `contains?` (2-arg) — 3 more opcodes (`Append`, `Get`, `ContainsQ`).
 
-**Remaining** — extend to string/misc operations:
-- String: `string-length`, `string-ref`, `string-append`
-- Misc: `apply`, `display`
+**Done** (string ops, Jun 2026): `string-length`, `string-ref`, `string-append` (2-arg) — opcodes `StringLength`/`StringRef`/`StringAppend`. Char-indexed, semantics identical to the stdlib fns; redefinition guard respected; N-ary `string-append` stays generic. **No measurable suite impact** — none of the current benchmarks exercise these in a hot path (`string-pipeline`/1BRC use slash-namespaced `string/split` + `string->float`). They help user code that hammers the legacy names; the win is latent here.
+
+**Remaining** — extend to misc operations:
+- Misc: `apply`, `display` (control-flow/IO — trickier, deferred)
+- `substring` skipped: 2-or-3-arg optional arity doesn't map to a fixed-pop stack opcode
 
 This is what Lua's VM does — `OP_GETTABLE`, `OP_CONCAT`, `OP_LEN` etc. are inline opcodes, not function calls.
 
@@ -162,17 +164,17 @@ Combined, Sema would be **competitive with Janet** and **ahead of Guile/Gauche**
 
 ### 10. LTO "fat" for release builds
 
-**Impact:** Estimated 5–10% on cross-crate hot paths
+**Impact:** Measured 3–9% (1BRC −3%, tak −7%, several −8–10%; mandelbrot is noisy ±5%)
 **Effort:** Trivial (one-line change)
-**Status:** Not started — currently using `lto = "thin"`
+**Status:** ✅ Done (Jun 2026) — `lto = "fat"` on `[profile.release]` + `[profile.dist]`. Shippable; only cost is compile time (~71s thin → ~2.5min fat).
 
 The VM dispatcher in `sema-vm` calls into `sema-core` value operations (`view()`, `try_as_small_int()`, `as_int()`) millions of times per benchmark. With thin LTO, LLVM can't always inline across crate boundaries. Fat LTO (`lto = "fat"`) enables full cross-crate inlining at the cost of slower compile times. The `dist` profile should also be upgraded.
 
 ### 11. `target-cpu=native` for local benchmarking
 
-**Impact:** 0–5%, depends on instruction set extensions available
+**Impact:** Measured **no-op** on this workload — dispatch is branch-bound, not SIMD-bound, and generic aarch64 already uses NEON on Apple Silicon.
 **Effort:** Trivial (RUSTFLAGS)
-**Status:** Not started
+**Status:** ⚠️ Tested (Jun 2026), not pursued — zero measurable gain, and it breaks portable/distributable binaries. Keep it out of release builds.
 
 Building with `RUSTFLAGS="-C target-cpu=native"` lets LLVM use the full instruction set of the host CPU (e.g., Apple Silicon NEON, AVX2 on x86). Not suitable for distributed binaries, but should be standard practice for local benchmarking. Can be added to `.cargo/config.toml` under a `[target]` profile or a `Makefile` benchmark target.
 
@@ -186,9 +188,9 @@ Ensure the hottest `Value` methods are `#[inline(always)]`: `try_as_small_int()`
 
 ### 13. Profile-Guided Optimization (PGO)
 
-**Impact:** Estimated 10–20% on representative workloads
+**Impact:** Measured **−11% to −40%** (1BRC −25%/−27% best, higher-order-fold −40%, tak −32%, mandelbrot −29%, deriv/hashmap/bench-features ≈ −21–22%). The single biggest free win — it reorders the `match op` dispatch hot blocks by real opcode frequency.
 **Effort:** Medium (set up PGO pipeline)
-**Status:** Not started
+**Status:** ⏳ Measured locally (Jun 2026), NOT yet wired into release. Pipeline: `cargo build` with `-C profile-generate` → run the **full** bench suite + 1BRC as training → `llvm-profdata merge` (binary lives in the rustlib bin dir, not PATH) → rebuild with `-C profile-use`. **Train on a representative corpus**: a partial corpus regressed `bench-features` +29%; full-suite training fixed it (→ −21%, no regressions). Next step is integrating this into cargo-dist/CI release builds with a committed training corpus.
 
 Use Rust's PGO support (`-C profile-generate` / `-C profile-use`) with representative Sema benchmarks (tak, 1BRC, deriv) as the training workload. This lets LLVM:
 - Lay out the dispatch function's basic blocks optimally for actual opcode frequency

--- a/scripts/pgo-build.sh
+++ b/scripts/pgo-build.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Profile-Guided Optimization build of the `sema` binary.
+#
+# Pipeline: instrument -> train (compute benches + a 1BRC sample) -> merge -> rebuild.
+# Measured win on the bench suite: 1BRC -25%, compute -11..40% (see docs/performance-roadmap.md).
+#
+# Two modes:
+#   ./scripts/pgo-build.sh            # full pipeline, leaves an optimized ./target/<profile>/sema
+#   ./scripts/pgo-build.sh --profile-only   # instrument + train + merge, emit the .profdata only
+#
+# The emitted profile (target/pgo/merged.profdata) is what CI consumes via
+# `RUSTFLAGS="-Cprofile-use=..."` for a single-pass release build (no per-runner
+# training needed, works even when cross-compiling).
+#
+# Env knobs: PROFILE (release|dist, default release), TRAIN_ROWS (default 2000000),
+#            PGO_DIR (default target/pgo).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+PROFILE="${PROFILE:-release}"
+PGO_DIR="${PGO_DIR:-$ROOT/target/pgo}"
+PROFRAW_DIR="$PGO_DIR/profraw"
+PROFDATA="$PGO_DIR/merged.profdata"
+BENCH_DIR="examples/benchmarks"
+TRAIN_ROWS="${TRAIN_ROWS:-2000000}"
+TRAIN_DATA="$PGO_DIR/train-1brc.txt"
+PROFILE_ONLY=0
+[[ "${1:-}" == "--profile-only" ]] && PROFILE_ONLY=1
+
+# llvm-profdata ships with the `llvm-tools` component; it lives in the rustlib
+# bin dir, not on PATH.
+find_profdata() {
+  if command -v llvm-profdata >/dev/null 2>&1; then command -v llvm-profdata; return; fi
+  local sysroot host cand
+  sysroot="$(rustc --print sysroot)"
+  host="$(rustc -vV | sed -n 's/host: //p')"
+  cand="$sysroot/lib/rustlib/$host/bin/llvm-profdata"
+  if [[ -x "$cand" ]]; then echo "$cand"; return; fi
+  echo "ERROR: llvm-profdata not found. Run: rustup component add llvm-tools-preview" >&2
+  exit 1
+}
+PROFDATA_BIN="$(find_profdata)"
+
+BIN="$ROOT/target/$PROFILE/sema"
+profile_flag() { [[ "$PROFILE" == "release" ]] && echo "--release" || echo "--profile $PROFILE"; }
+
+rm -rf "$PROFRAW_DIR" "$PROFDATA"
+mkdir -p "$PROFRAW_DIR"
+
+echo "==> [1/4] instrumented build ($PROFILE)"
+RUSTFLAGS="-Cprofile-generate=$PROFRAW_DIR" cargo build $(profile_flag) --bin sema
+
+echo "==> [2/4] training"
+if [[ ! -f "$TRAIN_DATA" ]]; then
+  if command -v python3 >/dev/null 2>&1; then
+    python3 benchmarks/1brc/generate-test-data.py "$TRAIN_ROWS" "$TRAIN_DATA"
+  else
+    echo "   (python3 unavailable: training on compute benches only)"
+  fi
+fi
+if [[ -f "$TRAIN_DATA" ]]; then
+  "$BIN" "$BENCH_DIR/1brc.sema" -- "$TRAIN_DATA" >/dev/null
+fi
+# Compute / closure / string / data / exception workloads exercise the dispatch loop.
+for b in tak nqueens deriv upvalue-counter closure-storm higher-order-fold \
+         hashmap-bench bench-features string-pipeline mandelbrot throw-catch; do
+  [[ -f "$BENCH_DIR/$b.sema" ]] && "$BIN" "$BENCH_DIR/$b.sema" >/dev/null 2>&1 || true
+done
+
+echo "==> [3/4] merge profiles ($(ls "$PROFRAW_DIR"/*.profraw 2>/dev/null | wc -l | tr -d ' ') raw files)"
+"$PROFDATA_BIN" merge -o "$PROFDATA" "$PROFRAW_DIR"
+echo "    profile: $PROFDATA ($(du -h "$PROFDATA" | cut -f1))"
+
+if [[ "$PROFILE_ONLY" == "1" ]]; then
+  echo "==> profile-only: skipping optimized rebuild. Consume with:"
+  echo "    RUSTFLAGS=\"-Cprofile-use=$PROFDATA\" cargo build $(profile_flag) --bin sema"
+  exit 0
+fi
+
+echo "==> [4/4] optimized build (profile-use)"
+RUSTFLAGS="-Cprofile-use=$PROFDATA -Cllvm-args=-pgo-warn-missing-function" cargo build $(profile_flag) --bin sema
+echo "PGO build complete: $BIN"

--- a/website/docs/internals/bytecode-format.md
+++ b/website/docs/internals/bytecode-format.md
@@ -433,6 +433,20 @@ The verifier is **sound** — it never accepts an underflowing chunk. It is inte
 
 The loader also enforces two hard limits while deserializing, both of which a re-implementation must respect to stay compatible: a chunk may declare a maximum stack depth of at most **65535** (`MAX_STACK_DEPTH`), and a constant-pool value may nest at most **128** levels deep (`MAX_VALUE_DEPTH`) — the latter bounds recursion in the value deserializer so a hostile file can't blow the native stack. Both are defined in `serialize.rs`.
 
+## Opcodes
+
+The complete, numbered opcode set lives in `crates/sema-vm/src/opcodes.rs` (the `Op` enum and its `Op::from_u8` mapping are the single source of truth). Most opcodes are single-byte; a handful carry inline operands (`u16`/`u32`/`i32`) as noted in the encoding descriptions above.
+
+To keep the common path off the `CallGlobal` → hash-lookup → `NativeFn` route, a set of **inline stdlib intrinsics** are compiled directly to dedicated single-byte opcodes when the call site references the canonical global with the matching arity (and that global has not been redefined in the program). These include list/collection ops (`Car`, `Cdr`, `Cons`, `Append`, `Length`, `Get`, `Nth`, …), type predicates (`IsNull`, `IsString`, …), and **string ops**:
+
+| Opcode | Source name(s) | Arity | Stack effect | Behavior |
+|--------|----------------|-------|--------------|----------|
+| `StringLength` (0x42) | `string-length` | 1 | pop 1, push 1 | push char count (`chars().count()`) of the string; type error if not a string |
+| `StringRef` (0x43) | `string-ref` | 2 | pop 2, push 1 | push the char at the 0-based char index; errors on negative index, non-int index, non-string, or out-of-bounds index (matching the stdlib messages) |
+| `StringAppend` (0x44) | `string-append` | 2 | pop 2, push 1 | push the concatenation of two values (non-strings coerced via `Display`); the N-ary `string-append` stays on the generic path |
+
+String indexing is by **Unicode scalar (char)**, not byte, matching the stdlib semantics. These opcodes are additive within the existing encoding (single-byte, no new operand shapes), so they do not change the `format_version`.
+
 ## Example
 
 Given this source file:


### PR DESCRIPTION
## Purpose

Smoke-test the PGO release wiring (`.github/pgo-setup.yml` + `github-build-setup`) before cutting **1.19.2**. This PR temporarily sets `pr-run-mode = "upload"` so `release.yml` runs the full build matrix on the PR — **no publishing happens** (`publish.yml`/`publish-npm.yml` and the dist host/announce jobs are tag-only).

## What to check in the `build-local-artifacts` logs

For each target, the **"PGO: generate profile (native targets only)"** step should print:
- **native runners** (`aarch64-apple-darwin`, `x86_64-apple-darwin`, `x86_64-unknown-linux-gnu`, `x86_64-pc-windows-msvc`): `PGO: profile ready (...)` → the following `dist build` rebuilds with `-Cprofile-use`.
- **cross-compiled** (`aarch64-unknown-linux-gnu`): `PGO: target ... != host ... — skipping` → plain LTO build (expected, fail-safe).

## After validation

Close this PR (do **not** merge — it carries the temporary `pr-run-mode` change). The real 1.19.2 release ships from `main` via a `v1.19.2` tag, which does **not** have `pr-run-mode = upload`.

Carries the 1.19.2 perf commits for context (LTO + inline + string opcodes, PGO pipeline, release bump).