### PR TITLE
Add grammar-based fuzzer written in Sema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,11 @@ that there's no second backend to differentially compare against.
 - Notebook E2E tests: `crates/sema-notebook/tests/e2e/` (Playwright, run via `make test-notebook-e2e`)
 - A few `#[ignore]`d tests in `integration_test.rs` are a ready acceptance suite for the deferred VM stack-trace parity work (see `docs/deferred.md`).
 
+### Fuzzing
+
+- **Byte-level (cargo-fuzz)**: `make fuzz` (nightly + cargo-fuzz). Mutates raw bytes to find reader/eval panics — targets in `crates/sema-reader/fuzz` and `crates/sema-eval/fuzz`.
+- **Grammar-based (in Sema)**: `make fuzz-grammar` (just the release binary). Generates random *valid* Sema programs and checks a printer/reader round-trip oracle and a compiler/VM value oracle; detects VM panics. Written in Sema itself at `fuzz/grammar-fuzz.sema`, driven by `scripts/grammar-fuzz.sh`. Every finding reproduces from one integer seed; `make fuzz-grammar-emit` prints sample programs. See `fuzz/README.md`.
+
 ## Adding New Functionality
 
 - **Builtin fn**: add to `crates/sema-stdlib/src/*.rs`, register in that module's `register()` fn, add dual-eval test.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build release build-pgo pgo-profile install install-pgo uninstall test test-lsp test-embedding-bench test-http test-llm check clippy fmt fmt-check clean run lint lint-links docs docs-check update-pricing examples smoke-bytecode test-providers fuzz fuzz-reader fuzz-eval setup bench-1m bench-10m bench-100m site-dev site-build site-preview site-deploy deploy coverage coverage-html bench bench-vm bench-save bench-suite bench-closure bench-numeric bench-compare bench-baseline profile profile-vm ts-setup ts-generate ts-test ts-playground js-lib-build js-lib-dev
+.PHONY: all build release build-pgo pgo-profile install install-pgo uninstall test test-lsp test-embedding-bench test-http test-llm check clippy fmt fmt-check clean run lint lint-links docs docs-check update-pricing examples smoke-bytecode test-providers fuzz fuzz-reader fuzz-eval fuzz-grammar fuzz-grammar-emit setup bench-1m bench-10m bench-100m site-dev site-build site-preview site-deploy deploy coverage coverage-html bench bench-vm bench-save bench-suite bench-closure bench-numeric bench-compare bench-baseline profile profile-vm ts-setup ts-generate ts-test ts-playground js-lib-build js-lib-dev
 build:
 	cargo build
 
@@ -143,6 +143,21 @@ fuzz-reader:
 
 fuzz-eval:
 	cd crates/sema-eval && rustup run nightly cargo fuzz run fuzz_eval -- -max_total_time=120 -timeout=10
