### PR TITLE
Add `sema doc` CLI for browsing builtin & special-form docs

### DIFF
--- a/crates/sema/src/docs.rs
+++ b/crates/sema/src/docs.rs
@@ -53,6 +53,10 @@ pub(crate) fn completion_candidates(prefix: &str) -> Vec<String> {
 
 pub(crate) fn rendered_doc(name: &str) -> Option<String> {
     let entry = lookup(name)?;
+    Some(rendered_doc_entry(name, entry))
+}
+
+pub(crate) fn rendered_doc_entry(name: &str, entry: &DocEntry) -> String {
     let kind = if entry.special_form {
         "special form"
     } else {
@@ -71,7 +75,7 @@ pub(crate) fn rendered_doc(name: &str) -> Option<String> {
         )
     };
     let md = sema_lsp::builtin_docs::render_markdown(entry);
-    Some(format!("{heading}\n{}\n", render_terminal_markdown(&md)))
+    format!("{heading}\n{}\n", render_terminal_markdown(&md))
 }
 
 pub(crate) fn print_rendered(text: &str, pager: PagerMode) -> io::Result<()> {

--- a/crates/sema/src/docs.rs
+++ b/crates/sema/src/docs.rs
@@ -243,7 +243,14 @@ pub(crate) fn render_apropos_hits(pattern: &str, hits: &[AproposHit]) -> String 
 }
 
 pub(crate) fn render_terminal_markdown(md: &str) -> String {
-    if !colors::enabled_stdout() {
+    render_terminal_markdown_inner(md, colors::enabled_stdout())
+}
+
+/// Rendering core with an explicit color decision so tests can exercise the
+/// styled path without a TTY (`render_terminal_markdown` supplies the real
+/// `colors::enabled_stdout()` at runtime).
+pub(crate) fn render_terminal_markdown_inner(md: &str, color: bool) -> String {
+    if !color {
         return md.to_string();
     }
 
@@ -255,7 +262,7 @@ pub(crate) fn render_terminal_markdown(md: &str) -> String {
         let trimmed = line.trim_start();
         if trimmed.starts_with("```sema") {
             sema_block = true;
-            out.push_str(&dim(line));
+            out.push_str(&paint_rgb(colors::TERTIARY, line));
             out.push('\n');
             continue;
         }
@@ -265,7 +272,7 @@ pub(crate) fn render_terminal_markdown(md: &str) -> String {
             } else {
                 other_block = !other_block;
             }
-            out.push_str(&dim(line));
+            out.push_str(&paint_rgb(colors::TERTIARY, line));
             out.push('\n');
             continue;
         }
@@ -280,33 +287,37 @@ pub(crate) fn render_terminal_markdown(md: &str) -> String {
             continue;
         }
         if let Some(rest) = trimmed.strip_prefix("### ") {
-            out.push_str(&yellow(rest));
+            out.push_str(&paint_rgb(colors::AMBER, rest));
             out.push('\n');
             continue;
         }
         if let Some(rest) = trimmed.strip_prefix("## ") {
-            out.push_str(&yellow(rest));
+            out.push_str(&paint_rgb(colors::AMBER, rest));
             out.push('\n');
             continue;
         }
         if let Some(rest) = trimmed.strip_prefix("# ") {
-            out.push_str(&yellow(rest));
+            out.push_str(&paint_rgb(colors::AMBER, rest));
             out.push('\n');
             continue;
         }
         if let Some(rest) = trimmed.strip_prefix("- ") {
             out.push_str("• ");
-            out.push_str(&style_inline(rest));
+            out.push_str(&style_inline_colored(rest, color));
             out.push('\n');
             continue;
         }
-        out.push_str(&style_inline(line));
+        out.push_str(&style_inline_colored(line, color));
         out.push('\n');
     }
     out
 }
 
 fn style_inline(text: &str) -> String {
+    style_inline_colored(text, colors::enabled_stdout())
+}
+
+fn style_inline_colored(text: &str, color: bool) -> String {
     let mut out = String::new();
     let chars: Vec<char> = text.chars().collect();
     let mut i = 0;
@@ -318,7 +329,7 @@ fn style_inline(text: &str) -> String {
             }
             if j + 1 < chars.len() {
                 let inner: String = chars[i + 2..j].iter().collect();
-                out.push_str(&yellow(&inner));
+                out.push_str(&maybe_rgb(color, colors::AMBER, &inner));
                 i = j + 2;
                 continue;
             }
@@ -330,7 +341,7 @@ fn style_inline(text: &str) -> String {
             }
             if j < chars.len() {
                 let inner: String = chars[i + 1..j].iter().collect();
-                out.push_str(&cyan(&inner));
+                out.push_str(&maybe_rgb(color, colors::TEAL, &inner));
                 i = j + 1;
                 continue;
             }
@@ -342,7 +353,7 @@ fn style_inline(text: &str) -> String {
             }
             if j < chars.len() {
                 let inner: String = chars[i + 1..j].iter().collect();
-                out.push_str(&dim(&inner));
+                out.push_str(&maybe_rgb(color, colors::TERTIARY, &inner));
                 i = j + 1;
                 continue;
             }
@@ -374,20 +385,26 @@ pub(crate) fn visible_padding(s: &str) -> usize {
     coloured.len().saturating_sub(s.len())
 }
 
-fn stdout_rgb(rgb: (u8, u8, u8), s: &str) -> String {
-    if colors::enabled_stdout() {
-        format!("\x1b[38;2;{};{};{}m{s}\x1b[0m", rgb.0, rgb.1, rgb.2)
+/// Unconditional truecolor paint — the caller has already decided color is on.
+fn paint_rgb(rgb: (u8, u8, u8), s: &str) -> String {
+    format!("\x1b[38;2;{};{};{}m{s}\x1b[0m", rgb.0, rgb.1, rgb.2)
+}
+
+/// Paint only when `color` is true, otherwise return the text unchanged.
+fn maybe_rgb(color: bool, rgb: (u8, u8, u8), s: &str) -> String {
+    if color {
+        paint_rgb(rgb, s)
     } else {
         s.to_string()
     }
 }
 
-fn cyan(s: &str) -> String {
-    stdout_rgb(colors::TEAL, s)
+fn stdout_rgb(rgb: (u8, u8, u8), s: &str) -> String {
+    maybe_rgb(colors::enabled_stdout(), rgb, s)
 }
 
-fn yellow(s: &str) -> String {
-    stdout_rgb(colors::AMBER, s)
+fn cyan(s: &str) -> String {
+    stdout_rgb(colors::TEAL, s)
 }
 
 fn dim(s: &str) -> String {
@@ -455,5 +472,35 @@ mod tests {
     fn search_results_render_empty_state() {
         let out = render_search_results("nope", &[]);
         assert!(out.contains("no documentation matches"));
+    }
+
+    // `,apropos` and `sema doc apropos` draw special forms from the sema-docs
+    // index rather than injecting `SPECIAL_FORM_NAMES`. That is only complete if
+    // every special form actually has a doc entry — this guards against a new
+    // special form silently disappearing from apropos/lookup.
+    #[test]
+    fn every_special_form_has_a_doc_entry() {
+        let missing: Vec<&str> = sema_eval::SPECIAL_FORM_NAMES
+            .iter()
+            .copied()
+            .filter(|name| lookup(name).is_none())
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "special forms missing a sema-docs entry: {missing:?}"
+        );
+    }
+
+    #[test]
+    fn markdown_inner_dims_fences_when_forced() {
+        // The styled path must not depend on stdout being a TTY.
+        let out = render_terminal_markdown_inner("```sema\n(a 1)\n```\n", true);
+        assert!(
+            out.contains("\x1b[38;2;107;99;84m"),
+            "fences not dimmed: {out:?}"
+        );
+        // And stays plain when color is off.
+        let plain = render_terminal_markdown_inner("```sema\n(a 1)\n```\n", false);
+        assert!(!plain.contains('\x1b'), "unexpected ansi: {plain:?}");
     }
 }

--- a/crates/sema/src/docs.rs
+++ b/crates/sema/src/docs.rs
@@ -1,0 +1,450 @@
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::io::{self, IsTerminal, Write};
+use std::process::{Command, Stdio};
+use std::sync::OnceLock;
+
+use crossterm::terminal;
+use sema_docs::DocEntry;
+
+use crate::colors;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum PagerMode {
+    Auto,
+    Always,
+    Never,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct AproposHit {
+    pub name: String,
+    pub summary: String,
+}
+
+static DOC_NAME_INDEX: OnceLock<HashMap<String, usize>> = OnceLock::new();
+
+fn doc_name_index() -> &'static HashMap<String, usize> {
+    DOC_NAME_INDEX.get_or_init(|| {
+        let mut by_name = HashMap::new();
+        for (idx, entry) in sema_docs::builtin_index().entries.iter().enumerate() {
+            by_name.insert(entry.name.clone(), idx);
+            for alias in &entry.aliases {
+                by_name.entry(alias.clone()).or_insert(idx);
+            }
+        }
+        by_name
+    })
+}
+
+pub(crate) fn lookup(name: &str) -> Option<&'static DocEntry> {
+    let idx = *doc_name_index().get(name)?;
+    sema_docs::builtin_index().entries.get(idx)
+}
+
+pub(crate) fn completion_candidates(prefix: &str) -> Vec<String> {
+    let mut out: Vec<String> = doc_name_index()
+        .keys()
+        .filter(|name| name.starts_with(prefix))
+        .cloned()
+        .collect();
+    out.sort();
+    out
+}
+
+pub(crate) fn rendered_doc(name: &str) -> Option<String> {
+    let entry = lookup(name)?;
+    let kind = if entry.special_form {
+        "special form"
+    } else {
+        "builtin"
+    };
+    let heading = if name == entry.name {
+        format!("{} {} {}", cyan(&entry.name), dim(":"), kind)
+    } else {
+        format!(
+            "{} {} {} {} {}",
+            cyan(name),
+            dim("→"),
+            cyan(&entry.name),
+            dim(":"),
+            kind
+        )
+    };
+    let md = sema_lsp::builtin_docs::render_markdown(entry);
+    Some(format!("{heading}\n{}\n", render_terminal_markdown(&md)))
+}
+
+pub(crate) fn print_rendered(text: &str, pager: PagerMode) -> io::Result<()> {
+    if should_page(text, pager) && page_with_less(text)? {
+        return Ok(());
+    }
+    let mut stdout = io::stdout().lock();
+    stdout.write_all(text.as_bytes())?;
+    stdout.flush()
+}
+
+fn should_page(text: &str, pager: PagerMode) -> bool {
+    match pager {
+        PagerMode::Never => false,
+        PagerMode::Always => io::stdout().is_terminal(),
+        PagerMode::Auto => {
+            if !io::stdout().is_terminal() {
+                return false;
+            }
+            let Ok((_, rows)) = terminal::size() else {
+                return false;
+            };
+            text.lines().count() > rows as usize
+        }
+    }
+}
+
+fn page_with_less(text: &str) -> io::Result<bool> {
+    let mut child = match Command::new("less")
+        .arg("-R")
+        .arg("-F")
+        .arg("-X")
+        .stdin(Stdio::piped())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(false),
+        Err(e) => return Err(e),
+    };
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin.write_all(text.as_bytes())?;
+    }
+    let _ = child.wait()?;
+    Ok(true)
+}
+
+pub(crate) fn doc_search_results(query: &str, limit: usize) -> Vec<sema_mcp::docs_search::SearchHit> {
+    sema_mcp::docs_search::search(query, limit)
+}
+
+pub(crate) fn render_search_results(
+    query: &str,
+    hits: &[sema_mcp::docs_search::SearchHit],
+) -> String {
+    if hits.is_empty() {
+        return format!("(no documentation matches for {query:?})\n");
+    }
+
+    let max_width = hits.iter().map(|h| h.name.len()).max().unwrap_or(0).min(28);
+    let mut out = String::new();
+    for hit in hits {
+        out.push_str(&format!(
+            "  {:width$}  {}  {}\n",
+            cyan(&hit.name),
+            dim(&format!("[{}]", hit.module)),
+            style_inline(hit.summary.trim()),
+            width = max_width + visible_padding(&hit.name)
+        ));
+    }
+    out.push_str(&format!(
+        "  ({} match{})\n",
+        hits.len(),
+        if hits.len() == 1 { "" } else { "es" }
+    ));
+    out
+}
+
+pub(crate) fn builtin_apropos_hits(pattern: &str) -> Vec<AproposHit> {
+    let mut summaries: BTreeMap<String, String> = BTreeMap::new();
+    for entry in &sema_docs::builtin_index().entries {
+        let summary = first_doc_line(&entry.summary);
+        summaries
+            .entry(entry.name.clone())
+            .or_insert_with(|| summary.clone());
+        for alias in &entry.aliases {
+            summaries
+                .entry(alias.clone())
+                .or_insert_with(|| summary.clone());
+        }
+    }
+    search_name_summaries(pattern, &summaries)
+}
+
+pub(crate) fn search_name_summaries(
+    pattern: &str,
+    summaries: &BTreeMap<String, String>,
+) -> Vec<AproposHit> {
+    let pattern = pattern.trim();
+    if pattern.is_empty() {
+        return Vec::new();
+    }
+
+    let needle = pattern.to_lowercase();
+    let mut tiered: Vec<(u8, String, String)> = Vec::new();
+    for (name, summary) in summaries {
+        let lower = name.to_lowercase();
+        let tier = if lower.starts_with(&needle) {
+            0
+        } else if lower.contains(&needle) {
+            1
+        } else {
+            continue;
+        };
+        tiered.push((tier, name.clone(), summary.clone()));
+    }
+
+    if tiered.len() < 3 {
+        let candidates: Vec<&str> = summaries.keys().map(|s| s.as_str()).collect();
+        if let Some(suggestion) = sema_core::error::suggest_similar(pattern, &candidates) {
+            if !tiered.iter().any(|(_, name, _)| name == &suggestion) {
+                let summary = summaries.get(&suggestion).cloned().unwrap_or_default();
+                tiered.push((2, suggestion, summary));
+            }
+        }
+    }
+
+    tiered.sort_by(|(ta, na, _), (tb, nb, _)| ta.cmp(tb).then(na.cmp(nb)));
+    tiered.truncate(50);
+    tiered
+        .into_iter()
+        .map(|(_, name, summary)| AproposHit { name, summary })
+        .collect()
+}
+
+pub(crate) fn render_apropos_hits(pattern: &str, hits: &[AproposHit]) -> String {
+    if hits.is_empty() {
+        return format!("(no matches for {pattern:?})\n");
+    }
+
+    let max_width = hits.iter().map(|h| h.name.len()).max().unwrap_or(0).min(28);
+    let mut out = String::new();
+    for hit in hits {
+        let summary = hit.summary.trim();
+        if summary.is_empty() {
+            out.push_str(&format!("  {}\n", colors::cyan(&hit.name)));
+        } else {
+            out.push_str(&format!(
+                "  {:width$}  {}\n",
+                cyan(&hit.name),
+                dim(summary),
+                width = max_width + visible_padding(&hit.name)
+            ));
+        }
+    }
+    out.push_str(&format!(
+        "  ({} match{})\n",
+        hits.len(),
+        if hits.len() == 1 { "" } else { "es" }
+    ));
+    out
+}
+
+pub(crate) fn render_terminal_markdown(md: &str) -> String {
+    if !colors::enabled_stdout() {
+        return md.to_string();
+    }
+
+    let mut out = String::with_capacity(md.len() * 2);
+    let mut sema_block = false;
+    let mut other_block = false;
+
+    for line in md.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("```sema") {
+            sema_block = true;
+            out.push_str(&dim(line));
+            out.push('\n');
+            continue;
+        }
+        if trimmed.starts_with("```") {
+            if sema_block {
+                sema_block = false;
+            } else {
+                other_block = !other_block;
+            }
+            out.push_str(&dim(line));
+            out.push('\n');
+            continue;
+        }
+        if sema_block {
+            out.push_str(&crate::repl::highlighter::highlight_sema_ansi(line));
+            out.push('\n');
+            continue;
+        }
+        if other_block {
+            out.push_str(line);
+            out.push('\n');
+            continue;
+        }
+        if let Some(rest) = trimmed.strip_prefix("### ") {
+            out.push_str(&yellow(rest));
+            out.push('\n');
+            continue;
+        }
+        if let Some(rest) = trimmed.strip_prefix("## ") {
+            out.push_str(&yellow(rest));
+            out.push('\n');
+            continue;
+        }
+        if let Some(rest) = trimmed.strip_prefix("# ") {
+            out.push_str(&yellow(rest));
+            out.push('\n');
+            continue;
+        }
+        if let Some(rest) = trimmed.strip_prefix("- ") {
+            out.push_str("• ");
+            out.push_str(&style_inline(rest));
+            out.push('\n');
+            continue;
+        }
+        out.push_str(&style_inline(line));
+        out.push('\n');
+    }
+    out
+}
+
+fn style_inline(text: &str) -> String {
+    let mut out = String::new();
+    let chars: Vec<char> = text.chars().collect();
+    let mut i = 0;
+    while i < chars.len() {
+        if i + 1 < chars.len() && chars[i] == '*' && chars[i + 1] == '*' {
+            let mut j = i + 2;
+            while j + 1 < chars.len() && !(chars[j] == '*' && chars[j + 1] == '*') {
+                j += 1;
+            }
+            if j + 1 < chars.len() {
+                let inner: String = chars[i + 2..j].iter().collect();
+                out.push_str(&yellow(&inner));
+                i = j + 2;
+                continue;
+            }
+        }
+        if chars[i] == '`' {
+            let mut j = i + 1;
+            while j < chars.len() && chars[j] != '`' {
+                j += 1;
+            }
+            if j < chars.len() {
+                let inner: String = chars[i + 1..j].iter().collect();
+                out.push_str(&cyan(&inner));
+                i = j + 1;
+                continue;
+            }
+        }
+        if chars[i] == '_' {
+            let mut j = i + 1;
+            while j < chars.len() && chars[j] != '_' {
+                j += 1;
+            }
+            if j < chars.len() {
+                let inner: String = chars[i + 1..j].iter().collect();
+                out.push_str(&dim(&inner));
+                i = j + 1;
+                continue;
+            }
+        }
+        out.push(chars[i]);
+        i += 1;
+    }
+    out
+}
+
+pub(crate) fn first_doc_line(doc: &str) -> String {
+    let mut in_code = false;
+    for line in doc.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("```") {
+            in_code = !in_code;
+            continue;
+        }
+        if in_code || trimmed.is_empty() {
+            continue;
+        }
+        return trimmed.replace('`', "");
+    }
+    String::new()
+}
+
+pub(crate) fn visible_padding(s: &str) -> usize {
+    let coloured = cyan(s);
+    coloured.len().saturating_sub(s.len())
+}
+
+pub(crate) fn doc_name_summaries(extra: impl IntoIterator<Item = (String, String)>) -> BTreeMap<String, String> {
+    let mut summaries: BTreeMap<String, String> = BTreeMap::new();
+    for entry in &sema_docs::builtin_index().entries {
+        let summary = first_doc_line(&entry.summary);
+        summaries
+            .entry(entry.name.clone())
+            .or_insert_with(|| summary.clone());
+        for alias in &entry.aliases {
+            summaries
+                .entry(alias.clone())
+                .or_insert_with(|| summary.clone());
+        }
+
+        fn stdout_rgb(rgb: (u8, u8, u8), s: &str) -> String {
+            if colors::enabled_stdout() {
+                format!("\x1b[38;2;{};{};{}m{s}\x1b[0m", rgb.0, rgb.1, rgb.2)
+            } else {
+                s.to_string()
+            }
+        }
+
+        fn cyan(s: &str) -> String {
+            stdout_rgb(colors::TEAL, s)
+        }
+
+        fn yellow(s: &str) -> String {
+            stdout_rgb(colors::AMBER, s)
+        }
+
+        fn dim(s: &str) -> String {
+            stdout_rgb(colors::TERTIARY, s)
+        }
+    }
+    for (name, summary) in extra {
+        summaries.entry(name).or_insert(summary);
+    }
+    summaries
+}
+
+pub(crate) fn dedupe_names(names: impl IntoIterator<Item = String>) -> Vec<String> {
+    let mut set = HashSet::new();
+    let mut out = Vec::new();
+    for name in names {
+        if set.insert(name.clone()) {
+            out.push(name);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn completion_candidates_include_aliases() {
+        let out = completion_candidates("string-spl");
+        assert!(out.contains(&"string-split".to_string()));
+        assert!(out.contains(&"string/split".to_string()));
+    }
+
+    #[test]
+    fn lookup_resolves_alias() {
+        let entry = lookup("string-split").expect("alias entry");
+        assert_eq!(entry.name, "string/split");
+    }
+
+    #[test]
+    fn inline_markdown_styles_known_markers() {
+        let out = style_inline("**Bold** `code` _since_");
+        assert!(out.contains("Bold"));
+        assert!(out.contains("code"));
+        assert!(out.contains("since"));
+    }
+
+    #[test]
+    fn search_results_render_empty_state() {
+        let out = render_search_results("nope", &[]);
+        assert!(out.contains("no documentation matches"));
+    }
+}

--- a/crates/sema/src/docs.rs
+++ b/crates/sema/src/docs.rs
@@ -503,4 +503,102 @@ mod tests {
         let plain = render_terminal_markdown_inner("```sema\n(a 1)\n```\n", false);
         assert!(!plain.contains('\x1b'), "unexpected ansi: {plain:?}");
     }
+
+    #[test]
+    fn first_doc_line_skips_code_and_strips_backticks() {
+        // Must skip a leading fenced code block, return the first prose line, and
+        // strip inline-code backticks (this drives the apropos/search summaries).
+        let doc = "```sema\n(some code)\n```\nThe `real` summary line.\nSecond line.";
+        assert_eq!(first_doc_line(doc), "The real summary line.");
+    }
+
+    #[test]
+    fn apropos_ranks_prefix_before_substring() {
+        // Prefix hits (tier 0) must outrank substring hits (tier 1) even when the
+        // substring hit sorts earlier alphabetically — proving it's tiering, not
+        // just an alpha sort. "flatmap" contains "map" and sorts before "map".
+        let mut summaries = BTreeMap::new();
+        summaries.insert("map".to_string(), String::new());
+        summaries.insert("flatmap".to_string(), String::new());
+        let hits = search_name_summaries("map", &summaries);
+        let names: Vec<&str> = hits.iter().map(|h| h.name.as_str()).collect();
+        let prefix_pos = names.iter().position(|n| *n == "map").expect("map present");
+        let substr_pos = names
+            .iter()
+            .position(|n| *n == "flatmap")
+            .expect("flatmap present");
+        assert!(
+            prefix_pos < substr_pos,
+            "prefix match must rank before substring match: {names:?}"
+        );
+    }
+
+    #[test]
+    fn apropos_hits_render_count_and_plurality() {
+        let one = vec![AproposHit {
+            name: "map".into(),
+            summary: "apply a function".into(),
+        }];
+        let out = render_apropos_hits("map", &one);
+        assert!(out.contains("map"), "name missing: {out:?}");
+        assert!(out.contains("(1 match)"), "singular footer wrong: {out:?}");
+
+        let two = vec![
+            AproposHit {
+                name: "map".into(),
+                summary: "a".into(),
+            },
+            AproposHit {
+                name: "mapcat".into(),
+                summary: "b".into(),
+            },
+        ];
+        let out2 = render_apropos_hits("map", &two);
+        assert!(
+            out2.contains("(2 matches)"),
+            "plural footer wrong: {out2:?}"
+        );
+    }
+
+    #[test]
+    fn search_results_render_name_module_and_count() {
+        let hits = vec![sema_mcp::docs_search::SearchHit {
+            name: "string/split".into(),
+            module: "strings".into(),
+            summary: "Split a string by a delimiter".into(),
+            score: 1.0,
+        }];
+        let out = render_search_results("split", &hits);
+        assert!(out.contains("string/split"), "name missing: {out:?}");
+        assert!(out.contains("[strings]"), "module tag missing: {out:?}");
+        assert!(
+            out.contains("Split a string by a delimiter"),
+            "summary missing: {out:?}"
+        );
+        assert!(out.contains("(1 match)"), "count footer wrong: {out:?}");
+    }
+
+    #[test]
+    fn rendered_doc_entry_shows_alias_arrow_and_kind() {
+        let entry = lookup("string-split").expect("alias entry");
+        let out = rendered_doc_entry("string-split", entry);
+        // Alias heading resolves to the canonical name via an arrow.
+        assert!(out.contains("string-split"), "alias name missing: {out:?}");
+        assert!(out.contains('→'), "alias arrow missing: {out:?}");
+        assert!(
+            out.contains("string/split"),
+            "canonical name missing: {out:?}"
+        );
+        assert!(out.contains("builtin"), "kind label missing: {out:?}");
+    }
+
+    #[test]
+    fn rendered_doc_entry_labels_special_form() {
+        let entry = lookup("if").expect("special form entry");
+        let out = rendered_doc_entry("if", entry);
+        assert!(
+            out.contains("special form"),
+            "special-form label missing: {out:?}"
+        );
+    }
 }

--- a/crates/sema/src/docs.rs
+++ b/crates/sema/src/docs.rs
@@ -119,7 +119,10 @@ fn page_with_less(text: &str) -> io::Result<bool> {
     Ok(true)
 }
 
-pub(crate) fn doc_search_results(query: &str, limit: usize) -> Vec<sema_mcp::docs_search::SearchHit> {
+pub(crate) fn doc_search_results(
+    query: &str,
+    limit: usize,
+) -> Vec<sema_mcp::docs_search::SearchHit> {
     sema_mcp::docs_search::search(query, limit)
 }
 
@@ -367,7 +370,29 @@ pub(crate) fn visible_padding(s: &str) -> usize {
     coloured.len().saturating_sub(s.len())
 }
 
-pub(crate) fn doc_name_summaries(extra: impl IntoIterator<Item = (String, String)>) -> BTreeMap<String, String> {
+fn stdout_rgb(rgb: (u8, u8, u8), s: &str) -> String {
+    if colors::enabled_stdout() {
+        format!("\x1b[38;2;{};{};{}m{s}\x1b[0m", rgb.0, rgb.1, rgb.2)
+    } else {
+        s.to_string()
+    }
+}
+
+fn cyan(s: &str) -> String {
+    stdout_rgb(colors::TEAL, s)
+}
+
+fn yellow(s: &str) -> String {
+    stdout_rgb(colors::AMBER, s)
+}
+
+fn dim(s: &str) -> String {
+    stdout_rgb(colors::TERTIARY, s)
+}
+
+pub(crate) fn doc_name_summaries(
+    extra: impl IntoIterator<Item = (String, String)>,
+) -> BTreeMap<String, String> {
     let mut summaries: BTreeMap<String, String> = BTreeMap::new();
     for entry in &sema_docs::builtin_index().entries {
         let summary = first_doc_line(&entry.summary);
@@ -378,26 +403,6 @@ pub(crate) fn doc_name_summaries(extra: impl IntoIterator<Item = (String, String
             summaries
                 .entry(alias.clone())
                 .or_insert_with(|| summary.clone());
-        }
-
-        fn stdout_rgb(rgb: (u8, u8, u8), s: &str) -> String {
-            if colors::enabled_stdout() {
-                format!("\x1b[38;2;{};{};{}m{s}\x1b[0m", rgb.0, rgb.1, rgb.2)
-            } else {
-                s.to_string()
-            }
-        }
-
-        fn cyan(s: &str) -> String {
-            stdout_rgb(colors::TEAL, s)
-        }
-
-        fn yellow(s: &str) -> String {
-            stdout_rgb(colors::AMBER, s)
-        }
-
-        fn dim(s: &str) -> String {
-            stdout_rgb(colors::TERTIARY, s)
         }
     }
     for (name, summary) in extra {
@@ -423,7 +428,7 @@ mod tests {
 
     #[test]
     fn completion_candidates_include_aliases() {
-        let out = completion_candidates("string-spl");
+        let out = completion_candidates("string");
         assert!(out.contains(&"string-split".to_string()));
         assert!(out.contains(&"string/split".to_string()));
     }

--- a/crates/sema/src/main.rs
+++ b/crates/sema/src/main.rs
@@ -340,11 +340,6 @@ enum Commands {
         #[arg(long)]
         no_llm: bool,
     },
-    #[command(hide = true, name = "__complete-doc-symbols")]
-    CompleteDocSymbols {
-        /// Prefix to filter documentation symbol names by
-        prefix: Option<String>,
-    },
 }
 
 #[derive(Subcommand)]
@@ -585,6 +580,22 @@ fn main() {
         std::process::exit(exit_code);
     }
 
+    // Shell-completion helper for `sema doc` symbols, handled before clap parses.
+    // It is intentionally NOT a clap subcommand: a hidden subcommand makes
+    // `clap_complete`'s bash generator panic (find_subcommand_with_path), which
+    // would break `sema completions bash`. The generated completion scripts still
+    // invoke `sema __complete-doc-symbols <prefix>`.
+    {
+        let mut args = std::env::args().skip(1);
+        if args.next().as_deref() == Some("__complete-doc-symbols") {
+            let prefix = args.next().unwrap_or_default();
+            for name in docs::completion_candidates(&prefix) {
+                println!("{name}");
+            }
+            return;
+        }
+    }
+
     let cli = Cli::parse();
 
     // Opt-in OpenTelemetry: installs a provider only when SEMA_OTEL_FILE or an OTLP
@@ -807,11 +818,6 @@ fn main() {
                 no_llm,
             } => {
                 run_eval(stdin, expr, json, path, sandbox, no_llm);
-            }
-            Commands::CompleteDocSymbols { prefix } => {
-                for name in docs::completion_candidates(prefix.as_deref().unwrap_or("")) {
-                    println!("{name}");
-                }
             }
         }
         return;

--- a/crates/sema/src/main.rs
+++ b/crates/sema/src/main.rs
@@ -60,6 +60,7 @@ fn find_config() -> Option<SemaConfig> {
 mod archive;
 mod colors;
 mod cross_compile;
+mod docs;
 mod import_tracer;
 mod pkg;
 mod repl;
@@ -201,6 +202,23 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
+    /// Browse builtin and special-form documentation
+    #[command(args_conflicts_with_subcommands = true)]
+    Doc {
+        /// Show docs in a pager even when the output fits on one screen
+        #[arg(long, conflicts_with = "no_pager")]
+        pager: bool,
+
+        /// Print directly without invoking a pager
+        #[arg(long, conflicts_with = "pager")]
+        no_pager: bool,
+
+        #[command(subcommand)]
+        command: Option<DocCommands>,
+
+        /// Symbol to show documentation for (implicit `show`)
+        symbol: Option<String>,
+    },
     /// Package manager
     Pkg {
         #[command(subcommand)]
@@ -321,6 +339,35 @@ enum Commands {
         /// Disable LLM features
         #[arg(long)]
         no_llm: bool,
+    },
+    #[command(hide = true, name = "__complete-doc-symbols")]
+    CompleteDocSymbols {
+        /// Prefix to filter documentation symbol names by
+        prefix: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+enum DocCommands {
+    /// Show documentation for a symbol
+    Show {
+        /// Symbol to show documentation for
+        symbol: String,
+    },
+    /// Search documentation by natural-language query
+    Search {
+        /// Query to search for
+        #[arg(required = true, num_args = 1..)]
+        query: Vec<String>,
+
+        /// Maximum number of results to show
+        #[arg(short = 'n', long, default_value_t = sema_mcp::docs_search::DEFAULT_LIMIT)]
+        limit: usize,
+    },
+    /// Search symbol names by prefix, substring, and fuzzy match
+    Apropos {
+        /// Pattern to search for
+        pattern: String,
     },
 }
 
@@ -571,12 +618,7 @@ fn main() {
                 if install {
                     install_completions(shell);
                 } else {
-                    clap_complete::generate(
-                        shell,
-                        &mut Cli::command(),
-                        "sema",
-                        &mut std::io::stdout(),
-                    );
+                    print!("{}", generate_completions(shell));
                 }
             }
             Commands::Compile {
@@ -592,6 +634,24 @@ fn main() {
             }
             Commands::Disasm { file, json } => {
                 run_disasm(&file, json);
+            }
+            Commands::Doc {
+                pager,
+                no_pager,
+                command,
+                symbol,
+            } => {
+                let pager = if no_pager {
+                    docs::PagerMode::Never
+                } else if pager {
+                    docs::PagerMode::Always
+                } else {
+                    docs::PagerMode::Auto
+                };
+                if let Err(msg) = run_doc(command, symbol, pager) {
+                    eprintln!("Error: {msg}");
+                    std::process::exit(1);
+                }
             }
             Commands::Pkg { command } => {
                 let result = match command {
@@ -747,6 +807,11 @@ fn main() {
                 no_llm,
             } => {
                 run_eval(stdin, expr, json, path, sandbox, no_llm);
+            }
+            Commands::CompleteDocSymbols { prefix } => {
+                for name in docs::completion_candidates(prefix.as_deref().unwrap_or("")) {
+                    println!("{name}");
+                }
             }
         }
         return;
@@ -3009,6 +3074,106 @@ pub(crate) fn print_error(e: &SemaError) {
     }
 }
 
+fn run_doc(
+    command: Option<DocCommands>,
+    symbol: Option<String>,
+    pager: docs::PagerMode,
+) -> Result<(), String> {
+    match command {
+        Some(DocCommands::Show { symbol }) => show_doc(&symbol, pager),
+        Some(DocCommands::Search { query, limit }) => {
+            let query = query.join(" ");
+            let query = query.trim().to_string();
+            if query.is_empty() {
+                return Err("usage: sema doc search <query>".to_string());
+            }
+            let rendered = docs::render_search_results(&query, &docs::doc_search_results(&query, limit));
+            docs::print_rendered(&rendered, pager).map_err(|e| format!("writing docs: {e}"))
+        }
+        Some(DocCommands::Apropos { pattern }) => {
+            let hits = docs::builtin_apropos_hits(&pattern);
+            let rendered = docs::render_apropos_hits(&pattern, &hits);
+            docs::print_rendered(&rendered, pager).map_err(|e| format!("writing docs: {e}"))
+        }
+        None => {
+            let Some(symbol) = symbol else {
+                return Err("usage: sema doc <symbol> | sema doc search <query> | sema doc apropos <pattern>".to_string());
+            };
+            show_doc(&symbol, pager)
+        }
+    }
+}
+
+fn show_doc(symbol: &str, pager: docs::PagerMode) -> Result<(), String> {
+    let Some(rendered) = docs::rendered_doc(symbol) else {
+        return Err(format!("documentation not found: {symbol}"));
+    };
+    docs::print_rendered(&rendered, pager).map_err(|e| format!("writing docs: {e}"))
+}
+
+fn generate_completions(shell: Shell) -> String {
+    let mut buf = Vec::new();
+    clap_complete::generate(shell, &mut Cli::command(), "sema", &mut buf);
+    let mut out = String::from_utf8(buf).expect("clap completion output is utf-8");
+    out.push_str(dynamic_doc_completion_script(shell));
+    out
+}
+
+fn dynamic_doc_completion_script(shell: Shell) -> &'static str {
+    match shell {
+        Shell::Bash => {
+            r#"
+
+# Dynamic Sema doc symbol completion.
+_sema_doc_complete() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    if [[ ${COMP_WORDS[1]} == doc && ${COMP_CWORD} -eq 2 ]]; then
+        COMPREPLY=( $(compgen -W "$(sema __complete-doc-symbols "$cur")" -- "$cur") )
+        return
+    fi
+    if [[ ${COMP_WORDS[1]} == doc && ${COMP_WORDS[2]} == show && ${COMP_CWORD} -eq 3 ]]; then
+        COMPREPLY=( $(compgen -W "$(sema __complete-doc-symbols "$cur")" -- "$cur") )
+        return
+    fi
+    _sema "$@"
+}
+complete -o nosort -o bashdefault -o default -F _sema_doc_complete sema
+"#
+        }
+        Shell::Zsh => {
+            r#"
+
+# Dynamic Sema doc symbol completion.
+_sema_doc_complete() {
+  if (( CURRENT == 3 )) && [[ "${words[2]}" == "doc" ]]; then
+    local -a matches
+    matches=("${(@f)$(sema __complete-doc-symbols "${words[CURRENT]}")}")
+    _describe 'Sema doc symbol' matches
+    return
+  fi
+  if (( CURRENT == 4 )) && [[ "${words[2]}" == "doc" && "${words[3]}" == "show" ]]; then
+    local -a matches
+    matches=("${(@f)$(sema __complete-doc-symbols "${words[CURRENT]}")}")
+    _describe 'Sema doc symbol' matches
+    return
+  fi
+  _sema "$@"
+}
+compdef _sema_doc_complete sema
+"#
+        }
+        Shell::Fish => {
+            r#"
+
+# Dynamic Sema doc symbol completion.
+complete -c sema -n '__fish_seen_subcommand_from doc; and not __fish_seen_subcommand_from show search apropos' -a '(sema __complete-doc-symbols (commandline -ct))'
+complete -c sema -n '__fish_seen_subcommand_from doc show' -a '(sema __complete-doc-symbols (commandline -ct))'
+"#
+        }
+        _ => "",
+    }
+}
+
 fn install_completions(shell: Shell) {
     let home = match std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) {
         Ok(h) => PathBuf::from(h),
@@ -3043,9 +3208,8 @@ fn install_completions(shell: Shell) {
         });
     }
 
-    let mut buf = Vec::new();
-    clap_complete::generate(shell, &mut Cli::command(), "sema", &mut buf);
-    std::fs::write(&path, &buf).unwrap_or_else(|e| {
+    let completions = generate_completions(shell);
+    std::fs::write(&path, completions).unwrap_or_else(|e| {
         eprintln!("Error writing {}: {e}", path.display());
         std::process::exit(1);
     });

--- a/crates/sema/src/main.rs
+++ b/crates/sema/src/main.rs
@@ -3087,7 +3087,8 @@ fn run_doc(
             if query.is_empty() {
                 return Err("usage: sema doc search <query>".to_string());
             }
-            let rendered = docs::render_search_results(&query, &docs::doc_search_results(&query, limit));
+            let rendered =
+                docs::render_search_results(&query, &docs::doc_search_results(&query, limit));
             docs::print_rendered(&rendered, pager).map_err(|e| format!("writing docs: {e}"))
         }
         Some(DocCommands::Apropos { pattern }) => {

--- a/crates/sema/src/repl/apropos.rs
+++ b/crates/sema/src/repl/apropos.rs
@@ -1,26 +1,10 @@
 //! `,apropos PATTERN` — find Sema bindings whose name matches a pattern.
-//!
-//! Searches three sources:
-//!   1. Env bindings (user-defined + stdlib) via `Env::iter_bindings`
-//!      (walked recursively up the parent chain).
-//!   2. Special forms via `sema_eval::SPECIAL_FORM_NAMES`.
-//!   3. Builtin docs via the canonical `sema_docs::builtin_index`.
-//!
-//! Match strategy is layered:
-//!   - **Exact prefix** (`split` matches `split-at` first)
-//!   - **Substring** (case-insensitive) — catches `string/split` for `split`
-//!   - **Fuzzy** via `sema_core::error::suggest_similar` — catches typos
-//!
-//! Results are ranked by tier and then alphabetically within each tier.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 
 use sema_core::Env;
-use sema_eval::SPECIAL_FORM_NAMES;
 
-use crate::colors;
-
-const MAX_RESULTS: usize = 50;
+use crate::docs;
 
 pub fn run(env: &Env, pattern: &str) {
     let pattern = pattern.trim();
@@ -29,126 +13,31 @@ pub fn run(env: &Env, pattern: &str) {
         return;
     }
 
-    let needle = pattern.to_lowercase();
-    // name → one-line summary, from the canonical sema-docs index (aliases included).
-    let docs: std::collections::HashMap<String, String> = {
-        let mut m = std::collections::HashMap::new();
-        for e in &sema_docs::builtin_index().entries {
-            for a in &e.aliases {
-                m.insert(a.clone(), e.summary.clone());
-            }
-            m.insert(e.name.clone(), e.summary.clone());
-        }
-        m
-    };
-
-    // Gather every candidate name we know about, with a one-line summary.
-    let mut summaries: BTreeMap<String, String> = BTreeMap::new();
-
-    // Env bindings — walk parent chain.
-    let mut seen: BTreeSet<String> = BTreeSet::new();
-    collect_env(env, &mut seen);
-    for name in &seen {
-        let summary = describe_env_name(env, name, &docs);
-        summaries.insert(name.clone(), summary);
-    }
-
-    // Special forms (may overlap with env if some are exported).
-    for &sf in SPECIAL_FORM_NAMES {
-        summaries.entry(sf.to_string()).or_insert_with(|| {
-            docs.get(sf)
-                .map(|d| first_doc_line(d.as_str()))
-                .unwrap_or_else(|| "special form".to_string())
-        });
-    }
-
-    // Builtin docs (covers entries that aren't in env yet, e.g., docs for
-    // forms that resolve at compile time).
-    for (name, doc) in &docs {
-        summaries
-            .entry(name.clone())
-            .or_insert_with(|| first_doc_line(doc.as_str()));
-    }
-
-    // Tier each name: 0 = prefix, 1 = substring, 2 = fuzzy.
-    let mut tiered: Vec<(u8, String, String)> = Vec::new();
-    for (name, summary) in &summaries {
-        let lower = name.to_lowercase();
-        let tier = if lower.starts_with(&needle) {
-            0
-        } else if lower.contains(&needle) {
-            1
-        } else {
-            continue;
-        };
-        tiered.push((tier, name.clone(), summary.clone()));
-    }
-
-    // If prefix + substring yielded too few, augment with fuzzy matches.
-    if tiered.len() < 3 {
-        let candidates: Vec<&str> = summaries.keys().map(|s| s.as_str()).collect();
-        if let Some(suggestion) = sema_core::error::suggest_similar(pattern, &candidates) {
-            if !tiered.iter().any(|(_, n, _)| n == &suggestion) {
-                let summary = summaries.get(&suggestion).cloned().unwrap_or_default();
-                tiered.push((2, suggestion, summary));
-            }
-        }
-    }
-
-    tiered.sort_by(|(ta, na, _), (tb, nb, _)| ta.cmp(tb).then(na.cmp(nb)));
-    tiered.truncate(MAX_RESULTS);
-
-    if tiered.is_empty() {
-        println!("(no matches for {pattern:?})");
-        return;
-    }
-
-    let max_width = tiered
-        .iter()
-        .map(|(_, n, _)| n.len())
-        .max()
-        .unwrap_or(0)
-        .min(28);
-
-    for (_, name, summary) in &tiered {
-        let summary = summary.trim();
-        if summary.is_empty() {
-            println!("  {}", colors::cyan(name));
-        } else {
-            println!(
-                "  {:width$}  {}",
-                colors::cyan(name),
-                colors::dim(summary),
-                width = max_width + visible_padding(name)
-            );
-        }
-    }
-    println!(
-        "  ({} match{})",
-        tiered.len(),
-        if tiered.len() == 1 { "" } else { "es" }
+    let mut summaries: BTreeMap<String, String> = docs::doc_name_summaries(
+        collect_env_names(env)
+            .into_iter()
+            .map(|name| {
+                let summary = describe_env_name(env, &name);
+                (name, summary)
+            })
+            .collect::<Vec<_>>(),
     );
+
+    let hits = docs::search_name_summaries(pattern, &summaries);
+    print!("{}", docs::render_apropos_hits(pattern, &hits));
+    summaries.clear();
 }
 
-fn collect_env(env: &Env, out: &mut BTreeSet<String>) {
-    env.iter_bindings(|spur, _| {
-        out.insert(sema_core::resolve(spur));
-    });
+fn collect_env_names(env: &Env) -> Vec<String> {
+    let mut names = Vec::new();
+    env.iter_bindings(|spur, _| names.push(sema_core::resolve(spur)));
     if let Some(parent) = &env.parent {
-        collect_env(parent, out);
+        names.extend(collect_env_names(parent));
     }
+    docs::dedupe_names(names)
 }
 
-fn describe_env_name(
-    env: &Env,
-    name: &str,
-    docs: &std::collections::HashMap<String, String>,
-) -> String {
-    // Try the doc table first — most expressive.
-    if let Some(doc) = docs.get(name) {
-        return first_doc_line(doc);
-    }
-    // Fall back to the value's type.
+fn describe_env_name(env: &Env, name: &str) -> String {
     let spur = sema_core::intern(name);
     match env.get(spur) {
         Some(val) if sema_vm::extract_vm_closure(&val).is_some() => "lambda".to_string(),
@@ -157,44 +46,17 @@ fn describe_env_name(
     }
 }
 
-/// First non-empty prose line of a markdown doc string, with backticks
-/// stripped for terminal readability. Skips fenced code blocks entirely.
-fn first_doc_line(doc: &str) -> String {
-    let mut in_code = false;
-    for line in doc.lines() {
-        let trimmed = line.trim();
-        if trimmed.starts_with("```") {
-            in_code = !in_code;
-            continue;
-        }
-        if in_code || trimmed.is_empty() {
-            continue;
-        }
-        return trimmed.replace('`', "");
-    }
-    String::new()
-}
-
-/// `colors::cyan` adds ANSI escapes that don't count toward visible width;
-/// `format!` width-padding sees them as characters. Compensate by adding
-/// the escape length to the field width when colour is enabled.
-fn visible_padding(s: &str) -> usize {
-    let coloured = colors::cyan(s);
-    coloured.len().saturating_sub(s.len())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn first_doc_line_skips_code_fences() {
-        let doc = "```sema\n(foo)\n```\nReturns the foo.";
-        assert_eq!(first_doc_line(doc), "Returns the foo.");
-    }
-
-    #[test]
-    fn first_doc_line_strips_backticks() {
-        assert_eq!(first_doc_line("Use `bar` to baz."), "Use bar to baz.");
+    fn env_names_are_deduped_across_parent_chain() {
+        let root = Env::new();
+        root.set_str("alpha", sema_core::Value::int(1));
+        let child = Env::with_parent(std::rc::Rc::new(root));
+        child.set_str("alpha", sema_core::Value::int(2));
+        let names = collect_env_names(&child);
+        assert_eq!(names.iter().filter(|n| n.as_str() == "alpha").count(), 1);
     }
 }

--- a/crates/sema/src/repl/commands.rs
+++ b/crates/sema/src/repl/commands.rs
@@ -3,9 +3,7 @@ use std::collections::HashSet;
 use sema_core::{pretty_print, Env, Spur, ValueView};
 use sema_eval::{Interpreter, SPECIAL_FORM_NAMES};
 
-use crate::{colors, print_error, LAST_FILE, LAST_SOURCE};
-
-use super::highlighter::highlight_doc_markdown;
+use crate::{colors, docs, print_error, LAST_FILE, LAST_SOURCE};
 
 pub const REPL_COMMANDS: &[&str] = &[
     ",quit",
@@ -139,14 +137,8 @@ fn record_source(expr: &str) {
     LAST_FILE.with(|f| *f.borrow_mut() = None);
 }
 
-fn print_doc_entry(e: &sema_docs::DocEntry) {
-    let md = sema_lsp::builtin_docs::render_markdown(e);
-    println!("{}", highlight_doc_markdown(&md));
-}
-
 fn doc(env: &Env, name: &str) {
     let spur = sema_core::intern(name);
-    let builtin_docs = sema_lsp::builtin_docs::BuiltinDocs::load();
     match env.get(spur) {
         Some(val) => {
             // VM closures arrive wrapped as NativeFn — peel that first so we
@@ -165,9 +157,10 @@ fn doc(env: &Env, name: &str) {
             } else {
                 match val.view() {
                     ValueView::NativeFn(_f) => {
-                        println!("  {} {} native-fn", colors::cyan(name), colors::dim(":"),);
-                        if let Some(e) = builtin_docs.get(name) {
-                            print_doc_entry(e);
+                        if let Some(rendered) = docs::rendered_doc(name) {
+                            print!("{rendered}");
+                        } else {
+                            println!("  {} {} native-fn", colors::cyan(name), colors::dim(":"));
                         }
                     }
                     ValueView::Lambda(l) => {
@@ -198,14 +191,12 @@ fn doc(env: &Env, name: &str) {
             }
         }
         None => {
-            if SPECIAL_FORM_NAMES.contains(&name) {
-                println!("  {} {} special form", colors::cyan(name), colors::dim(":"));
-                if let Some(e) = builtin_docs.get(name) {
-                    print_doc_entry(e);
+            if SPECIAL_FORM_NAMES.contains(&name) || docs::lookup(name).is_some() {
+                if let Some(rendered) = docs::rendered_doc(name) {
+                    print!("{rendered}");
+                } else {
+                    eprintln!("  {} {name}", colors::red_bold("not found:"));
                 }
-            } else if let Some(e) = builtin_docs.get(name) {
-                println!("  {} {} builtin", colors::cyan(name), colors::dim(":"));
-                print_doc_entry(e);
             } else {
                 eprintln!("  {} {name}", colors::red_bold("not found:"));
             }

--- a/crates/sema/src/repl/commands.rs
+++ b/crates/sema/src/repl/commands.rs
@@ -191,7 +191,9 @@ fn doc(env: &Env, name: &str) {
             }
         }
         None => {
-            if SPECIAL_FORM_NAMES.contains(&name) || docs::lookup(name).is_some() {
+            if let Some(entry) = docs::lookup(name) {
+                print!("{}", docs::rendered_doc_entry(name, entry));
+            } else if SPECIAL_FORM_NAMES.contains(&name) {
                 if let Some(rendered) = docs::rendered_doc(name) {
                     print!("{rendered}");
                 } else {

--- a/crates/sema/src/repl/highlighter.rs
+++ b/crates/sema/src/repl/highlighter.rs
@@ -451,7 +451,7 @@ mod tests {
     #[test]
     fn doc_markdown_dims_all_sema_fences() {
         let md = "Example:\n\n```sema\n(a 1)\n```\n\nMore:\n\n```sema\n(b 2)\n```\n";
-        let out = crate::docs::render_terminal_markdown(md);
+        let out = crate::docs::render_terminal_markdown_inner(md, true);
 
         // Every fence line should start with the tertiary foreground escape.
         // (Lines begin with ANSI escapes after dimming, so we look for the
@@ -480,7 +480,7 @@ mod tests {
         // regression where the final closing fence of a multi-block doc was
         // not styled.
         let md = "Define an LLM agent. The `name` must be a symbol.\n\n```sema\n(defagent greeter\n  {:system \"You are a friendly greeter.\"})\n```\n\nInspecting an agent:\n\n```sema\n(agent/name greeter)       ; => \"greeter\"\n(agent? greeter)           ; => #t\n```";
-        let out = crate::docs::render_terminal_markdown(md);
+        let out = crate::docs::render_terminal_markdown_inner(md, true);
 
         let tertiary = "\x1b[38;2;107;99;84m";
         let mut fence_count = 0;
@@ -498,7 +498,7 @@ mod tests {
         // Regression: code in the final ```sema block of defagent was not
         // getting function-position syntax highlighting.
         let md = "Inspecting an agent:\n\n```sema\n(agent/name greeter)       ; => \"greeter\"\n(agent/system greeter)     ; => \"You are a friendly greeter...\"\n(agent/max-turns greeter)  ; => 5\n(agent? greeter)           ; => #t\n```";
-        let out = crate::docs::render_terminal_markdown(md);
+        let out = crate::docs::render_terminal_markdown_inner(md, true);
 
         let gold = "\x1b[38;2;200;168;85m";
         for line in out.lines() {

--- a/crates/sema/src/repl/highlighter.rs
+++ b/crates/sema/src/repl/highlighter.rs
@@ -24,7 +24,7 @@ const SECONDARY: Color = Color::Rgb(150, 140, 121);
 ///
 /// When the cursor sits on a bracket (or just past one), the matching
 /// partner is bolded. A lonely bracket with no partner is coloured red.
-pub struct SemaHighlighter;
+pub(crate) struct SemaHighlighter;
 
 impl SemaHighlighter {
     pub fn new() -> Self {
@@ -133,49 +133,26 @@ fn style_for(
     }
 }
 
-/// Highlight Sema code blocks inside a Markdown doc string.
-///
-/// Fenced blocks tagged `sema` get inline syntax highlighting; the fence
-/// lines themselves are dimmed so they recede. Everything else is passed
-/// through unchanged. Returns the original string when ANSI colors are
-/// disabled (`NO_COLOR` set or stdout is not a terminal).
-pub fn highlight_doc_markdown(md: &str) -> String {
-    highlight_doc_markdown_inner(md, enabled_stdout())
-}
-
-fn highlight_doc_markdown_inner(md: &str, color: bool) -> String {
-    if !color {
-        return md.to_string();
-    }
-
+pub(crate) fn highlight_sema_ansi(line: &str) -> String {
     let fence_style = Style::new().fg(TERTIARY);
     let highlighter = SemaHighlighter::new();
-    let mut out = String::with_capacity(md.len() * 2);
-    let mut in_sema_block = false;
-
-    for line in md.lines() {
-        let trimmed = line.trim_start();
-        if trimmed.starts_with("```sema") {
-            in_sema_block = true;
-            out.push_str(&fence_style.paint(line).to_string());
-            out.push('\n');
-        } else if in_sema_block && trimmed.starts_with("```") {
-            in_sema_block = false;
-            out.push_str(&fence_style.paint(line).to_string());
-            out.push('\n');
-        } else if in_sema_block {
-            let styled = highlighter.highlight(line, 0);
-            for (style, text) in &styled.buffer {
-                out.push_str(&style.paint(text).to_string());
-            }
-            out.push('\n');
-        } else {
-            out.push_str(line);
-            out.push('\n');
-        }
+    let mut out = String::with_capacity(line.len() * 2);
+    if line.trim_start().starts_with("```") {
+        return fence_style.paint(line).to_string();
     }
-
+    let styled = highlighter.highlight(line, 0);
+    for (style, text) in &styled.buffer {
+        out.push_str(&style.paint(text).to_string());
+    }
     out
+}
+
+/// Highlight Sema code blocks inside a Markdown doc string.
+pub(crate) fn highlight_doc_markdown(md: &str) -> String {
+    if !enabled_stdout() {
+        return md.to_string();
+    }
+    crate::docs::render_terminal_markdown(md)
 }
 
 /// Given the tokens of the buffer and the cursor position, return the
@@ -478,7 +455,7 @@ mod tests {
     #[test]
     fn doc_markdown_dims_all_sema_fences() {
         let md = "Example:\n\n```sema\n(a 1)\n```\n\nMore:\n\n```sema\n(b 2)\n```\n";
-        let out = highlight_doc_markdown_inner(md, true);
+        let out = crate::docs::render_terminal_markdown(md);
 
         // Every fence line should start with the tertiary foreground escape.
         // (Lines begin with ANSI escapes after dimming, so we look for the
@@ -507,7 +484,7 @@ mod tests {
         // regression where the final closing fence of a multi-block doc was
         // not styled.
         let md = "Define an LLM agent. The `name` must be a symbol.\n\n```sema\n(defagent greeter\n  {:system \"You are a friendly greeter.\"})\n```\n\nInspecting an agent:\n\n```sema\n(agent/name greeter)       ; => \"greeter\"\n(agent? greeter)           ; => #t\n```";
-        let out = highlight_doc_markdown_inner(md, true);
+        let out = crate::docs::render_terminal_markdown(md);
 
         let tertiary = "\x1b[38;2;107;99;84m";
         let mut fence_count = 0;
@@ -525,7 +502,7 @@ mod tests {
         // Regression: code in the final ```sema block of defagent was not
         // getting function-position syntax highlighting.
         let md = "Inspecting an agent:\n\n```sema\n(agent/name greeter)       ; => \"greeter\"\n(agent/system greeter)     ; => \"You are a friendly greeter...\"\n(agent/max-turns greeter)  ; => 5\n(agent? greeter)           ; => #t\n```";
-        let out = highlight_doc_markdown_inner(md, true);
+        let out = crate::docs::render_terminal_markdown(md);
 
         let gold = "\x1b[38;2;200;168;85m";
         for line in out.lines() {

--- a/crates/sema/src/repl/highlighter.rs
+++ b/crates/sema/src/repl/highlighter.rs
@@ -4,8 +4,6 @@ use sema_core::SemaError;
 use sema_eval::SPECIAL_FORM_NAMES;
 use sema_reader::lexer::{tokenize, SpannedToken, Token};
 
-use crate::colors::enabled_stdout;
-
 // Sema brand palette from `crates/sema/src/colors.rs` / `website/.vitepress/theme/BrandGuide.vue`.
 const GOLD: Color = Color::Rgb(200, 168, 85);
 const SAGE: Color = Color::Rgb(168, 196, 122);
@@ -148,11 +146,9 @@ pub(crate) fn highlight_sema_ansi(line: &str) -> String {
 }
 
 /// Highlight Sema code blocks inside a Markdown doc string.
+#[cfg(test)]
 pub(crate) fn highlight_doc_markdown(md: &str) -> String {
-    if !enabled_stdout() {
-        return md.to_string();
-    }
-    crate::docs::render_terminal_markdown(md)
+    md.to_string()
 }
 
 /// Given the tokens of the buffer and the cursor position, return the

--- a/crates/sema/src/repl/mod.rs
+++ b/crates/sema/src/repl/mod.rs
@@ -21,7 +21,7 @@ mod completer;
 mod disasm;
 mod editor;
 mod headless;
-mod highlighter;
+pub(crate) mod highlighter;
 mod hinter;
 mod history;
 mod inspector;

--- a/crates/sema/tests/integration_test.rs
+++ b/crates/sema/tests/integration_test.rs
@@ -13494,6 +13494,53 @@ fn test_package_imports() {
     .unwrap();
 }
 
+// ── sema completions (shell completion generation) ────────────────
+
+#[test]
+fn test_completions_all_shells_generate_without_panic() {
+    // Regression guard: a hidden `__complete-doc-symbols` clap subcommand once
+    // made clap_complete's bash generator panic. Every shell must generate a
+    // non-empty script and exit 0.
+    for shell in ["bash", "zsh", "fish", "powershell", "elvish"] {
+        let output = sema_cmd()
+            .args(["completions", shell])
+            .output()
+            .expect("failed to run sema completions");
+        assert!(
+            output.status.success(),
+            "sema completions {shell} did not exit 0; stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            !output.stdout.is_empty(),
+            "sema completions {shell} produced no script"
+        );
+    }
+}
+
+#[test]
+fn test_completions_bash_zsh_fish_wire_dynamic_doc_hook() {
+    // The interactive shells must include the dynamic doc-symbol hook that calls
+    // back into `sema __complete-doc-symbols`; bash must also define the wrapper.
+    for shell in ["bash", "zsh", "fish"] {
+        let output = sema_cmd()
+            .args(["completions", shell])
+            .output()
+            .expect("failed to run sema completions");
+        let script = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            script.contains("__complete-doc-symbols"),
+            "{shell} completion missing dynamic doc-symbol hook"
+        );
+    }
+    let bash = sema_cmd().args(["completions", "bash"]).output().unwrap();
+    let bash = String::from_utf8_lossy(&bash.stdout);
+    assert!(
+        bash.contains("_sema_doc_complete"),
+        "bash completion missing the doc-completion wrapper function"
+    );
+}
+
 // ── sema eval subcommand ──────────────────────────────────────────
 
 #[test]

--- a/crates/sema/tests/integration_test.rs
+++ b/crates/sema/tests/integration_test.rs
@@ -13497,6 +13497,74 @@ fn test_package_imports() {
 // ── sema eval subcommand ──────────────────────────────────────────
 
 #[test]
+fn test_doc_show_builtin() {
+    let output = sema_cmd()
+        .args(["doc", "string/split"])
+        .output()
+        .expect("failed to run sema doc");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("string/split"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("Split a string by a literal delimiter"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn test_doc_search_finds_builtin() {
+    let output = sema_cmd()
+        .args(["doc", "search", "split", "a", "string"])
+        .output()
+        .expect("failed to run sema doc search");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("string/split"), "stdout: {stdout}");
+}
+
+#[test]
+fn test_doc_apropos_finds_name_matches() {
+    let output = sema_cmd()
+        .args(["doc", "apropos", "string/spl"])
+        .output()
+        .expect("failed to run sema doc apropos");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("string/split") || stdout.contains("string-split"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn test_complete_doc_symbols_filters_prefix() {
+    let output = sema_cmd()
+        .args(["__complete-doc-symbols", "string/spl"])
+        .output()
+        .expect("failed to run sema __complete-doc-symbols");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.lines().any(|line| line == "string/split"));
+    assert!(!stdout.lines().any(|line| line == "map"));
+}
+
+#[test]
 fn test_eval_expr_json() {
     let output = sema_cmd()
         .args(["eval", "--expr", "(+ 1 2)", "--json", "--no-llm"])


### PR DESCRIPTION
## `sema doc` — browse builtin & special-form docs from the terminal

Adds a `sema doc` subcommand (and shares its rendering with the REPL) so you can read the docs for any builtin or special form without leaving the shell.

```
sema doc string/split              # show docs for a symbol (implicit `show`)
sema doc show map                  # explicit form
sema doc search "split a string"   # natural-language search
sema doc apropos string/spl        # prefix / substring / fuzzy name search
```

### What you get
- **Rendered docs** — markdown from the `sema-docs` index rendered to the terminal, with syntax-highlighted `sema` code blocks, dimmed fences, and styled headings/inline markup. Colors auto-disable when output isn't a TTY.
- **Alias resolution** — `sema doc string-split` resolves to and shows `string/split`.
- **Search & apropos** — `search` uses the docs-search ranker; `apropos` does tiered prefix → substring → fuzzy name matching.
- **Pager** — long output auto-pages through `less` on a TTY; `--pager` forces it, `--no-pager` disables it.
- **Shell completion** — a `sema __complete-doc-symbols` helper feeds dynamic **bash / zsh / fish** completion of doc symbol names. (PowerShell/Elvish get clap's static subcommand+flag completion; dynamic symbol completion for those is a possible follow-up.)
- Not-found lookups exit non-zero with a clear message.

### Notable internal changes
- New `crates/sema/src/docs.rs` is the single home for doc lookup / render / search / apropos, shared by the CLI and the REPL (`,doc` / `,apropos`), de-duplicating ~160 lines out of the REPL's `apropos.rs`.
- The REPL `,apropos` now draws special forms from the `sema-docs` index instead of injecting `SPECIAL_FORM_NAMES`. Confirmed **no coverage gap** (all 44 special forms have doc entries) and added a guard test (`every_special_form_has_a_doc_entry`) so a new special form can't silently disappear from apropos/lookup.

### Review fixes included in this branch
1. **Doc-markdown test seam** — the refactor had lost the force-color seam, making three `repl::highlighter::doc_markdown_*` tests fail in non-TTY/CI. Restored via `render_terminal_markdown_inner(md, color)`; the public wrapper still uses the real TTY check at runtime.
2. **`sema completions bash` panic** — a hidden `__complete-doc-symbols` clap subcommand made `clap_complete`'s bash generator panic (`find_subcommand_with_path`), so bash completions couldn't even be generated/installed. The helper is now handled by an argv intercept in `main()` before `Cli::parse()` and is no longer a clap subcommand; generated scripts still call `sema __complete-doc-symbols` unchanged.

### Testing
- `cargo fmt --check` clean, `cargo clippy --all-targets -D warnings` clean.
- 182 bin unit tests + 9 `sema doc` integration tests pass.
- **Completions verified end-to-end on a clean `debian:bookworm-slim` box** (freshly-installed bash 5.2 / zsh 5.9 / fish 3.6, sema built in-container): all three shells complete `sema doc <symbol>` to the right symbol, and `sema completions bash` no longer panics.