+
+# Grammar-based fuzzer written in Sema itself (fuzz/grammar-fuzz.sema). Generates
+# random *valid* Sema programs and checks two correctness oracles: printer/reader
+# round-trip and a compiler/VM value oracle. No nightly / cargo-fuzz needed — runs
+# on the release binary. Every finding is reproducible from one integer seed.
+#   make fuzz-grammar                  # default sweep (random seed)
+#   make fuzz-grammar SEED=123 N=20000 DEPTH=5
+#   make fuzz-grammar-emit             # print a few sample generated programs
+fuzz-grammar: release
+	@./scripts/grammar-fuzz.sh check \
+		$(if $(N),-n $(N)) $(if $(DEPTH),-d $(DEPTH)) $(if $(SEED),-s $(SEED)) $(if $(V),-v)
+
+fuzz-grammar-emit: release
+	@./scripts/grammar-fuzz.sh emit \
+		$(if $(N),-n $(N)) $(if $(DEPTH),-d $(DEPTH)) $(if $(SEED),-s $(SEED)) $(if $(OUT),-o $(OUT))
 
 bench-1m: release
 	time ./target/release/sema examples/benchmarks/1brc.sema -- bench-1m.txt

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,116 @@
+# Grammar fuzzer (in Sema)
+
+A grammar-based fuzzer for Sema, **written in Sema itself** (`grammar-fuzz.sema`).
+It generates random *valid* Sema programs and checks them against correctness
+oracles. It complements the byte-level `cargo-fuzz` targets in
+`crates/sema-reader/fuzz` and `crates/sema-eval/fuzz`, which mutate raw bytes to
+find parser/evaluator panics. This one generates *structured, valid* input, so it
+reaches past the parser into the compiler and VM.
+
+## Why generate (instead of mutate)?
+
+Because Sema is homoiconic, a generated program *is* an ordinary Sema value, which
+makes two sharp oracles nearly free:
+
+1. **Round-trip — printer vs. reader.**
+   `(= form (read (str form)))`. We generate arbitrary valid s-expression *data*
+   (nested lists, vectors, maps, and every atom kind: ints, floats, bools, nil,
+   strings, symbols, keywords, chars) and assert that printing then re-reading
+   yields a structurally equal value. Any asymmetry between Sema's printer and
+   reader falls straight out.
+
+2. **Value oracle — compiler/VM vs. straight-line evaluation.**
+   `(= expected (eval form))`. We generate *well-typed, closed* integer/boolean
+   programs and compute their expected value **bottom-up while generating them**
+   (applying the same primitive ops incrementally). Then we `eval` the whole
+   nested form, which drives the full `macro-expand → lower → optimize → compile →
+   bytecode-VM` pipeline, and compare. A mismatch means the compiled/optimized
+   form disagrees with incremental evaluation — i.e. a bug in constant folding,
+   `if`/`let` lowering, closure capture, TCO, or short-circuit logic.
+
+3. **Hard crashes — VM panics.** Release builds are `panic = "abort"`, so a VM
+   panic kills the process. The driver records each iteration's seed to a
+   breadcrumb file *before* running it, so a crash is still reproducible from one
+   integer seed.
+
+The typed programs are deliberately a **closed, total** sublanguage (`+ - * min
+max abs`, comparisons, `and/or/not`, `if`, `let`, and immediately-applied
+`lambda`s over integers/booleans) so they evaluate to a known value instead of
+bouncing off type/arity/unbound-variable errors. That keeps the oracle exact and
+the programs reaching deep into the VM.
+
+## Running
+
+```bash
+make fuzz-grammar                         # default sweep, random seed
+make fuzz-grammar SEED=123 N=20000 DEPTH=5
+make fuzz-grammar V=1                      # verbose: print passing forms too
+make fuzz-grammar-emit N=10                # print sample generated programs
+make fuzz-grammar-emit N=50 OUT=/tmp/progs.sema
+
+# or call the driver directly (no rebuild):
+./scripts/grammar-fuzz.sh check -n 5000 -d 4
+./scripts/grammar-fuzz.sh emit  -n 10 -s 7
+```
+
+The driver exits `0` on success, `1` on a deterministic mismatch (round-trip or
+value oracle), and `2` on a hard crash. In every failure case it prints the exact
+reproduction command.
+
+### Reproducing and minimizing a finding
+
+Iteration *i* uses seed `base + i` and re-seeds the PRNG, so each finding
+reproduces from a single seed with count 1:
+
+```bash
+# see the offending program:
+SEMA_FUZZ_MODE=emit SEMA_FUZZ_SEED=<seed> SEMA_FUZZ_COUNT=1 \
+  ./target/release/sema fuzz/grammar-fuzz.sema
+
+# re-run just that case under the checker:
+SEMA_FUZZ_SEED=<seed> SEMA_FUZZ_COUNT=1 \
+  ./target/release/sema fuzz/grammar-fuzz.sema
+```
+
+Lower `SEMA_FUZZ_DEPTH` to shrink the form, then hand-minimize from the emitted
+program.
+
+## Configuration (environment variables)
+
+| Variable               | Meaning                                              | Default  |
+| ---------------------- | --------------------------------------------------- | -------- |
+| `SEMA_FUZZ_SEED`       | base seed                                            | `0`      |
+| `SEMA_FUZZ_COUNT`      | iterations / programs                                | `200`    |
+| `SEMA_FUZZ_DEPTH`      | max generation depth                                 | `4`      |
+| `SEMA_FUZZ_MODE`       | `check` (run oracles) or `emit` (print programs)     | `check`  |
+| `SEMA_FUZZ_OUT`        | emit mode: output file (else stdout)                | stdout   |
+| `SEMA_FUZZ_CRASH_FILE` | check mode: breadcrumb file for the in-flight seed   | (unset)  |
+| `SEMA_FUZZ_VERBOSE`    | `1` to also print passing forms                     | `0`      |
+
+## Extending the grammar
+
+The generator is small and self-contained. To add a production:
+
+- **New typed (evaluable) form** — add a case to `gen-int` (or `gen-bool`) and a
+  helper that returns `(mk form value)`, where `form` is the generated code and
+  `value` is its result computed from the children's values. Keep it **total**
+  (no errors for any input) so the oracle stays exact — e.g. guard division, or
+  skip partial ops. Bump the `(rng-int! N)` arms count to include it.
+- **New datum kind** (round-trip coverage) — add a case to `gen-atom` or a new
+  container to `gen-datum`. Make sure it round-trips (e.g. unique map keys so the
+  literal doesn't collapse; avoid string contents the printer can't yet escape —
+  see the note on `*str-alpha*`).
+
+## Known limitations / deliberate exclusions
+
+- **String escaping.** The current printer renders strings without escaping `"`
+  and `\`, so generated strings draw from a safe alphabet (`*str-alpha*`). This is
+  a real, separate printer gap; including those characters would mask structural
+  findings. Re-enable them once the printer escapes — that itself becomes a
+  round-trip test.
+- **No reference interpreter.** The value oracle compares the VM against
+  *incremental* evaluation using the same primitives, so it targets the
+  compiler/optimizer/VM, not the arithmetic primitives themselves. Bringing in an
+  external reference (e.g. another Scheme) would extend it to primitive semantics.
+- **Floats** are generated as `k/1000`; they test float printing + shortest
+  round-trip parsing, not the full float space.

--- a/fuzz/grammar-fuzz.sema
+++ b/fuzz/grammar-fuzz.sema
@@ -1,0 +1,348 @@
+;; grammar-fuzz.sema — a grammar-based fuzzer for Sema, written in Sema.
+;;
+;; Because Sema is homoiconic, a generated program *is* an ordinary Sema value
+;; (a list/vector/atom). That makes two sharp correctness oracles almost free:
+;;
+;;   1. Round-trip (reader <-> printer):   (= form (read (str form)))
+;;      Generates arbitrary valid s-expression *data* and asserts that printing
+;;      it and reading it back yields a structurally equal value. Any asymmetry
+;;      between the printer and the reader falls straight out.
+;;
+;;   2. Differential value oracle (compiler/VM):  (= expected (eval form))
+;;      Generates *well-typed, closed* integer/boolean programs and, crucially,
+;;      computes their expected value bottom-up *while generating* them (using
+;;      the same primitive ops, applied incrementally). It then `eval`s the whole
+;;      nested form — which drives the full macro-expand -> lower -> optimize ->
+;;      compile -> bytecode-VM pipeline — and compares. A mismatch means the
+;;      compiler/optimizer/VM disagrees with straight-line evaluation: constant
+;;      folding, `if`/`let` lowering, closure capture, TCO, short-circuit logic.
+;;
+;; A third failure mode — a hard VM crash (Rust panic; release builds are
+;; panic=abort) — is detected by the driver (scripts/grammar-fuzz.sh): before
+;; each iteration we write the iteration's seed to SEMA_FUZZ_CRASH_FILE, so if
+;; the process dies the driver knows exactly which seed reproduces it.
+;;
+;; Everything is driven by a small self-contained PRNG so every finding is
+;; reproducible from a single integer seed.
+;;
+;; Configuration (environment variables):
+;;   SEMA_FUZZ_SEED        base seed (int, default 0)
+;;   SEMA_FUZZ_COUNT       number of iterations / programs (default 200)
+;;   SEMA_FUZZ_DEPTH       max generation depth (default 4)
+;;   SEMA_FUZZ_MODE        "check" (run oracles, default) or "emit" (print programs)
+;;   SEMA_FUZZ_OUT         emit mode: file to write to (default: stdout)
+;;   SEMA_FUZZ_CRASH_FILE  check mode: file to record the in-flight seed (crash breadcrumb)
+;;   SEMA_FUZZ_VERBOSE     "1" to print every passing form too
+;;
+;; Iteration i uses seed (base + i), and each iteration re-seeds the PRNG, so a
+;; failure reported at a given seed reproduces exactly with
+;;   SEMA_FUZZ_SEED=<seed> SEMA_FUZZ_COUNT=1
+
+;; ─────────────────────────────────────────────────────────────────────────
+;; PRNG — PCG-style LCG over wrapping 64-bit integers (deterministic, seedable)
+;; ─────────────────────────────────────────────────────────────────────────
+
+(define *rng* 1)
+
+(define (rng-seed! s)
+  ;; Force a nonzero odd-ish state; magnitude kept under 2^63.
+  (set! *rng* (bit/or 1 (mod (abs s) 9223372036854775806))))
+
+(define (rng-next!)
+  (set! *rng* (+ (* *rng* 6364136223846793005) 1442695040888963407))
+  *rng*)
+
+(define (rng-int! n)
+  ;; uniform-ish in [0, n); uses the high bits of the LCG state
+  (if (<= n 1) 0 (mod (abs (bit/shift-right (rng-next!) 17)) n)))
+
+(define (rng-range! lo hi)            ; inclusive [lo, hi]
+  (+ lo (rng-int! (+ 1 (- hi lo)))))
+
+(define (rng-pick! xs) (nth xs (rng-int! (length xs))))
+(define (rng-bool!) (= 0 (rng-int! 2)))
+
+;; ─────────────────────────────────────────────────────────────────────────
+;; Datum generator — arbitrary valid s-expression data (for the round-trip test)
+;; ─────────────────────────────────────────────────────────────────────────
+
+;; Pools of literal symbols/keywords/chars. Symbols are deliberately "safe"
+;; identifiers (no reader-special tokens) so the only thing under test is the
+;; printer/reader, not our choice of names.
+(define *sym-pool* (list 'a 'b 'c 'foo 'bar 'x 'y 'list 'quote 'do-thing))
+(define *kw-pool*  (list :a :b :c :foo :bar :k1 :k2 :k3))
+(define *char-pool* (list #\a #\Z #\0 #\space #\newline #\tab #\return))
+;; Safe string alphabet — excludes " and \ which the current printer does not
+;; escape (a separate, known printer gap; keep it out so structural bugs aren't
+;; masked by it).
+(define *str-alpha* "abcdefghijkRSTUVWXYZ0123456789 -_./:?!()[]{}*+=<>")
+
+(define (gen-char-from alpha)
+  (let ((k (rng-int! (string-length alpha))))
+    (substring alpha k (+ k 1))))
+
+(define (gen-string)
+  (let ((len (rng-int! 8)))
+    (let loop ((i 0) (acc ""))
+      (if (>= i len)
+          acc
+          (loop (+ i 1) (string-append acc (gen-char-from *str-alpha*)))))))
+
+(define (gen-float)
+  ;; k/1000 style values exercise float printing + shortest-round-trip parsing
+  (/ (rng-range! -1000000 1000000) 1000.0))
+
+(define (gen-atom)
+  (let ((c (rng-int! 8)))
+    (cond
+      ((= c 0) (rng-range! -100000 100000))
+      ((= c 1) (gen-float))
+      ((= c 2) (rng-bool!))
+      ((= c 3) nil)
+      ((= c 4) (gen-string))
+      ((= c 5) (rng-pick! *sym-pool*))
+      ((= c 6) (rng-pick! *kw-pool*))
+      (else    (rng-pick! *char-pool*)))))
+
+(define (gen-list depth)
+  (let ((k (rng-int! 5)))
+    (let loop ((i 0) (acc (list)))
+      (if (>= i k)
+          (reverse acc)
+          (loop (+ i 1) (cons (gen-datum (- depth 1)) acc))))))
+
+(define (gen-vector depth)
+  (list->vector (gen-list depth)))
+
+(define (gen-map depth)
+  ;; Unique keyword keys (indexed into the pool) so the literal never collapses.
+  (let ((k (rng-int! 4)))
+    (let loop ((i 0) (m {}))
+      (if (>= i k)
+          m
+          (loop (+ i 1) (assoc m (nth *kw-pool* i) (gen-datum (- depth 1))))))))
+
+(define (gen-datum depth)
+  (if (<= depth 0)
+      (gen-atom)
+      (let ((choice (rng-int! 10)))
+        (cond
+          ((< choice 5) (gen-atom))
+          ((< choice 7) (gen-list depth))
+          ((< choice 9) (gen-vector depth))
+          (else         (gen-map depth))))))
+
+;; ─────────────────────────────────────────────────────────────────────────
+;; Typed program generator — well-typed, closed int/bool programs (eval oracle)
+;;
+;; Each generator returns a 2-element list (form expected-value): `form` is the
+;; Sema code, `expected-value` is what evaluating it must produce, computed
+;; bottom-up during generation.
+;;
+;; `env` is a list of (symbol value) pairs giving the variables in scope and
+;; their known values, so every generated reference is bound and its value known.
+;; ─────────────────────────────────────────────────────────────────────────
+
+(define (mk form val) (list form val))
+(define (gf p) (nth p 0))            ; the generated form
+(define (gv p) (nth p 1))            ; its expected value
+
+(define (gen-int env depth)
+  (if (or (<= depth 0) (and (pair? env) (= 0 (rng-int! 4))))
+      ;; leaf: a bound variable reference or an integer literal
+      (if (and (pair? env) (rng-bool!))
+          (let ((b (rng-pick! env))) (mk (nth b 0) (nth b 1)))
+          (let ((n (rng-range! -12 12))) (mk n n)))
+      ;; compound
+      (let ((choice (rng-int! 8)))
+        (cond
+          ((= choice 0) (gen-int-bin '+   env depth +))
+          ((= choice 1) (gen-int-bin '-   env depth -))
+          ((= choice 2) (gen-int-bin '*   env depth *))
+          ((= choice 3) (gen-int-bin 'min env depth min))
+          ((= choice 4) (gen-int-bin 'max env depth max))
+          ((= choice 5) (gen-int-if  env depth))
+          ((= choice 6) (gen-int-let env depth))
+          (else         (gen-int-app env depth))))))
+
+(define (gen-int-bin op env depth f)
+  (let* ((a (gen-int env (- depth 1)))
+         (b (gen-int env (- depth 1))))
+    (mk (list op (gf a) (gf b)) (f (gv a) (gv b)))))
+
+(define (gen-int-if env depth)
+  (let* ((c (gen-bool env (- depth 1)))
+         (t (gen-int  env (- depth 1)))
+         (e (gen-int  env (- depth 1))))
+    (mk (list 'if (gf c) (gf t) (gf e))
+        (if (gv c) (gv t) (gv e)))))
+
+(define (gen-int-let env depth)
+  (let* ((v    (gensym "v"))
+         (init (gen-int env (- depth 1)))
+         (env2 (cons (list v (gv init)) env))
+         (body (gen-int env2 (- depth 1))))
+    (mk (list 'let (list (list v (gf init))) (gf body))
+        (gv body))))
+
+(define (gen-int-app env depth)
+  ;; ((lambda (p) body) arg) — exercises closures + application
+  (let* ((p    (gensym "p"))
+         (arg  (gen-int env (- depth 1)))
+         (env2 (cons (list p (gv arg)) env))
+         (body (gen-int env2 (- depth 1))))
+    (mk (list (list 'lambda (list p) (gf body)) (gf arg))
+        (gv body))))
+
+(define (gen-bool env depth)
+  (if (<= depth 0)
+      (let ((b (rng-bool!))) (mk b b))
+      (let ((choice (rng-int! 8)))
+        (cond
+          ((= choice 0) (let ((b (rng-bool!))) (mk b b)))
+          ((= choice 1) (gen-bool-cmp '=  env depth =))
+          ((= choice 2) (gen-bool-cmp '<  env depth <))
+          ((= choice 3) (gen-bool-cmp '>  env depth >))
+          ((= choice 4) (gen-bool-cmp '<= env depth <=))
+          ((= choice 5) (gen-bool-cmp '>= env depth >=))
+          ((= choice 6) (gen-bool-logic 'and env depth))
+          (else         (gen-bool-not env depth))))))
+
+(define (gen-bool-cmp op env depth f)
+  (let* ((a (gen-int env (- depth 1)))
+         (b (gen-int env (- depth 1))))
+    (mk (list op (gf a) (gf b)) (f (gv a) (gv b)))))
+
+(define (gen-bool-logic op env depth)
+  (let* ((x (gen-bool env (- depth 1)))
+         (y (gen-bool env (- depth 1))))
+    (if (= 0 (rng-int! 2))
+        (mk (list 'and (gf x) (gf y)) (and (gv x) (gv y)))
+        (mk (list 'or  (gf x) (gf y)) (or  (gv x) (gv y))))))
+
+(define (gen-bool-not env depth)
+  (let ((x (gen-bool env (- depth 1))))
+    (mk (list 'not (gf x)) (not (gv x)))))
+
+(define (gen-typed depth) (gen-int (list) depth))
+
+;; ─────────────────────────────────────────────────────────────────────────
+;; Oracles + reporting
+;; ─────────────────────────────────────────────────────────────────────────
+
+(define *failures* 0)
+(define *cur-seed* 0)
+(define *verbose* #f)
+
+(define (report-fail kind form a b)
+  (set! *failures* (+ *failures* 1))
+  (display "FAIL [") (display kind) (display "] seed=") (display (number->string *cur-seed*))
+  (newline)
+  (display "  form:     ") (display (str form)) (newline)
+  (display "  expected: ") (display (str a)) (newline)
+  (display "  actual:   ") (display (str b)) (newline)
+  (display "  reproduce: SEMA_FUZZ_SEED=") (display (number->string *cur-seed*))
+  (display " SEMA_FUZZ_COUNT=1") (newline)
+  #f)
+
+(define (check-roundtrip d)
+  ;; Wrap in a list so the *readable* printer path is exercised (Sema's `str`
+  ;; renders a bare top-level string as its raw contents — display semantics —
+  ;; but quotes strings nested inside a container, which is the readable form
+  ;; programs are actually printed with). This tests Sema's printer against
+  ;; Sema's reader, not our harness against either.
+  (let* ((wrapped (list d))
+         (s (str wrapped)))
+    (try
+      (let ((d2 (read s)))
+        (if (= wrapped d2)
+            #t
+            (report-fail "roundtrip" wrapped s d2)))
+      (catch e (report-fail "roundtrip-read-error" wrapped s e)))))
+
+(define (check-oracle pair)
+  (let ((form     (gf pair))
+        (expected (gv pair)))
+    (try
+      (let ((got (eval form)))
+        (if (= expected got)
+            #t
+            (report-fail "oracle" form expected got)))
+      (catch e (report-fail "oracle-eval-error" form expected e)))))
+
+;; ─────────────────────────────────────────────────────────────────────────
+;; Config
+;; ─────────────────────────────────────────────────────────────────────────
+
+(define (cfg name default)
+  (let ((v (env name)))
+    (if (null? v) default v)))
+
+(define (cfg-int name default)
+  (let ((v (env name)))
+    (if (null? v) default (string->number v))))
+
+(define base-seed  (cfg-int "SEMA_FUZZ_SEED" 0))
+(define iterations (cfg-int "SEMA_FUZZ_COUNT" 200))
+(define max-depth  (cfg-int "SEMA_FUZZ_DEPTH" 4))
+(define mode       (cfg "SEMA_FUZZ_MODE" "check"))
+(define out-file   (env "SEMA_FUZZ_OUT"))
+(define crash-file (env "SEMA_FUZZ_CRASH_FILE"))
+(set! *verbose* (= "1" (cfg "SEMA_FUZZ_VERBOSE" "0")))
+
+;; ─────────────────────────────────────────────────────────────────────────
+;; Modes
+;; ─────────────────────────────────────────────────────────────────────────
+
+(define (run-check)
+  (display "grammar-fuzz: check  seed=") (display (number->string base-seed))
+  (display " count=") (display (number->string iterations))
+  (display " depth=") (display (number->string max-depth)) (newline)
+  (let loop ((i 0))
+    (if (>= i iterations)
+        (finish)
+        (let ((seed (+ base-seed i)))
+          (set! *cur-seed* seed)
+          (when (not (null? crash-file)) (file/write crash-file (number->string seed)))
+          (rng-seed! seed)
+          ;; round-trip property on a random datum
+          (let ((d (gen-datum max-depth)))
+            (let ((ok (check-roundtrip d)))
+              (when (and *verbose* ok)
+                (display "ok roundtrip: ") (display (str d)) (newline))))
+          ;; value oracle on a typed program (same RNG stream continues)
+          (let ((p (gen-typed max-depth)))
+            (let ((ok (check-oracle p)))
+              (when (and *verbose* ok)
+                (display "ok oracle: ") (display (str (gf p)))
+                (display " = ") (display (str (gv p))) (newline))))
+          (loop (+ i 1))))))
+
+(define (finish)
+  ;; success: clear the crash breadcrumb so the driver knows we exited cleanly
+  (when (not (null? crash-file)) (file/write crash-file "ok"))
+  (newline)
+  (if (= *failures* 0)
+      (begin (display "PASS: ") (display (number->string iterations))
+             (display " iterations, 0 failures") (newline) (exit 0))
+      (begin (display "FAILURES: ") (display (number->string *failures*)) (newline)
+             (exit 1))))
+
+(define (run-emit)
+  (let loop ((i 0) (acc (list)))
+    (if (>= i iterations)
+        (let ((text (string/join (reverse acc) "\n")))
+          (if (null? out-file)
+              (begin (display text) (newline))
+              (begin (file/write out-file (string-append text "\n"))
+                     (display "wrote ") (display (number->string iterations))
+                     (display " programs to ") (display out-file) (newline))))
+        (begin
+          (rng-seed! (+ base-seed i))
+          (let ((p (gen-typed max-depth)))
+            (loop (+ i 1)
+                  (cons (string-append "; seed=" (number->string (+ base-seed i))
+                                       " => " (str (gv p)) "\n" (str (gf p)))
+                        acc)))))))
+
+(if (= mode "emit") (run-emit) (run-check))

--- a/fuzz/grammar-fuzz.sema
+++ b/fuzz/grammar-fuzz.sema
@@ -9,13 +9,20 @@
 ;;      between the printer and the reader falls straight out.
 ;;
 ;;   2. Differential value oracle (compiler/VM):  (= expected (eval form))
-;;      Generates *well-typed, closed* integer/boolean programs and, crucially,
-;;      computes their expected value bottom-up *while generating* them (using
-;;      the same primitive ops, applied incrementally). It then `eval`s the whole
-;;      nested form — which drives the full macro-expand -> lower -> optimize ->
+;;      Generates *well-typed, closed* programs over int / bool / float / string /
+;;      list / vector / map, computing their expected value bottom-up *while
+;;      generating* them (applying the real ops incrementally). It then `eval`s the
+;;      whole nested form — driving the full macro-expand -> lower -> optimize ->
 ;;      compile -> bytecode-VM pipeline — and compares. A mismatch means the
-;;      compiler/optimizer/VM disagrees with straight-line evaluation: constant
-;;      folding, `if`/`let` lowering, closure capture, TCO, short-circuit logic.
+;;      compiler/optimizer/VM disagrees with straight-line evaluation.
+;;
+;;      Constructs: arithmetic (+ - * variadic, min/max, mod, abs, unary -),
+;;      comparisons, even?/odd?/zero?/positive?/negative?, and/or/not, if, cond,
+;;      case, match (incl. binding), multi-binding/mixed-type let, multi-arg
+;;      lambdas + application, curried closures, set!, try/throw/catch, apply,
+;;      named-let TCO recursion (large N), and list/vector/map/string ops.
+;;      Excluded by design: non-deterministic surfaces (LLM, time, randomness,
+;;      uuid, file/network IO, async timing) — no stable oracle.
 ;;
 ;; A third failure mode — a hard VM crash (Rust panic; release builds are
 ;; panic=abort) — is detected by the driver (scripts/grammar-fuzz.sh): before
@@ -45,8 +52,16 @@
 (define *rng* 1)
 
 (define (rng-seed! s)
-  ;; Force a nonzero odd-ish state; magnitude kept under 2^63.
-  (set! *rng* (bit/or 1 (mod (abs s) 9223372036854775806))))
+  ;; Scramble the seed through one LCG step before use. The previous version did
+  ;; `(bit/or 1 ...)`, which collapsed every adjacent pair of seeds (2k and 2k+1)
+  ;; to the same state — and since the driver feeds consecutive seeds (base+i),
+  ;; that silently made half of every run an exact duplicate. Diffusing the seed
+  ;; here makes adjacent base+i streams fully independent. (The LCG below is
+  ;; full-period from any state — Hull-Dobell: A=...005 ≡ 1 mod 4, C odd — so no
+  ;; odd-state requirement exists in the first place.)
+  (set! *rng*
+        (mod (abs (+ (* (+ (abs s) 1) 6364136223846793005) 1442695040888963407))
+             9223372036854775806)))
 
 (define (rng-next!)
   (set! *rng* (+ (* *rng* 6364136223846793005) 1442695040888963407))
@@ -147,84 +162,557 @@
 (define (gf p) (nth p 0))            ; the generated form
 (define (gv p) (nth p 1))            ; its expected value
 
+;; env entries are (symbol value type), type one of 'int 'bool 'list. Tracking
+;; the type lets every generated variable reference be well-typed.
+(define (env-of-type env t)
+  (filter (lambda (e) (= (nth e 2) t)) env))
+
+;; A (form value) for a random in-scope var of type t, or nil if none exist.
+(define (maybe-ref env t)
+  (let ((cands (env-of-type env t)))
+    (if (pair? cands)
+        (let ((b (rng-pick! cands))) (mk (nth b 0) (nth b 1)))
+        nil)))
+
+;; The set of value types the program generator understands (LLM/IO/time/random
+;; are deliberately excluded — no deterministic oracle).
+(define *types* (list 'int 'int 'int 'bool 'list 'float 'string 'vec 'map))
+
+;; Dispatch generation by type.
+(define (gen-of t env depth)
+  (cond ((= t 'int)    (gen-int    env depth))
+        ((= t 'bool)   (gen-bool   env depth))
+        ((= t 'list)   (gen-ilist  env depth))
+        ((= t 'float)  (gen-flt env depth))
+        ((= t 'string) (gen-str    env depth))
+        ((= t 'vec)    (gen-vec    env depth))
+        (else          (gen-map-v  env depth))))
+
+;; Nonzero divisor literals for mod (avoids division-by-zero, which raises).
+(define *nz* (list 1 2 3 -1 -2 -3 4 -4 7 -7 11 -11))
+
+;; ── int ──────────────────────────────────────────────────────────────────
 (define (gen-int env depth)
-  (if (or (<= depth 0) (and (pair? env) (= 0 (rng-int! 4))))
-      ;; leaf: a bound variable reference or an integer literal
-      (if (and (pair? env) (rng-bool!))
-          (let ((b (rng-pick! env))) (mk (nth b 0) (nth b 1)))
-          (let ((n (rng-range! -12 12))) (mk n n)))
-      ;; compound
-      (let ((choice (rng-int! 8)))
+  (if (<= depth 0)
+      (gen-int-leaf env)
+      (let ((choice (rng-int! 23)))
         (cond
-          ((= choice 0) (gen-int-bin '+   env depth +))
-          ((= choice 1) (gen-int-bin '-   env depth -))
-          ((= choice 2) (gen-int-bin '*   env depth *))
-          ((= choice 3) (gen-int-bin 'min env depth min))
-          ((= choice 4) (gen-int-bin 'max env depth max))
-          ((= choice 5) (gen-int-if  env depth))
-          ((= choice 6) (gen-int-let env depth))
-          (else         (gen-int-app env depth))))))
+          ((< choice 3)  (gen-int-leaf env))
+          ((= choice 3)  (gen-int-bin '+ env depth +))
+          ((= choice 4)  (gen-int-bin '- env depth -))
+          ((= choice 5)  (gen-int-bin '* env depth *))
+          ((= choice 6)  (gen-int-vararith env depth))
+          ((= choice 7)  (gen-int-minmax env depth))
+          ((= choice 8)  (gen-int-unary env depth))
+          ((= choice 9)  (gen-int-mod env depth))
+          ((= choice 10) (gen-int-if env depth))
+          ((= choice 11) (gen-int-cond env depth))
+          ((= choice 12) (gen-int-let env depth))
+          ((= choice 13) (gen-int-app env depth))
+          ((= choice 14) (gen-int-fromlist env depth))
+          ((= choice 15) (gen-int-recur env depth))
+          ((= choice 16) (gen-int-setbang env depth))
+          ((= choice 17) (gen-int-try env depth))
+          ((= choice 18) (gen-int-match env depth))
+          ((= choice 19) (gen-int-case env depth))
+          ((= choice 20) (gen-int-apply env depth))
+          ((= choice 21) (gen-int-curry env depth))
+          (else          (gen-int-fromcontainer env depth))))))
+
+(define (gen-int-leaf env)
+  (let ((r (maybe-ref env 'int)))
+    (if (and (not (null? r)) (rng-bool!))
+        r
+        (let ((n (rng-range! -12 12))) (mk n n)))))
 
 (define (gen-int-bin op env depth f)
-  (let* ((a (gen-int env (- depth 1)))
-         (b (gen-int env (- depth 1))))
+  (let ((a (gen-int env (- depth 1))) (b (gen-int env (- depth 1))))
     (mk (list op (gf a) (gf b)) (f (gv a) (gv b)))))
+
+(define (gen-int-vararith env depth)
+  (let ((a (gen-int env (- depth 1)))
+        (b (gen-int env (- depth 1)))
+        (c (gen-int env (- depth 1))))
+    (if (rng-bool!)
+        (mk (list '+ (gf a) (gf b) (gf c)) (+ (gv a) (gv b) (gv c)))
+        (mk (list '* (gf a) (gf b) (gf c)) (* (gv a) (gv b) (gv c))))))
+
+(define (gen-int-minmax env depth)
+  (let ((a (gen-int env (- depth 1))) (b (gen-int env (- depth 1))))
+    (if (rng-bool!)
+        (mk (list 'min (gf a) (gf b)) (min (gv a) (gv b)))
+        (mk (list 'max (gf a) (gf b)) (max (gv a) (gv b))))))
+
+(define (gen-int-unary env depth)
+  (let ((a (gen-int env (- depth 1))))
+    (if (rng-bool!)
+        (mk (list '- (gf a)) (- (gv a)))
+        (mk (list 'abs (gf a)) (abs (gv a))))))
+
+(define (gen-int-mod env depth)
+  (let ((a (gen-int env (- depth 1))) (d (rng-pick! *nz*)))
+    (mk (list 'mod (gf a) d) (mod (gv a) d))))
 
 (define (gen-int-if env depth)
-  (let* ((c (gen-bool env (- depth 1)))
-         (t (gen-int  env (- depth 1)))
-         (e (gen-int  env (- depth 1))))
-    (mk (list 'if (gf c) (gf t) (gf e))
-        (if (gv c) (gv t) (gv e)))))
+  (let ((c (gen-bool env (- depth 1)))
+        (t (gen-int env (- depth 1)))
+        (e (gen-int env (- depth 1))))
+    (mk (list 'if (gf c) (gf t) (gf e)) (if (gv c) (gv t) (gv e)))))
 
+(define (gen-int-cond env depth)
+  (let ((c1 (gen-bool env (- depth 1))) (e1 (gen-int env (- depth 1)))
+        (c2 (gen-bool env (- depth 1))) (e2 (gen-int env (- depth 1)))
+        (ed (gen-int env (- depth 1))))
+    (mk (list 'cond
+              (list (gf c1) (gf e1))
+              (list (gf c2) (gf e2))
+              (list 'else (gf ed)))
+        (cond ((gv c1) (gv e1)) ((gv c2) (gv e2)) (else (gv ed))))))
+
+;; Multi-binding let where each binding can be any type (so bool/list vars also
+;; enter scope), body is an int.
 (define (gen-int-let env depth)
-  (let* ((v    (gensym "v"))
-         (init (gen-int env (- depth 1)))
-         (env2 (cons (list v (gv init)) env))
+  (let* ((v1 (gensym "v")) (t1 (rng-pick! *types*))
+         (i1 (gen-of t1 env (- depth 1)))
+         (v2 (gensym "v")) (t2 (rng-pick! *types*))
+         (i2 (gen-of t2 env (- depth 1)))
+         (env2 (cons (list v1 (gv i1) t1) (cons (list v2 (gv i2) t2) env)))
          (body (gen-int env2 (- depth 1))))
-    (mk (list 'let (list (list v (gf init))) (gf body))
+    (mk (list 'let (list (list v1 (gf i1)) (list v2 (gf i2))) (gf body))
         (gv body))))
 
+;; ((lambda (p1 p2) body) a1 a2) — closures + multi-arg application.
 (define (gen-int-app env depth)
-  ;; ((lambda (p) body) arg) — exercises closures + application
-  (let* ((p    (gensym "p"))
-         (arg  (gen-int env (- depth 1)))
-         (env2 (cons (list p (gv arg)) env))
+  (let* ((p1 (gensym "p")) (p2 (gensym "p"))
+         (a1 (gen-int env (- depth 1))) (a2 (gen-int env (- depth 1)))
+         (env2 (cons (list p1 (gv a1) 'int) (cons (list p2 (gv a2) 'int) env)))
          (body (gen-int env2 (- depth 1))))
-    (mk (list (list 'lambda (list p) (gf body)) (gf arg))
+    (mk (list (list 'lambda (list p1 p2) (gf body)) (gf a1) (gf a2))
         (gv body))))
 
+;; Pull an int out of a generated list: length / nth / foldl.
+(define (gen-int-fromlist env depth)
+  (let* ((l (gen-ilist env (- depth 1))) (lv (gv l)) (c (rng-int! 3)))
+    (cond
+      ((= c 0) (mk (list 'length (gf l)) (length lv)))
+      ((= c 1) (if (> (length lv) 0)
+                   (let ((idx (rng-int! (length lv))))
+                     (mk (list 'nth (gf l) idx) (nth lv idx)))
+                   (let ((n (rng-range! -9 9))) (mk n n))))
+      (else (if (rng-bool!)
+                (mk (list 'foldl '+ 0 (gf l)) (foldl + 0 lv))
+                (mk (list 'foldl '* 1 (gf l)) (foldl * 1 lv)))))))
+
+;; Tail-recursive sum 1..N via named let — stresses TCO at large N. If TCO is
+;; broken this overflows the stack (caught as an eval error / crash).
+(define (sum-to n)
+  (let loop ((i n) (acc 0)) (if (> i 0) (loop (- i 1) (+ acc i)) acc)))
+
+(define (gen-int-recur env depth)
+  (let* ((loop (gensym "loop")) (i (gensym "i")) (acc (gensym "acc"))
+         (n (rng-range! 1 40000)))
+    (mk (list 'let loop
+              (list (list i n) (list acc 0))
+              (list 'if (list '> i 0)
+                    (list loop (list '- i 1) (list '+ acc i))
+                    acc))
+        (sum-to n))))
+
+;; ── bool ─────────────────────────────────────────────────────────────────
 (define (gen-bool env depth)
   (if (<= depth 0)
-      (let ((b (rng-bool!))) (mk b b))
-      (let ((choice (rng-int! 8)))
+      (gen-bool-leaf env)
+      (let ((choice (rng-int! 14)))
         (cond
-          ((= choice 0) (let ((b (rng-bool!))) (mk b b)))
-          ((= choice 1) (gen-bool-cmp '=  env depth =))
-          ((= choice 2) (gen-bool-cmp '<  env depth <))
-          ((= choice 3) (gen-bool-cmp '>  env depth >))
-          ((= choice 4) (gen-bool-cmp '<= env depth <=))
-          ((= choice 5) (gen-bool-cmp '>= env depth >=))
-          ((= choice 6) (gen-bool-logic 'and env depth))
-          (else         (gen-bool-not env depth))))))
+          ((< choice 2)  (gen-bool-leaf env))
+          ((= choice 2)  (gen-bool-cmp '= env depth =))
+          ((= choice 3)  (gen-bool-cmp '< env depth <))
+          ((= choice 4)  (gen-bool-cmp '> env depth >))
+          ((= choice 5)  (gen-bool-cmp '<= env depth <=))
+          ((= choice 6)  (gen-bool-cmp '>= env depth >=))
+          ((= choice 7)  (gen-bool-logic env depth))
+          ((= choice 8)  (gen-bool-not env depth))
+          ((= choice 9)  (gen-bool-pred env depth))
+          ((= choice 10) (gen-bool-if env depth))
+          ((= choice 11) (gen-bool-floatcmp env depth))
+          ((= choice 12) (gen-bool-mapcontains env depth))
+          (else          (gen-bool-let env depth))))))
+
+(define (gen-bool-leaf env)
+  (let ((r (maybe-ref env 'bool)))
+    (if (and (not (null? r)) (rng-bool!))
+        r
+        (let ((b (rng-bool!))) (mk b b)))))
 
 (define (gen-bool-cmp op env depth f)
-  (let* ((a (gen-int env (- depth 1)))
-         (b (gen-int env (- depth 1))))
+  (let ((a (gen-int env (- depth 1))) (b (gen-int env (- depth 1))))
     (mk (list op (gf a) (gf b)) (f (gv a) (gv b)))))
 
-(define (gen-bool-logic op env depth)
-  (let* ((x (gen-bool env (- depth 1)))
-         (y (gen-bool env (- depth 1))))
-    (if (= 0 (rng-int! 2))
-        (mk (list 'and (gf x) (gf y)) (and (gv x) (gv y)))
-        (mk (list 'or  (gf x) (gf y)) (or  (gv x) (gv y))))))
+(define (gen-bool-logic env depth)
+  (let ((x (gen-bool env (- depth 1))) (y (gen-bool env (- depth 1)))
+        (c (rng-int! 3)))
+    (cond
+      ((= c 0) (mk (list 'and (gf x) (gf y)) (and (gv x) (gv y))))
+      ((= c 1) (mk (list 'or  (gf x) (gf y)) (or  (gv x) (gv y))))
+      (else (let ((z (gen-bool env (- depth 1))))
+              (mk (list 'and (gf x) (gf y) (gf z))
+                  (and (gv x) (gv y) (gv z))))))))
 
 (define (gen-bool-not env depth)
   (let ((x (gen-bool env (- depth 1))))
     (mk (list 'not (gf x)) (not (gv x)))))
 
-(define (gen-typed depth) (gen-int (list) depth))
+(define (gen-bool-pred env depth)
+  (let ((a (gen-int env (- depth 1))) (c (rng-int! 5)))
+    (cond
+      ((= c 0) (mk (list 'even?     (gf a)) (even?     (gv a))))
+      ((= c 1) (mk (list 'odd?      (gf a)) (odd?      (gv a))))
+      ((= c 2) (mk (list 'zero?     (gf a)) (zero?     (gv a))))
+      ((= c 3) (mk (list 'positive? (gf a)) (positive? (gv a))))
+      (else    (mk (list 'negative? (gf a)) (negative? (gv a)))))))
+
+(define (gen-bool-if env depth)
+  (let ((c (gen-bool env (- depth 1)))
+        (t (gen-bool env (- depth 1)))
+        (e (gen-bool env (- depth 1))))
+    (mk (list 'if (gf c) (gf t) (gf e)) (if (gv c) (gv t) (gv e)))))
+
+(define (gen-bool-let env depth)
+  (let* ((v (gensym "v")) (init (gen-int env (- depth 1)))
+         (env2 (cons (list v (gv init) 'int) env))
+         (body (gen-bool env2 (- depth 1))))
+    (mk (list 'let (list (list v (gf init))) (gf body)) (gv body))))
+
+;; ── list (of ints) ─────────────────────────────────────────────────────────
+(define (gen-ilist env depth)
+  (if (<= depth 0)
+      (gen-list-leaf env)
+      (let ((choice (rng-int! 12)))
+        (cond
+          ((< choice 3)  (gen-list-leaf env))
+          ((= choice 3)  (gen-list-cons env depth))
+          ((= choice 4)  (gen-list-reverse env depth))
+          ((= choice 5)  (gen-list-append env depth))
+          ((= choice 6)  (gen-list-map env depth))
+          ((= choice 7)  (gen-list-filter env depth))
+          ((= choice 8)  (gen-list-range env depth))
+          ((= choice 9)  (gen-list-rest env depth))
+          (else          (gen-list-let env depth))))))
+
+(define (gen-list-leaf env)
+  (let ((r (maybe-ref env 'list)))
+    (if (and (not (null? r)) (rng-bool!))
+        r
+        (let ((k (rng-int! 5)))
+          (let loop ((i 0) (fs (list)) (vs (list)))
+            (if (>= i k)
+                (mk (cons 'list (reverse fs)) (reverse vs))
+                (let ((n (rng-range! -9 9)))
+                  (loop (+ i 1) (cons n fs) (cons n vs)))))))))
+
+(define (gen-list-cons env depth)
+  (let ((x (gen-int env (- depth 1))) (l (gen-ilist env (- depth 1))))
+    (mk (list 'cons (gf x) (gf l)) (cons (gv x) (gv l)))))
+
+(define (gen-list-reverse env depth)
+  (let ((l (gen-ilist env (- depth 1))))
+    (mk (list 'reverse (gf l)) (reverse (gv l)))))
+
+(define (gen-list-append env depth)
+  (let ((a (gen-ilist env (- depth 1))) (b (gen-ilist env (- depth 1))))
+    (mk (list 'append (gf a) (gf b)) (append (gv a) (gv b)))))
+
+;; map with a closed, simple lambda — expected computed by applying the matching
+;; real function to the known list value.
+(define (gen-list-map env depth)
+  (let* ((l (gen-ilist env (- depth 1))) (lv (gv l))
+         (k (rng-range! -5 5)) (c (rng-int! 3)))
+    (cond
+      ((= c 0) (mk (list 'map (list 'lambda (list 'x) (list '+ 'x k)) (gf l))
+                   (map (lambda (x) (+ x k)) lv)))
+      ((= c 1) (mk (list 'map (list 'lambda (list 'x) (list '* 'x k)) (gf l))
+                   (map (lambda (x) (* x k)) lv)))
+      (else    (mk (list 'map (list 'lambda (list 'x) (list 'abs 'x)) (gf l))
+                   (map (lambda (x) (abs x)) lv))))))
+
+(define (gen-list-filter env depth)
+  (let* ((l (gen-ilist env (- depth 1))) (lv (gv l)) (c (rng-int! 3)))
+    (cond
+      ((= c 0) (mk (list 'filter 'even? (gf l)) (filter even? lv)))
+      ((= c 1) (mk (list 'filter 'odd?  (gf l)) (filter odd?  lv)))
+      (else (let ((k (rng-range! -5 5)))
+              (mk (list 'filter (list 'lambda (list 'x) (list '> 'x k)) (gf l))
+                  (filter (lambda (x) (> x k)) lv)))))))
+
+(define (gen-list-range env depth)
+  (let* ((lo (rng-range! -5 5)) (hi (rng-range! lo (+ lo 8))))
+    (mk (list 'range lo hi) (range lo hi))))
+
+(define (gen-list-rest env depth)
+  (let* ((l (gen-ilist env (- depth 1))) (lv (gv l)))
+    (if (> (length lv) 0)
+        (mk (list 'rest (gf l)) (rest lv))
+        (mk (gf l) lv))))
+
+(define (gen-list-let env depth)
+  (let* ((v (gensym "v")) (init (gen-int env (- depth 1)))
+         (env2 (cons (list v (gv init) 'int) env))
+         (body (gen-ilist env2 (- depth 1))))
+    (mk (list 'let (list (list v (gf init))) (gf body)) (gv body))))
+
+;; ── int productions over the richer types + control forms ──────────────────
+
+;; (let ((v A)) (set! v B) v)  — mutation through set!.
+(define (gen-int-setbang env depth)
+  (let* ((v (gensym "v"))
+         (a (gen-int env (- depth 1)))
+         (b (gen-int (cons (list v (gv a) 'int) env) (- depth 1))))
+    (mk (list 'let (list (list v (gf a))) (list 'set! v (gf b)) v)
+        (gv b))))
+
+;; (try BODY (catch e HANDLER)) — either BODY always throws (=> HANDLER) or never
+;; throws (=> BODY). HANDLER does not reference e, so its value is deterministic.
+(define (gen-int-try env depth)
+  (let ((h (gen-int env (- depth 1))) (e (gensym "e")))
+    (if (rng-bool!)
+        (let ((thrown (gen-int env (- depth 1))))
+          (mk (list 'try (list 'throw (gf thrown)) (list 'catch e (gf h)))
+              (gv h)))
+        (let ((body (gen-int env (- depth 1))))
+          (mk (list 'try (gf body) (list 'catch e (gf h)))
+              (gv body))))))
+
+;; (match V (lit r) ... (x BODY))  — V is an int; last clause binds, so total.
+(define (gen-int-match env depth)
+  (let* ((scrut (gen-int env (- depth 1)))
+         (sv (gv scrut))
+         (k1 (rng-range! -6 6)) (r1 (gen-int env (- depth 1)))
+         (k2 (rng-range! -6 6)) (r2 (gen-int env (- depth 1)))
+         (bn (gensym "m"))
+         (rb (gen-int (cons (list bn sv 'int) env) (- depth 1))))
+    (mk (list 'match (gf scrut)
+              (list k1 (gf r1))
+              (list k2 (gf r2))
+              (list bn (gf rb)))
+        (cond ((= sv k1) (gv r1))
+              ((= sv k2) (gv r2))
+              (else (gv rb))))))
+
+;; (case V ((k1) r1) ((k2) r2) (else rd))
+(define (gen-int-case env depth)
+  (let* ((scrut (gen-int env (- depth 1)))
+         (sv (gv scrut))
+         (k1 (rng-range! -6 6)) (r1 (gen-int env (- depth 1)))
+         (k2 (rng-range! -6 6)) (r2 (gen-int env (- depth 1)))
+         (rd (gen-int env (- depth 1))))
+    (mk (list 'case (gf scrut)
+              (list (list k1) (gf r1))
+              (list (list k2) (gf r2))
+              (list 'else (gf rd)))
+        (cond ((= sv k1) (gv r1))
+              ((= sv k2) (gv r2))
+              (else (gv rd))))))
+
+;; (apply OP list-form) for OP in {+ *} — exercises apply + variadic dispatch.
+(define (gen-int-apply env depth)
+  (let* ((l (gen-ilist env (- depth 1))) (lv (gv l)))
+    (if (rng-bool!)
+        (mk (list 'apply '+ (gf l)) (apply + lv))
+        (mk (list 'apply '* (gf l)) (apply * lv)))))
+
+;; (((lambda (a) (lambda (b) (+ a b))) A) B) — curried/nested closures.
+(define (gen-int-curry env depth)
+  (let* ((a1 (gen-int env (- depth 1))) (a2 (gen-int env (- depth 1)))
+         (pa (gensym "a")) (pb (gensym "b")))
+    (mk (list (list (list 'lambda (list pa)
+                          (list 'lambda (list pb) (list '+ pa pb)))
+                    (gf a1))
+              (gf a2))
+        (+ (gv a1) (gv a2)))))
+
+;; Pull an int out of a vec / string / map.
+(define (gen-int-fromcontainer env depth)
+  (let ((c (rng-int! 5)))
+    (cond
+      ((= c 0) (let* ((v (gen-vec env (- depth 1))) (vv (gv v)))
+                 (if (> (count vv) 0)
+                     (let ((i (rng-int! (count vv))))
+                       (mk (list 'nth (gf v) i) (nth vv i)))
+                     (mk (list 'count (gf v)) (count vv)))))
+      ((= c 1) (let ((v (gen-vec env (- depth 1))))
+                 (mk (list 'count (gf v)) (count (gv v)))))
+      ((= c 2) (let ((s (gen-str env (- depth 1))))
+                 (mk (list 'string-length (gf s)) (string-length (gv s)))))
+      ((= c 3) (let ((m (gen-map-v env (- depth 1))))
+                 (mk (list 'count (gf m)) (count (gv m)))))
+      (else (let* ((m (gen-map-v env (- depth 1))) (mv (gv m)) (d (rng-range! -9 9)))
+              ;; get with default: deterministic regardless of key presence
+              (mk (list 'get (gf m) :zzz d) (get mv :zzz d)))))))
+
+;; ── float ──────────────────────────────────────────────────────────────────
+;; Magnitudes kept small so +/-/* never overflow to inf and never produce NaN;
+;; float `=` is exact, and expected is computed with the same ops, so it holds.
+(define (gen-flt env depth)
+  (if (<= depth 0)
+      (gen-flt-leaf env)
+      (let ((choice (rng-int! 9)))
+        (cond
+          ((< choice 3) (gen-flt-leaf env))
+          ((= choice 3) (gen-flt-bin '+ env depth +))
+          ((= choice 4) (gen-flt-bin '- env depth -))
+          ((= choice 5) (gen-flt-bin '* env depth *))
+          ((= choice 6) (gen-flt-unary env depth))
+          ((= choice 7) (gen-flt-if env depth))
+          (else         (gen-flt-let env depth))))))
+
+(define (gen-flt-leaf env)
+  (let ((r (maybe-ref env 'float)))
+    (if (and (not (null? r)) (rng-bool!))
+        r
+        (let ((f (/ (rng-range! -400 400) 8.0))) (mk f f)))))
+
+(define (gen-flt-bin op env depth f)
+  (let ((a (gen-flt env (- depth 1))) (b (gen-flt env (- depth 1))))
+    (mk (list op (gf a) (gf b)) (f (gv a) (gv b)))))
+
+(define (gen-flt-unary env depth)
+  (let ((a (gen-flt env (- depth 1))))
+    (mk (list '- (gf a)) (- (gv a)))))
+
+(define (gen-flt-if env depth)
+  (let ((c (gen-bool env (- depth 1)))
+        (t (gen-flt env (- depth 1)))
+        (e (gen-flt env (- depth 1))))
+    (mk (list 'if (gf c) (gf t) (gf e)) (if (gv c) (gv t) (gv e)))))
+
+(define (gen-flt-let env depth)
+  (let* ((v (gensym "f")) (init (gen-flt env (- depth 1)))
+         (env2 (cons (list v (gv init) 'float) env))
+         (body (gen-flt env2 (- depth 1))))
+    (mk (list 'let (list (list v (gf init))) (gf body)) (gv body))))
+
+(define (gen-bool-floatcmp env depth)
+  (let ((a (gen-flt env (- depth 1))) (b (gen-flt env (- depth 1)))
+        (c (rng-int! 3)))
+    (cond
+      ((= c 0) (mk (list '< (gf a) (gf b)) (< (gv a) (gv b))))
+      ((= c 1) (mk (list '> (gf a) (gf b)) (> (gv a) (gv b))))
+      (else    (mk (list '= (gf a) (gf a)) (= (gv a) (gv a)))))))
+
+;; ── string ──────────────────────────────────────────────────────────────────
+;; Forms are eval'd directly (not printed→read), so any content is fine; `=` is
+;; exact. Expected computed with the same string ops.
+(define *str-chars* "abcXYZ012 _-")
+
+(define (rand-string)
+  (let ((len (rng-int! 6)))
+    (let loop ((i 0) (acc ""))
+      (if (>= i len)
+          acc
+          (let ((k (rng-int! (string-length *str-chars*))))
+            (loop (+ i 1) (string-append acc (substring *str-chars* k (+ k 1)))))))))
+
+(define (gen-str env depth)
+  (if (<= depth 0)
+      (gen-str-leaf env)
+      (let ((choice (rng-int! 9)))
+        (cond
+          ((< choice 3) (gen-str-leaf env))
+          ((= choice 3) (gen-str-append env depth))
+          ((= choice 4) (gen-str-sub env depth))
+          ((= choice 5) (gen-str-case env depth #t))
+          ((= choice 6) (gen-str-case env depth #f))
+          ((= choice 7) (gen-str-reverse env depth))
+          (else         (gen-str-let env depth))))))
+
+(define (gen-str-leaf env)
+  (let ((r (maybe-ref env 'string)))
+    (if (and (not (null? r)) (rng-bool!))
+        r
+        (let ((s (rand-string))) (mk s s)))))
+
+(define (gen-str-append env depth)
+  (let ((a (gen-str env (- depth 1))) (b (gen-str env (- depth 1))))
+    (mk (list 'string-append (gf a) (gf b)) (string-append (gv a) (gv b)))))
+
+(define (gen-str-sub env depth)
+  (let* ((s (gen-str env (- depth 1))) (sv (gv s)) (n (string-length sv)))
+    (if (= n 0)
+        (mk (gf s) sv)
+        (let* ((start (rng-int! n)) (end (rng-range! start n)))
+          (mk (list 'substring (gf s) start end) (substring sv start end))))))
+
+(define (gen-str-case env depth up)
+  (let ((s (gen-str env (- depth 1))))
+    (if up
+        (mk (list 'string-upcase (gf s)) (string-upcase (gv s)))
+        (mk (list 'string-downcase (gf s)) (string-downcase (gv s))))))
+
+(define (gen-str-reverse env depth)
+  (let ((s (gen-str env (- depth 1))))
+    (mk (list 'string/reverse (gf s)) (string/reverse (gv s)))))
+
+(define (gen-str-let env depth)
+  (let* ((v (gensym "s")) (init (gen-str env (- depth 1)))
+         (env2 (cons (list v (gv init) 'string) env))
+         (body (gen-str env2 (- depth 1))))
+    (mk (list 'let (list (list v (gf init))) (gf body)) (gv body))))
+
+;; ── vector (of ints; immutable) ─────────────────────────────────────────────
+(define (gen-vec env depth)
+  (let ((r (maybe-ref env 'vec)))
+    (if (and (not (null? r)) (rng-bool!))
+        r
+        (let ((k (rng-int! 5)))
+          (let loop ((i 0) (fs (list)) (vs (list)))
+            (if (>= i k)
+                (mk (cons 'vector (reverse fs)) (list->vector (reverse vs)))
+                (let ((n (rng-range! -9 9)))
+                  (loop (+ i 1) (cons n fs) (cons n vs)))))))))
+
+;; ── map (keyword -> int) ─────────────────────────────────────────────────────
+(define *map-keys* (list :a :b :c :d :e))
+
+(define (gen-map-v env depth)
+  (if (<= depth 0)
+      (gen-map-leaf env)
+      (let ((choice (rng-int! 6)))
+        (cond
+          ((< choice 3) (gen-map-leaf env))
+          ((= choice 3) (gen-map-assoc env depth))
+          ((= choice 4) (gen-map-dissoc env depth))
+          (else         (gen-map-leaf env))))))
+
+(define (gen-map-leaf env)
+  (let ((r (maybe-ref env 'map)))
+    (if (and (not (null? r)) (rng-bool!))
+        r
+        ;; build a literal via an assoc chain over distinct keys
+        (let ((k (rng-int! 4)))
+          (let loop ((i 0) (form {}) (val {}))
+            (if (>= i k)
+                (mk form val)
+                (let ((key (nth *map-keys* i)) (n (rng-range! -9 9)))
+                  (loop (+ i 1)
+                        (list 'assoc form key n)
+                        (assoc val key n)))))))))
+
+(define (gen-map-assoc env depth)
+  (let ((m (gen-map-v env (- depth 1))) (k (rng-pick! *map-keys*))
+        (x (gen-int env (- depth 1))))
+    (mk (list 'assoc (gf m) k (gf x)) (assoc (gv m) k (gv x)))))
+
+(define (gen-map-dissoc env depth)
+  (let ((m (gen-map-v env (- depth 1))) (k (rng-pick! *map-keys*)))
+    (mk (list 'dissoc (gf m) k) (dissoc (gv m) k))))
+
+(define (gen-bool-mapcontains env depth)
+  (let ((m (gen-map-v env (- depth 1))) (k (rng-pick! *map-keys*)))
+    (mk (list 'contains? (gf m) k) (contains? (gv m) k))))
+
+;; Top-level: pick a result type (int-biased) and generate a closed program.
+(define (gen-typed depth)
+  (gen-of (rng-pick! *types*) (list) depth))
 
 ;; ─────────────────────────────────────────────────────────────────────────
 ;; Oracles + reporting

--- a/scripts/grammar-fuzz.sh
+++ b/scripts/grammar-fuzz.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# grammar-fuzz.sh — driver for the Sema grammar fuzzer (fuzz/grammar-fuzz.sema).
+#
+# Runs the in-language fuzzer, which checks two correctness oracles over randomly
+# generated Sema programs:
+#   * round-trip:  (= form (read (str form)))           — printer/reader symmetry
+#   * value oracle: (= expected (eval form))            — compiler/VM correctness
+# and detects hard VM crashes (panics; release is panic=abort) via a seed
+# breadcrumb so every finding is reproducible from one integer seed.
+#
+# Usage:
+#   scripts/grammar-fuzz.sh [check] [-n COUNT] [-d DEPTH] [-s SEED] [-v]
+#   scripts/grammar-fuzz.sh emit  [-n COUNT] [-d DEPTH] [-s SEED] [-o FILE]
+#
+# Options:
+#   -n COUNT   iterations / programs (default: 5000 for check, 20 for emit)
+#   -d DEPTH   max generation depth (default: 4)
+#   -s SEED    base seed (default: random)
+#   -o FILE    emit mode: write programs to FILE instead of stdout
+#   -v         verbose (check mode: also print passing forms)
+#
+# Exit status:
+#   0  all checks passed
+#   1  a deterministic mismatch was found (round-trip or value oracle)
+#   2  a hard crash (VM panic) was found; reproducing seed is printed
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+MODE="check"
+case "${1:-}" in
+  check|emit) MODE="$1"; shift ;;
+esac
+
+COUNT=""
+DEPTH="4"
+SEED=""
+OUT=""
+VERBOSE="0"
+
+while getopts "n:d:s:o:v" opt; do
+  case "$opt" in
+    n) COUNT="$OPTARG" ;;
+    d) DEPTH="$OPTARG" ;;
+    s) SEED="$OPTARG" ;;
+    o) OUT="$OPTARG" ;;
+    v) VERBOSE="1" ;;
+    *) echo "usage: $0 [check|emit] [-n COUNT] [-d DEPTH] [-s SEED] [-o FILE] [-v]" >&2; exit 64 ;;
+  esac
+done
+
+# Locate (or build) the sema binary.
+BIN=""
+for cand in "$ROOT/target/release/sema" "$ROOT/target/debug/sema" "$(command -v sema 2>/dev/null || true)"; do
+  if [ -n "$cand" ] && [ -x "$cand" ]; then BIN="$cand"; break; fi
+done
+if [ -z "$BIN" ]; then
+  echo "==> building release binary (cargo build --release -p sema-lang)" >&2
+  cargo build --release -p sema-lang || { echo "build failed" >&2; exit 70; }
+  BIN="$ROOT/target/release/sema"
+fi
+
+# Default counts per mode.
+if [ -z "$COUNT" ]; then
+  if [ "$MODE" = "emit" ]; then COUNT="20"; else COUNT="5000"; fi
+fi
+
+# Random seed if not pinned.
+if [ -z "$SEED" ]; then
+  SEED=$(( ($(date +%s) ^ ($$ << 13) ^ ${RANDOM:-0}) % 1000000000 ))
+fi
+
+export SEMA_FUZZ_COUNT="$COUNT"
+export SEMA_FUZZ_DEPTH="$DEPTH"
+export SEMA_FUZZ_SEED="$SEED"
+export SEMA_FUZZ_VERBOSE="$VERBOSE"
+
+if [ "$MODE" = "emit" ]; then
+  export SEMA_FUZZ_MODE="emit"
+  [ -n "$OUT" ] && export SEMA_FUZZ_OUT="$OUT"
+  exec "$BIN" "$ROOT/fuzz/grammar-fuzz.sema"
+fi
+
+# check mode: use a crash breadcrumb so a hard panic is still reproducible.
+CRASH_FILE="$(mktemp)"
+trap 'rm -f "$CRASH_FILE"' EXIT
+export SEMA_FUZZ_CRASH_FILE="$CRASH_FILE"
+
+"$BIN" "$ROOT/fuzz/grammar-fuzz.sema"
+status=$?
+
+if [ "$status" -eq 0 ]; then
+  exit 0
+elif [ "$status" -eq 1 ]; then
+  # Deterministic mismatch; the sema program already printed reproduction info.
+  exit 1
+else
+  # Hard crash (e.g. SIGABRT from panic=abort). Recover the in-flight seed.
+  last="$(cat "$CRASH_FILE" 2>/dev/null || true)"
+  echo "" >&2
+  echo "CRASH: sema exited with status $status (likely a VM panic)" >&2
+  if [ -n "$last" ] && [ "$last" != "ok" ]; then
+    echo "  reproduce with: SEMA_FUZZ_SEED=$last SEMA_FUZZ_COUNT=1 SEMA_FUZZ_DEPTH=$DEPTH \\" >&2
+    echo "                  $BIN $ROOT/fuzz/grammar-fuzz.sema" >&2
+    echo "  or:             SEMA_FUZZ_MODE=emit SEMA_FUZZ_SEED=$last SEMA_FUZZ_COUNT=1 SEMA_FUZZ_DEPTH=$DEPTH \\" >&2
+    echo "                  $BIN $ROOT/fuzz/grammar-fuzz.sema   # to see the offending program" >&2
+  else
+    echo "  (no breadcrumb captured; rerun with the same -s SEED to reproduce)" >&2
+  fi
+  exit 2
+fi


### PR DESCRIPTION
Generates random *valid* Sema programs and checks two correctness oracles,
complementing the byte-level cargo-fuzz targets (which only reach the
parser frontend):

- Round-trip: (= form (read (str form))) — exercises Sema's printer against
  its reader over arbitrary nested s-expression data (all atom kinds, lists,
  vectors, maps). Any printer/reader asymmetry surfaces directly.
- Value oracle: (= expected (eval form)) — generates well-typed, closed
  integer/boolean programs and computes the expected value bottom-up while
  generating, then evals the whole nested form through the full
  macro-expand -> lower -> optimize -> compile -> bytecode-VM pipeline and
  compares. Catches constant-folding, if/let lowering, closure capture, TCO,
  and short-circuit bugs.
- Crash detection: release builds are panic=abort; the driver writes a seed
  breadcrumb before each iteration so a VM panic is still reproducible.

The fuzzer itself is written in Sema (fuzz/grammar-fuzz.sema), leveraging
homoiconicity so a generated program is just a value. A self-contained
seedable PRNG makes every finding reproducible from one integer seed.

- fuzz/grammar-fuzz.sema  — generator + oracles (check and emit modes)
- scripts/grammar-fuzz.sh — driver (random seed, crash reproduction)
- fuzz/README.md          — design, usage, how to extend the grammar
- make fuzz-grammar / fuzz-grammar-emit targets

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013axSUQD3ouQEPW48BFkot5