### PR TITLE
feat(mcp): MCP client — stdio + HTTP transports, agent adapter, native OAuth 2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,17 @@
   silent; expired tokens are refreshed automatically. A headless RFC 8628
   device-authorization flow and a bring-your-own-token option (`:headers`) are
   also supported. `sema mcp login <url>` (with `--device` / `--client-id`) and
-  `sema mcp logout <url>` manage credentials from the CLI.
+  `sema mcp logout <url>` manage credentials from the CLI. A mid-session `401`
+  (expired token) or `403 insufficient_scope` re-authorizes and retries the call
+  transparently — refreshing, or stepping up to the union of scopes — on both the
+  Streamable-HTTP and legacy HTTP+SSE transports. Set `SEMA_MCP_TOKEN_STORE=file`
+  to force the `0600`-file store instead of the OS keychain (handy on headless
+  boxes or to avoid repeated keychain prompts while developing).
+- **MCP tool-call cassettes.** MCP `tools/call` results record and replay through
+  the same cassette tape as LLM calls (`llm/cassette-load`/`llm/cassette-save`,
+  or the `SEMA_LLM_CASSETTE` env var), keyed by a hash of the server identity,
+  tool, and arguments — so an agent-over-MCP flow can be captured once and
+  replayed offline/deterministically in CI, with no network or live server.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,29 @@
 
 ### Added
 
-- **MCP client (stdio transport).** Sema can now act as an MCP *client*, not just
-  a server: `mcp/connect` launches an external MCP server as a child process,
-  performs the `initialize` handshake (including the required
-  `notifications/initialized` follow-up), and returns an opaque handle.
-  `mcp/tools` lists the server's tools, `mcp/call` invokes one, and `mcp/close`
-  shuts the server down. `mcp/tools->sema` converts a server's tools into the
-  same value shape `deftool` produces, so `defagent` can consume external MCP
-  tools with no agent-loop changes; a tool that reports `isError` surfaces as an
-  error the loop feeds back to the model. `mcp/connect` spawns a process and so
-  requires the `process` sandbox capability; tokens for servers that need them
-  are passed through the `:env` map. (Remote Streamable-HTTP transport and the
-  OAuth login flow remain future milestones — see
-  `docs/plans/2026-06-21-mcp-client-spike.md`.)
+- **MCP client.** Sema can now act as an MCP *client*, not just a server, over
+  every standard transport. `mcp/connect` picks the transport from its config:
+  `:command` spawns a **stdio** server (gated on the `process` capability;
+  credentials via the `:env` map), `:url` connects to a remote server over
+  **Streamable HTTP** (gated on `network`; MCP spec `2025-11-25`, with
+  `Mcp-Session-Id` / `MCP-Protocol-Version` handling and JSON-or-SSE responses),
+  and it auto-falls-back to the deprecated 2024-11-05 HTTP+SSE transport when a
+  server only speaks that. `mcp/tools` lists tools, `mcp/call` invokes one,
+  `mcp/close` disconnects, and `mcp/tools->sema` converts a server's tools into
+  the exact value shape `deftool` produces so `defagent` consumes external MCP
+  tools with no agent-loop changes (`isError` surfaces as an error).
+- **MCP client OAuth 2.1 login.** Remote servers that require authorization are
+  handled natively per the MCP authorization spec: on a `401`, Sema discovers the
+  authorization server (RFC 9728 protected-resource metadata → RFC 8414/OIDC
+  metadata), registers a client (RFC 7591 dynamic registration, a pre-registered
+  `:auth {:client-id …}`, or a cached one), and runs the Authorization-Code +
+  PKCE-S256 flow over an RFC 8252 loopback redirect — opening the system browser,
+  binding `resource=` (RFC 8707), then exchanging the code for tokens. Tokens are
+  cached in the OS keychain (with a `0600`-file fallback), so later connects are
+  silent; expired tokens are refreshed automatically. A headless RFC 8628
+  device-authorization flow and a bring-your-own-token option (`:headers`) are
+  also supported. `sema mcp login <url>` (with `--device` / `--client-id`) and
+  `sema mcp logout <url>` manage credentials from the CLI.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+### Added
+
+- **MCP client (stdio transport).** Sema can now act as an MCP *client*, not just
+  a server: `mcp/connect` launches an external MCP server as a child process,
+  performs the `initialize` handshake (including the required
+  `notifications/initialized` follow-up), and returns an opaque handle.
+  `mcp/tools` lists the server's tools, `mcp/call` invokes one, and `mcp/close`
+  shuts the server down. `mcp/tools->sema` converts a server's tools into the
+  same value shape `deftool` produces, so `defagent` can consume external MCP
+  tools with no agent-loop changes; a tool that reports `isError` surfaces as an
+  error the loop feeds back to the model. `mcp/connect` spawns a process and so
+  requires the `process` sandbox capability; tokens for servers that need them
+  are passed through the `:env` map. (Remote Streamable-HTTP transport and the
+  OAuth login flow remain future milestones — see
+  `docs/plans/2026-06-21-mcp-client-spike.md`.)
+
 ### Fixed
 
 - **`str` is now a real alias of `string-append`.** The two builtins had

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "ascii-canvas"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,6 +426,12 @@ dependencies = [
  "wasm-bindgen",
  "windows-link",
 ]
+
+[[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "cipher"
@@ -738,6 +750,27 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1600,7 +1633,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.0",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -1608,10 +1641,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -1640,6 +1722,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "linux-keyutils",
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
 ]
 
 [[package]]
@@ -1757,6 +1854,16 @@ checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
 dependencies = [
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "linux-keyutils"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
 ]
 
 [[package]]
@@ -1967,6 +2074,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2058,6 +2171,50 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64",
+ "chrono",
+ "getrandom 0.2.17",
+ "http",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
 ]
 
 [[package]]
@@ -2176,6 +2333,12 @@ dependencies = [
  "tokio",
  "tokio-stream",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking_lot"
@@ -2489,7 +2652,7 @@ dependencies = [
  "bitflags 2.11.0",
  "num-traits",
  "rand 0.9.3",
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -2620,11 +2783,22 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -2641,12 +2815,31 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2715,6 +2908,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2901,7 +3105,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -2922,14 +3126,14 @@ checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
  "log",
  "once_cell",
  "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -3015,6 +3219,19 @@ name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
 
 [[package]]
 name = "security-framework"
@@ -3177,8 +3394,13 @@ dependencies = [
 name = "sema-mcp"
 version = "1.28.1"
 dependencies = [
+ "base64",
  "crc32fast",
+ "directories",
  "futures",
+ "keyring",
+ "oauth2",
+ "rand 0.10.1",
  "reqwest",
  "sema-core",
  "sema-docs",
@@ -3188,8 +3410,11 @@ dependencies = [
  "sema-vm",
  "serde",
  "serde_json",
+ "sha2",
+ "tiny_http",
  "tokio",
  "uuid",
+ "webbrowser",
 ]
 
 [[package]]
@@ -3560,6 +3785,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3833,6 +4074,18 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
 ]
 
 [[package]]
@@ -4535,6 +4788,22 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webbrowser"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
+dependencies = [
+ "core-foundation 0.10.1",
+ "jni 0.22.4",
+ "log",
+ "ndk-context",
+ "objc2",
+ "objc2-foundation",
+ "url",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3413,6 +3413,7 @@ dependencies = [
  "sha2",
  "tiny_http",
  "tokio",
+ "url",
  "uuid",
  "webbrowser",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3178,6 +3178,8 @@ name = "sema-mcp"
 version = "1.28.1"
 dependencies = [
  "crc32fast",
+ "futures",
+ "reqwest",
  "sema-core",
  "sema-docs",
  "sema-eval",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,18 @@ tar = "0.4"
 flate2 = "1"
 crc32fast = "1"
 
+# MCP client OAuth (native, hand-rolled per Option B). oauth2 provides PKCE-S256
+# + code/refresh exchange; we drive it with our own reqwest client. tiny_http is
+# the lean loopback-redirect listener; webbrowser opens the system browser;
+# keyring is the OS keychain (with a 0600-file fallback we implement). directories
+# resolves the config dir. Platform-native keyring backends avoid extra system
+# libs (no dbus) so CI builds stay green.
+oauth2 = { version = "5", default-features = false }
+tiny_http = "0.12"
+webbrowser = "1"
+keyring = { version = "3", features = ["apple-native", "windows-native", "linux-native"] }
+directories = "6"
+
 wasm-bindgen = "0.2"
 js-sys = "0.3"
 web-sys = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ crc32fast = "1"
 # resolves the config dir. Platform-native keyring backends avoid extra system
 # libs (no dbus) so CI builds stay green.
 oauth2 = { version = "5", default-features = false }
+url = "2"
 tiny_http = "0.12"
 webbrowser = "1"
 keyring = { version = "3", features = ["apple-native", "windows-native", "linux-native"] }

--- a/crates/sema-core/src/lib.rs
+++ b/crates/sema-core/src/lib.rs
@@ -33,11 +33,11 @@ pub use context::{
 pub use error::{CallFrame, SemaError, Span, SpanMap, StackTrace};
 pub use home::sema_home;
 pub use json::{json_to_value, key_to_string, value_to_json, value_to_json_lossy};
+pub use lasso::Spur;
 pub use mcp_cassette::{
     clear_mcp_cassette_hook, mcp_cassette_decide, mcp_cassette_record, set_mcp_cassette_hook,
     McpCassetteDecision,
 };
-pub use lasso::Spur;
 pub use output_hook::{set_stderr_hook, set_stdout_hook, write_stderr, write_stdout};
 pub use sandbox::{Caps, Sandbox};
 pub use text_util::truncate_chars;

--- a/crates/sema-core/src/lib.rs
+++ b/crates/sema-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod context;
 pub mod error;
 pub mod home;
 pub mod json;
+pub mod mcp_cassette;
 pub mod output_hook;
 pub mod resolve;
 pub mod sandbox;
@@ -32,6 +33,10 @@ pub use context::{
 pub use error::{CallFrame, SemaError, Span, SpanMap, StackTrace};
 pub use home::sema_home;
 pub use json::{json_to_value, key_to_string, value_to_json, value_to_json_lossy};
+pub use mcp_cassette::{
+    clear_mcp_cassette_hook, mcp_cassette_decide, mcp_cassette_record, set_mcp_cassette_hook,
+    McpCassetteDecision,
+};
 pub use lasso::Spur;
 pub use output_hook::{set_stderr_hook, set_stdout_hook, write_stderr, write_stdout};
 pub use sandbox::{Caps, Sandbox};

--- a/crates/sema-core/src/mcp_cassette.rs
+++ b/crates/sema-core/src/mcp_cassette.rs
@@ -1,0 +1,102 @@
+//! MCP-call cassette hook — a crate-neutral seam so `sema-mcp` can record/replay
+//! tool calls through the LLM cassette that lives in `sema-llm`, without a
+//! dependency edge between the two crates.
+//!
+//! `sema-llm` owns the tape and installs the hook at interpreter init (function
+//! pointers into its thread-local cassette, exactly like `set_eval_callback`);
+//! `sema-mcp` consults the hook around each real `tools/call`. When no cassette
+//! is active the hook is absent and calls pass straight through.
+
+use std::cell::RefCell;
+
+use serde_json::Value;
+
+/// What to do for an MCP tool call under an active cassette.
+pub enum McpCassetteDecision {
+    /// Serve this recorded result — do NOT touch the network.
+    Replay(Value),
+    /// Replay mode with no matching entry — a hard miss (surfaces drift).
+    Miss,
+    /// Perform the real call, then record the result.
+    Record,
+}
+
+type DecideFn = fn(&str) -> McpCassetteDecision;
+type RecordFn = fn(&str, &Value);
+
+thread_local! {
+    static HOOK: RefCell<Option<(DecideFn, RecordFn)>> = const { RefCell::new(None) };
+}
+
+/// Register the cassette hook. Called by `sema-llm` when a cassette is active.
+pub fn set_mcp_cassette_hook(decide: DecideFn, record: RecordFn) {
+    HOOK.with(|h| *h.borrow_mut() = Some((decide, record)));
+}
+
+/// Remove the cassette hook (calls pass straight through afterwards).
+pub fn clear_mcp_cassette_hook() {
+    HOOK.with(|h| *h.borrow_mut() = None);
+}
+
+/// Decide how to handle an MCP call for `key`; `None` when no cassette is active.
+pub fn mcp_cassette_decide(key: &str) -> Option<McpCassetteDecision> {
+    HOOK.with(|h| {
+        let hook = h.borrow();
+        hook.as_ref().map(|&(decide, _)| decide(key))
+    })
+}
+
+/// Record an MCP call result under `key`. No-op when no cassette is active.
+pub fn mcp_cassette_record(key: &str, value: &Value) {
+    HOOK.with(|h| {
+        if let Some(&(_, record)) = h.borrow().as_ref() {
+            record(key, value);
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    thread_local! {
+        static TEST_TAPE: RefCell<HashMap<String, Value>> = RefCell::new(HashMap::new());
+    }
+
+    fn test_decide(key: &str) -> McpCassetteDecision {
+        TEST_TAPE.with(|t| match t.borrow().get(key) {
+            Some(v) => McpCassetteDecision::Replay(v.clone()),
+            None => McpCassetteDecision::Record,
+        })
+    }
+
+    fn test_record(key: &str, value: &Value) {
+        TEST_TAPE.with(|t| {
+            t.borrow_mut().insert(key.to_string(), value.clone());
+        });
+    }
+
+    #[test]
+    fn hook_routes_decide_and_record() {
+        // No hook → transparent.
+        assert!(mcp_cassette_decide("k").is_none());
+        mcp_cassette_record("k", &serde_json::json!({"ignored": true})); // no-op, must not panic
+
+        set_mcp_cassette_hook(test_decide, test_record);
+        // Unknown key → Record.
+        assert!(matches!(
+            mcp_cassette_decide("k"),
+            Some(McpCassetteDecision::Record)
+        ));
+        // Record then replay the exact value.
+        mcp_cassette_record("k", &serde_json::json!({"a": 1}));
+        match mcp_cassette_decide("k") {
+            Some(McpCassetteDecision::Replay(v)) => assert_eq!(v, serde_json::json!({"a": 1})),
+            _ => panic!("expected a replay hit"),
+        }
+
+        clear_mcp_cassette_hook();
+        assert!(mcp_cassette_decide("k").is_none());
+    }
+}

--- a/crates/sema-docs/builtin_docs.generated.json
+++ b/crates/sema-docs/builtin_docs.generated.json
@@ -5800,6 +5800,105 @@
       "body": "Drop the fractional part, rounding toward zero (so negatives round *up*). Unlike [`round`](#round), it never inspects the fraction — `3.9` truncates to `3`.\n\n```sema\n(truncate 3.7)  ; => 3\n(truncate -3.7) ; => -3   ; toward zero, not floor (-4)\n(truncate 3.9)  ; => 3\n```"
     },
     {
+      "name": "mcp/call",
+      "module": "mcp",
+      "section": "MCP Client",
+      "summary": "Invoke a tool on an MCP server (`tools/call`) and return its result normalized to a Sema value: a plain text result collapses to a string; a richer result (images, resources, `structuredContent`) is returned as the full map. A tool that reports `isError` surfaces as a `SemaError`.",
+      "params": [
+        {
+          "name": "handle",
+          "type": "string"
+        },
+        {
+          "name": "tool",
+          "type": "string",
+          "doc": "tool name"
+        },
+        {
+          "name": "args",
+          "type": "map",
+          "doc": "arguments object"
+        }
+      ],
+      "returns": "any",
+      "examples": [
+        "(define fs (mcp/connect {:command \"npx\"\n                         :args [\"-y\" \"@modelcontextprotocol/server-filesystem\" \"/tmp\"]}))\n\n(mcp/call fs \"read_file\" {:path \"/tmp/notes.txt\"})\n; => \"…file contents…\""
+      ],
+      "body": "```\n(mcp/call handle tool args)\n```\n\nInvoke a tool on an MCP server (`tools/call`) and return its result normalized to\na Sema value: a plain text result collapses to a string; a richer result (images,\nresources, `structuredContent`) is returned as the full map. A tool that reports\n`isError` surfaces as a `SemaError`.\n\n```sema\n(define fs (mcp/connect {:command \"npx\"\n                         :args [\"-y\" \"@modelcontextprotocol/server-filesystem\" \"/tmp\"]}))\n\n(mcp/call fs \"read_file\" {:path \"/tmp/notes.txt\"})\n; => \"…file contents…\"\n```\n\nFor agent use, prefer `mcp/tools->sema` so the model drives the calls; use\n`mcp/call` directly for scripted, non-agent access."
+    },
+    {
+      "name": "mcp/close",
+      "module": "mcp",
+      "section": "MCP Client",
+      "summary": "Close an MCP connection. For a stdio server this terminates the child process; for an HTTP server it best-effort ends the session (`DELETE`). After closing, the handle is no longer valid. Dropping a handle without calling `mcp/close` still tears down a stdio child, but calling it explicitly is clearer and deterministic.",
+      "params": [
+        {
+          "name": "handle",
+          "type": "string",
+          "doc": "connection handle from mcp/connect"
+        }
+      ],
+      "returns": "nil",
+      "examples": [
+        "(define fs (mcp/connect {:command \"npx\" :args [\"-y\" \"server-filesystem\" \"/tmp\"]}))\n;; … use it …\n(mcp/close fs)"
+      ],
+      "body": "```\n(mcp/close handle)\n```\n\nClose an MCP connection. For a stdio server this terminates the child process;\nfor an HTTP server it best-effort ends the session (`DELETE`). After closing, the\nhandle is no longer valid. Dropping a handle without calling `mcp/close` still\ntears down a stdio child, but calling it explicitly is clearer and deterministic.\n\n```sema\n(define fs (mcp/connect {:command \"npx\" :args [\"-y\" \"server-filesystem\" \"/tmp\"]}))\n;; … use it …\n(mcp/close fs)\n```"
+    },
+    {
+      "name": "mcp/connect",
+      "module": "mcp",
+      "section": "MCP Client",
+      "summary": "Connect to an external MCP (Model Context Protocol) server and return an opaque connection **handle** (a string) for use with `mcp/tools`, `mcp/call`, `mcp/tools->sema`, and `mcp/close`. The handshake (`initialize`) runs eagerly, so a returned handle is ready to use. The transport is chosen from the config map:",
+      "params": [
+        {
+          "name": "config",
+          "type": "map",
+          "doc": "connection spec: :command (stdio) or :url (http)"
+        }
+      ],
+      "returns": "string",
+      "examples": [
+        ";; Local stdio server\n(define fs (mcp/connect {:command \"npx\"\n                         :args [\"-y\" \"@modelcontextprotocol/server-filesystem\" \"/tmp\"]}))\n\n;; Remote server (OAuth handled automatically on first use)\n(define asana (mcp/connect {:url \"https://mcp.asana.com/mcp\"}))\n\n;; Remote server with a bring-your-own bearer token\n(define gh (mcp/connect {:url \"https://mcp.example.com/mcp\"\n                         :headers {\"Authorization\" \"Bearer ghp_…\"}}))"
+      ],
+      "body": "```\n(mcp/connect {:command \"…\" :args […] :env {…} :cwd \"…\"})\n(mcp/connect {:url \"https://…/mcp\" :headers {…} :auth {:client-id \"…\"}})\n```\n\nConnect to an external MCP (Model Context Protocol) server and return an opaque\nconnection **handle** (a string) for use with `mcp/tools`, `mcp/call`,\n`mcp/tools->sema`, and `mcp/close`. The handshake (`initialize`) runs eagerly, so\na returned handle is ready to use. The transport is chosen from the config map:\n\n- **`:command`** — spawn a local server as a child process and speak JSON-RPC\n  over stdio. Optional `:args` (list of strings), `:env` (map of extra\n  environment variables — the place to pass a token a server reads from its\n  environment), and `:cwd`. Requires the `process` sandbox capability.\n- **`:url`** — connect to a remote server over **Streamable HTTP** (falls back\n  automatically to the deprecated 2024-11-05 HTTP+SSE transport when a server\n  only speaks that). Requires the `network` capability. Optional `:headers`\n  attaches a static bearer token (`{\"Authorization\" \"Bearer …\"}`); `:auth\n  {:client-id \"…\"}` supplies a pre-registered OAuth client id.\n\nA remote server that requires OAuth is handled automatically: the first `401`\ntriggers the browser login flow (or a cached/refreshed token), then the handshake\nretries. See `sema mcp login` to authenticate ahead of time.\n\nConnecting to an MCP server runs its tools with the **server's** authority, not\nSema's sandbox — treat an untrusted server like untrusted code.\n\n```sema\n;; Local stdio server\n(define fs (mcp/connect {:command \"npx\"\n                         :args [\"-y\" \"@modelcontextprotocol/server-filesystem\" \"/tmp\"]}))\n\n;; Remote server (OAuth handled automatically on first use)\n(define asana (mcp/connect {:url \"https://mcp.asana.com/mcp\"}))\n\n;; Remote server with a bring-your-own bearer token\n(define gh (mcp/connect {:url \"https://mcp.example.com/mcp\"\n                         :headers {\"Authorization\" \"Bearer ghp_…\"}}))\n```"
+    },
+    {
+      "name": "mcp/tools",
+      "module": "mcp",
+      "section": "MCP Client",
+      "summary": "List the tools an MCP server exposes (`tools/list`). Returns a list of maps, one per tool, each with `:name`, `:description`, and `:input-schema` (the tool's raw JSON-Schema for its arguments).",
+      "params": [
+        {
+          "name": "handle",
+          "type": "string",
+          "doc": "connection handle from mcp/connect"
+        }
+      ],
+      "returns": "list",
+      "examples": [
+        "(define fs (mcp/connect {:command \"npx\"\n                         :args [\"-y\" \"@modelcontextprotocol/server-filesystem\" \"/tmp\"]}))\n\n(mcp/tools fs)\n; => ({:name \"read_file\" :description \"Read a file\" :input-schema {…}} …)\n\n;; Just the names:\n(map (fn (t) (:name t)) (mcp/tools fs))"
+      ],
+      "body": "```\n(mcp/tools handle)\n```\n\nList the tools an MCP server exposes (`tools/list`). Returns a list of maps, one\nper tool, each with `:name`, `:description`, and `:input-schema` (the tool's raw\nJSON-Schema for its arguments).\n\nTo feed these tools to an agent, use `mcp/tools->sema` instead — it produces the\nvalue shape `deftool`/`defagent` expect.\n\n```sema\n(define fs (mcp/connect {:command \"npx\"\n                         :args [\"-y\" \"@modelcontextprotocol/server-filesystem\" \"/tmp\"]}))\n\n(mcp/tools fs)\n; => ({:name \"read_file\" :description \"Read a file\" :input-schema {…}} …)\n\n;; Just the names:\n(map (fn (t) (:name t)) (mcp/tools fs))\n```"
+    },
+    {
+      "name": "mcp/tools->sema",
+      "module": "mcp",
+      "section": "MCP Client",
+      "summary": "Convert an MCP server's tools into the exact value shape `deftool` produces (name, description, params map, handler), so `defagent` can consume external MCP tools as first-class agent tools with no agent-loop changes. Each returned tool's handler calls back into the server via the connection; a tool that reports `isError` surfaces to the agent loop as an error it can react to.",
+      "params": [
+        {
+          "name": "handle",
+          "type": "string",
+          "doc": "connection handle from mcp/connect"
+        }
+      ],
+      "returns": "list",
+      "examples": [
+        "(define fs (mcp/connect {:command \"npx\"\n                         :args [\"-y\" \"@modelcontextprotocol/server-filesystem\" \"/tmp\"]}))\n\n(defagent librarian\n  {:model \"claude-sonnet-5\"\n   :system \"You manage files.\"\n   :tools (mcp/tools->sema fs)})     ; MCP tools become agent tools\n\n(agent/run librarian \"Summarize /tmp/notes.txt\")"
+      ],
+      "body": "```\n(mcp/tools->sema handle)\n```\n\nConvert an MCP server's tools into the exact value shape `deftool` produces\n(name, description, params map, handler), so `defagent` can consume external MCP\ntools as first-class agent tools with no agent-loop changes. Each returned tool's\nhandler calls back into the server via the connection; a tool that reports\n`isError` surfaces to the agent loop as an error it can react to.\n\nThe MCP `inputSchema` (JSON Schema) is inverted into the `{param-name -> spec}`\nmap the agent loop expects (type, description, enum, and `:optional` for\nparameters not in the schema's `required` list).\n\n```sema\n(define fs (mcp/connect {:command \"npx\"\n                         :args [\"-y\" \"@modelcontextprotocol/server-filesystem\" \"/tmp\"]}))\n\n(defagent librarian\n  {:model \"claude-sonnet-5\"\n   :system \"You manage files.\"\n   :tools (mcp/tools->sema fs)})     ; MCP tools become agent tools\n\n(agent/run librarian \"Summarize /tmp/notes.txt\")\n```"
+    },
+    {
       "name": "memory/append",
       "module": "memory",
       "section": "Agent Memory",

--- a/crates/sema-docs/builtin_docs.generated.json
+++ b/crates/sema-docs/builtin_docs.generated.json
@@ -5830,7 +5830,7 @@
       "name": "mcp/close",
       "module": "mcp",
       "section": "MCP Client",
-      "summary": "Close an MCP connection. For a stdio server this terminates the child process; for an HTTP server it best-effort ends the session (`DELETE`). After closing, the handle is no longer valid. Dropping a handle without calling `mcp/close` still tears down a stdio child, but calling it explicitly is clearer and deterministic.",
+      "summary": "Close an MCP connection. For a stdio server this terminates the child process; for an HTTP server it best-effort ends the session (`DELETE`). After closing, the handle is no longer valid.",
       "params": [
         {
           "name": "handle",
@@ -5842,7 +5842,7 @@
       "examples": [
         "(define fs (mcp/connect {:command \"npx\" :args [\"-y\" \"server-filesystem\" \"/tmp\"]}))\n;; … use it …\n(mcp/close fs)"
       ],
-      "body": "```\n(mcp/close handle)\n```\n\nClose an MCP connection. For a stdio server this terminates the child process;\nfor an HTTP server it best-effort ends the session (`DELETE`). After closing, the\nhandle is no longer valid. Dropping a handle without calling `mcp/close` still\ntears down a stdio child, but calling it explicitly is clearer and deterministic.\n\n```sema\n(define fs (mcp/connect {:command \"npx\" :args [\"-y\" \"server-filesystem\" \"/tmp\"]}))\n;; … use it …\n(mcp/close fs)\n```"
+      "body": "```\n(mcp/close handle)\n```\n\nClose an MCP connection. For a stdio server this terminates the child process;\nfor an HTTP server it best-effort ends the session (`DELETE`). After closing, the\nhandle is no longer valid.\n\nAlways call `mcp/close` when you're done: a connection stays alive (and a stdio\nchild keeps running) until you close it or the Sema process exits — the handle is\njust an opaque string, so letting it go out of scope does **not** disconnect.\n\n```sema\n(define fs (mcp/connect {:command \"npx\" :args [\"-y\" \"server-filesystem\" \"/tmp\"]}))\n;; … use it …\n(mcp/close fs)\n```"
     },
     {
       "name": "mcp/connect",

--- a/crates/sema-docs/entries/stdlib/mcp/mcp-call.md
+++ b/crates/sema-docs/entries/stdlib/mcp/mcp-call.md
@@ -1,0 +1,27 @@
+---
+name: "mcp/call"
+module: "mcp"
+section: "MCP Client"
+params: [{ name: handle, type: string }, { name: tool, type: string, doc: "tool name" }, { name: args, type: map, doc: "arguments object" }]
+returns: "any"
+---
+
+```
+(mcp/call handle tool args)
+```
+
+Invoke a tool on an MCP server (`tools/call`) and return its result normalized to
+a Sema value: a plain text result collapses to a string; a richer result (images,
+resources, `structuredContent`) is returned as the full map. A tool that reports
+`isError` surfaces as a `SemaError`.
+
+```sema
+(define fs (mcp/connect {:command "npx"
+                         :args ["-y" "@modelcontextprotocol/server-filesystem" "/tmp"]}))
+
+(mcp/call fs "read_file" {:path "/tmp/notes.txt"})
+; => "…file contents…"
+```
+
+For agent use, prefer `mcp/tools->sema` so the model drives the calls; use
+`mcp/call` directly for scripted, non-agent access.

--- a/crates/sema-docs/entries/stdlib/mcp/mcp-close.md
+++ b/crates/sema-docs/entries/stdlib/mcp/mcp-close.md
@@ -1,0 +1,22 @@
+---
+name: "mcp/close"
+module: "mcp"
+section: "MCP Client"
+params: [{ name: handle, type: string, doc: "connection handle from mcp/connect" }]
+returns: "nil"
+---
+
+```
+(mcp/close handle)
+```
+
+Close an MCP connection. For a stdio server this terminates the child process;
+for an HTTP server it best-effort ends the session (`DELETE`). After closing, the
+handle is no longer valid. Dropping a handle without calling `mcp/close` still
+tears down a stdio child, but calling it explicitly is clearer and deterministic.
+
+```sema
+(define fs (mcp/connect {:command "npx" :args ["-y" "server-filesystem" "/tmp"]}))
+;; … use it …
+(mcp/close fs)
+```

--- a/crates/sema-docs/entries/stdlib/mcp/mcp-close.md
+++ b/crates/sema-docs/entries/stdlib/mcp/mcp-close.md
@@ -12,8 +12,11 @@ returns: "nil"
 
 Close an MCP connection. For a stdio server this terminates the child process;
 for an HTTP server it best-effort ends the session (`DELETE`). After closing, the
-handle is no longer valid. Dropping a handle without calling `mcp/close` still
-tears down a stdio child, but calling it explicitly is clearer and deterministic.
+handle is no longer valid.
+
+Always call `mcp/close` when you're done: a connection stays alive (and a stdio
+child keeps running) until you close it or the Sema process exits — the handle is
+just an opaque string, so letting it go out of scope does **not** disconnect.
 
 ```sema
 (define fs (mcp/connect {:command "npx" :args ["-y" "server-filesystem" "/tmp"]}))

--- a/crates/sema-docs/entries/stdlib/mcp/mcp-connect.md
+++ b/crates/sema-docs/entries/stdlib/mcp/mcp-connect.md
@@ -1,0 +1,47 @@
+---
+name: "mcp/connect"
+module: "mcp"
+section: "MCP Client"
+params: [{ name: config, type: map, doc: "connection spec: :command (stdio) or :url (http)" }]
+returns: "string"
+---
+
+```
+(mcp/connect {:command "…" :args […] :env {…} :cwd "…"})
+(mcp/connect {:url "https://…/mcp" :headers {…} :auth {:client-id "…"}})
+```
+
+Connect to an external MCP (Model Context Protocol) server and return an opaque
+connection **handle** (a string) for use with `mcp/tools`, `mcp/call`,
+`mcp/tools->sema`, and `mcp/close`. The handshake (`initialize`) runs eagerly, so
+a returned handle is ready to use. The transport is chosen from the config map:
+
+- **`:command`** — spawn a local server as a child process and speak JSON-RPC
+  over stdio. Optional `:args` (list of strings), `:env` (map of extra
+  environment variables — the place to pass a token a server reads from its
+  environment), and `:cwd`. Requires the `process` sandbox capability.
+- **`:url`** — connect to a remote server over **Streamable HTTP** (falls back
+  automatically to the deprecated 2024-11-05 HTTP+SSE transport when a server
+  only speaks that). Requires the `network` capability. Optional `:headers`
+  attaches a static bearer token (`{"Authorization" "Bearer …"}`); `:auth
+  {:client-id "…"}` supplies a pre-registered OAuth client id.
+
+A remote server that requires OAuth is handled automatically: the first `401`
+triggers the browser login flow (or a cached/refreshed token), then the handshake
+retries. See `sema mcp login` to authenticate ahead of time.
+
+Connecting to an MCP server runs its tools with the **server's** authority, not
+Sema's sandbox — treat an untrusted server like untrusted code.
+
+```sema
+;; Local stdio server
+(define fs (mcp/connect {:command "npx"
+                         :args ["-y" "@modelcontextprotocol/server-filesystem" "/tmp"]}))
+
+;; Remote server (OAuth handled automatically on first use)
+(define asana (mcp/connect {:url "https://mcp.asana.com/mcp"}))
+
+;; Remote server with a bring-your-own bearer token
+(define gh (mcp/connect {:url "https://mcp.example.com/mcp"
+                         :headers {"Authorization" "Bearer ghp_…"}}))
+```

--- a/crates/sema-docs/entries/stdlib/mcp/mcp-tools-to-sema.md
+++ b/crates/sema-docs/entries/stdlib/mcp/mcp-tools-to-sema.md
@@ -1,0 +1,33 @@
+---
+name: "mcp/tools->sema"
+module: "mcp"
+section: "MCP Client"
+params: [{ name: handle, type: string, doc: "connection handle from mcp/connect" }]
+returns: "list"
+---
+
+```
+(mcp/tools->sema handle)
+```
+
+Convert an MCP server's tools into the exact value shape `deftool` produces
+(name, description, params map, handler), so `defagent` can consume external MCP
+tools as first-class agent tools with no agent-loop changes. Each returned tool's
+handler calls back into the server via the connection; a tool that reports
+`isError` surfaces to the agent loop as an error it can react to.
+
+The MCP `inputSchema` (JSON Schema) is inverted into the `{param-name -> spec}`
+map the agent loop expects (type, description, enum, and `:optional` for
+parameters not in the schema's `required` list).
+
+```sema
+(define fs (mcp/connect {:command "npx"
+                         :args ["-y" "@modelcontextprotocol/server-filesystem" "/tmp"]}))
+
+(defagent librarian
+  {:model "claude-sonnet-5"
+   :system "You manage files."
+   :tools (mcp/tools->sema fs)})     ; MCP tools become agent tools
+
+(agent/run librarian "Summarize /tmp/notes.txt")
+```

--- a/crates/sema-docs/entries/stdlib/mcp/mcp-tools.md
+++ b/crates/sema-docs/entries/stdlib/mcp/mcp-tools.md
@@ -1,0 +1,29 @@
+---
+name: "mcp/tools"
+module: "mcp"
+section: "MCP Client"
+params: [{ name: handle, type: string, doc: "connection handle from mcp/connect" }]
+returns: "list"
+---
+
+```
+(mcp/tools handle)
+```
+
+List the tools an MCP server exposes (`tools/list`). Returns a list of maps, one
+per tool, each with `:name`, `:description`, and `:input-schema` (the tool's raw
+JSON-Schema for its arguments).
+
+To feed these tools to an agent, use `mcp/tools->sema` instead — it produces the
+value shape `deftool`/`defagent` expect.
+
+```sema
+(define fs (mcp/connect {:command "npx"
+                         :args ["-y" "@modelcontextprotocol/server-filesystem" "/tmp"]}))
+
+(mcp/tools fs)
+; => ({:name "read_file" :description "Read a file" :input-schema {…}} …)
+
+;; Just the names:
+(map (fn (t) (:name t)) (mcp/tools fs))
+```

--- a/crates/sema-llm/src/builtins.rs
+++ b/crates/sema-llm/src/builtins.rs
@@ -360,6 +360,49 @@ pub fn reset_runtime_state() {
     pricing::clear_custom_pricing();
 }
 
+// ── MCP-call cassette bridge ─────────────────────────────────
+// The LLM cassette (thread-local `CASSETTE`) also serves MCP `tools/call`
+// interactions so agent-over-MCP flows replay deterministically. These fns are
+// registered into `sema-core` (fn pointers) so `sema-mcp` can consult the tape
+// without depending on `sema-llm`.
+
+fn mcp_cassette_decide(key: &str) -> sema_core::McpCassetteDecision {
+    use crate::cassette::Decision;
+    CASSETTE.with(|c| match c.borrow().as_ref() {
+        // No active cassette → behave as passthrough (real call, no recording).
+        None => sema_core::McpCassetteDecision::Record,
+        Some(cass) => match cass.decide(key) {
+            Decision::Replay(entry) => match entry.mcp_result {
+                Some(value) => sema_core::McpCassetteDecision::Replay(value),
+                // Present under this key but not an mcp-call entry — treat as drift.
+                None => sema_core::McpCassetteDecision::Miss,
+            },
+            Decision::Miss(_) => sema_core::McpCassetteDecision::Miss,
+            Decision::Record => sema_core::McpCassetteDecision::Record,
+        },
+    })
+}
+
+fn mcp_cassette_record(key: &str, value: &serde_json::Value) {
+    CASSETTE.with(|c| {
+        if let Some(cass) = c.borrow_mut().as_mut() {
+            cass.record_entry(crate::cassette::TapeEntry::from_mcp_call(key, value));
+        }
+    });
+}
+
+/// Install a cassette on the current thread (programmatic/test entry point;
+/// the env path `SEMA_LLM_CASSETTE` uses the same thread-local).
+pub fn install_cassette(cassette: crate::cassette::Cassette) {
+    CASSETTE.with(|c| *c.borrow_mut() = Some(cassette));
+}
+
+/// Remove and return the active cassette (e.g. to flush it to disk after
+/// recording).
+pub fn take_cassette() -> Option<crate::cassette::Cassette> {
+    CASSETTE.with(|c| c.borrow_mut().take())
+}
+
 /// Test-only: register `provider` as the default LLM provider, bypassing
 /// `llm/configure`. Lets integration tests drive the completion/agent paths with
 /// a scripted [`crate::fake::FakeProvider`] — no API keys, fully deterministic.
@@ -1162,6 +1205,10 @@ pub fn register_llm_builtins(env: &Env, sandbox: &sema_core::Sandbox) {
     // thread-local fn pointers); registering here keeps it in a crate that names
     // both `sema_core` and `sema_otel`.
     sema_otel::register_task_callbacks();
+
+    // Bridge the LLM cassette to MCP tool calls (sema-mcp consults this via
+    // sema-core). Idempotent — just sets two thread-local fn pointers.
+    sema_core::set_mcp_cassette_hook(mcp_cassette_decide, mcp_cassette_record);
 
     // CI/global cassette: SEMA_LLM_CASSETTE=path [+ SEMA_LLM_CASSETTE_MODE=replay|
     // record|auto] installs a cassette for the whole process, so a suite can be

--- a/crates/sema-llm/src/cassette.rs
+++ b/crates/sema-llm/src/cassette.rs
@@ -79,6 +79,9 @@ pub struct TapeEntry {
     /// For `kind:"embed"` — the recorded embedding vectors (one per input text).
     #[serde(default)]
     pub embeddings: Vec<Vec<f64>>,
+    /// For `kind:"mcp-call"` — the recorded `tools/call` result JSON.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mcp_result: Option<serde_json::Value>,
 }
 
 fn default_role() -> String {
@@ -103,6 +106,29 @@ impl TapeEntry {
             cache_creation_input_tokens: resp.usage.cache_creation_input_tokens,
             chunks: Vec::new(),
             embeddings: Vec::new(),
+            mcp_result: None,
+        }
+    }
+
+    /// Tape entry for an MCP `tools/call`: the recorded result JSON, keyed by a
+    /// hash of the server identity + tool + arguments.
+    pub fn from_mcp_call(key: &str, result: &serde_json::Value) -> TapeEntry {
+        TapeEntry {
+            v: 1,
+            kind: "mcp-call".to_string(),
+            key: key.to_string(),
+            content: String::new(),
+            role: default_role(),
+            model: String::new(),
+            tool_calls: Vec::new(),
+            stop_reason: None,
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            chunks: Vec::new(),
+            embeddings: Vec::new(),
+            mcp_result: Some(result.clone()),
         }
     }
 
@@ -136,6 +162,7 @@ impl TapeEntry {
             cache_creation_input_tokens: 0,
             chunks: Vec::new(),
             embeddings: embeddings.to_vec(),
+            mcp_result: None,
         }
     }
 
@@ -303,6 +330,31 @@ mod tests {
             },
             stop_reason: Some("end".to_string()),
         }
+    }
+
+    #[test]
+    fn mcp_call_round_trips_through_the_tape() {
+        let path = std::env::temp_dir().join(format!(
+            "sema-cassette-mcp-{}-{}/tape.ndjson",
+            std::process::id(),
+            line!()
+        ));
+        let result = serde_json::json!({"content": [{"type": "text", "text": "hi"}]});
+
+        let mut rec = Cassette::load(path.clone(), CassetteMode::Record);
+        rec.record_entry(TapeEntry::from_mcp_call("mcpkey", &result));
+        rec.save().unwrap();
+
+        // Reloaded from disk in replay mode → serves the recorded result.
+        let replay = Cassette::load(path, CassetteMode::Replay);
+        match replay.decide("mcpkey") {
+            Decision::Replay(entry) => {
+                assert_eq!(entry.kind, "mcp-call");
+                assert_eq!(entry.mcp_result.as_ref(), Some(&result));
+            }
+            _ => panic!("expected a replay hit for the recorded mcp-call"),
+        }
+        assert!(matches!(replay.decide("absent"), Decision::Miss(_)));
     }
 
     #[test]

--- a/crates/sema-llm/src/cassette.rs
+++ b/crates/sema-llm/src/cassette.rs
@@ -305,8 +305,14 @@ impl Cassette {
         self.dirty = true;
     }
 
-    /// Flush the tape to disk (idempotent; safe to call even if unchanged).
+    /// Flush the tape to disk — but only if it gained entries. A replay-only
+    /// session records nothing (`dirty` stays false), so `save`/`eject` won't
+    /// rewrite the file and silently drop any tape line `Tape::load` couldn't
+    /// parse.
     pub fn save(&self) -> std::io::Result<()> {
+        if !self.dirty {
+            return Ok(());
+        }
         self.tape.save(&self.path)
     }
 }

--- a/crates/sema-mcp/Cargo.toml
+++ b/crates/sema-mcp/Cargo.toml
@@ -18,6 +18,14 @@ serde_json.workspace = true
 tokio.workspace = true
 reqwest.workspace = true
 futures.workspace = true
+oauth2.workspace = true
+tiny_http.workspace = true
+webbrowser.workspace = true
+keyring.workspace = true
+directories.workspace = true
+base64.workspace = true
+sha2.workspace = true
+rand.workspace = true
 sema-notebook.workspace = true
 uuid = { workspace = true, features = ["v4"] }
 crc32fast.workspace = true

--- a/crates/sema-mcp/Cargo.toml
+++ b/crates/sema-mcp/Cargo.toml
@@ -19,6 +19,7 @@ tokio.workspace = true
 reqwest.workspace = true
 futures.workspace = true
 oauth2.workspace = true
+url.workspace = true
 tiny_http.workspace = true
 webbrowser.workspace = true
 keyring.workspace = true

--- a/crates/sema-mcp/Cargo.toml
+++ b/crates/sema-mcp/Cargo.toml
@@ -16,6 +16,8 @@ sema-docs.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
+reqwest.workspace = true
+futures.workspace = true
 sema-notebook.workspace = true
 uuid = { workspace = true, features = ["v4"] }
 crc32fast.workspace = true

--- a/crates/sema-mcp/src/builtins.rs
+++ b/crates/sema-mcp/src/builtins.rs
@@ -33,6 +33,29 @@ thread_local! {
         RefCell::new(HashMap::new());
     // Reuse one current-thread Tokio runtime for all MCP builtins in this evaluator context.
     static TOKIO_RT: RefCell<Option<Runtime>> = const { RefCell::new(None) };
+    // The evaluator's sandbox, captured at registration, so the OAuth browser
+    // launch (connect-time or mid-session re-auth) can be denied when `PROCESS`
+    // is — opening the system browser spawns a process.
+    static SANDBOX: RefCell<Sandbox> = RefCell::new(Sandbox::allow_all());
+}
+
+/// A browser opener that refuses to launch (spawn) a browser when the sandbox
+/// denies `PROCESS`. Only invoked when a browser is actually needed (a full
+/// login), so cached/refresh flows are unaffected.
+fn gated_browser_opener() -> crate::oauth::loopback::BrowserOpener {
+    Box::new(|url: &str| {
+        if let Some(err) = SANDBOX.with(|s| {
+            let sb = s.borrow();
+            if sb.is_unrestricted() {
+                None
+            } else {
+                sb.check(Caps::PROCESS, "mcp/connect (open browser)").err()
+            }
+        }) {
+            return Err(err.to_string());
+        }
+        crate::oauth::loopback::open_browser(url)
+    })
 }
 
 static HANDLE_COUNTER: AtomicU64 = AtomicU64::new(1);
@@ -126,7 +149,16 @@ fn connect_stdio(config_json: &serde_json::Value) -> Result<Value, SemaError> {
         .and_then(|value| value.as_str())
         .map(std::path::PathBuf::from);
 
-    let identity = format!("stdio\0{command}\0{}", args_vec.join(" "));
+    // Unambiguous identity for the cassette key: args as a JSON array (so
+    // ["a b"] and ["a","b"] don't collide) plus cwd. `env` is deliberately
+    // excluded — a rotated token there should not invalidate a recorded tape.
+    let identity = serde_json::json!({
+        "t": "stdio",
+        "command": command,
+        "args": args_vec,
+        "cwd": cwd.as_ref().map(|p| p.display().to_string()),
+    })
+    .to_string();
     let mut client = block_on(McpClient::connect(McpClientConfig {
         command: command.to_string(),
         args: args_vec,
@@ -233,8 +265,11 @@ fn obtain_access_token(
     let challenge = discovery::parse_www_authenticate(challenge_header);
     let http = reqwest::Client::new();
     let credential_store = store::default_store();
-    let driver = loopback::LoopbackDriver::new(std::time::Duration::from_secs(300))
-        .map_err(|e| SemaError::eval(format!("mcp/connect: {e}")))?;
+    let driver = loopback::LoopbackDriver::with_opener(
+        std::time::Duration::from_secs(300),
+        gated_browser_opener(),
+    )
+    .map_err(|e| SemaError::eval(format!("mcp/connect: {e}")))?;
 
     let config = login::LoginConfig {
         mcp_url: url,
@@ -394,8 +429,11 @@ fn reauthorize(
 ) -> Result<Option<String>, SemaError> {
     let http = reqwest::Client::new();
     let store = crate::oauth::store::default_store();
-    let driver = crate::oauth::loopback::LoopbackDriver::new(std::time::Duration::from_secs(300))
-        .map_err(|e| SemaError::eval(format!("mcp/call: {e}")))?;
+    let driver = crate::oauth::loopback::LoopbackDriver::with_opener(
+        std::time::Duration::from_secs(300),
+        gated_browser_opener(),
+    )
+    .map_err(|e| SemaError::eval(format!("mcp/call: {e}")))?;
     block_on(crate::oauth::login::reauth_on_challenge(
         &http,
         store.as_ref(),
@@ -486,6 +524,9 @@ fn schema_to_params(schema: &serde_json::Value) -> (Value, Vec<String>) {
 }
 
 pub fn register_mcp_builtins(env: &Env, sandbox: &Sandbox) {
+    // Capture the sandbox so the OAuth browser launch can honor the PROCESS cap.
+    SANDBOX.with(|s| *s.borrow_mut() = sandbox.clone());
+
     // `mcp/connect` picks its transport from the config map at runtime, so the
     // capability it needs is not fixed: a `:url` server is network I/O
     // (`NETWORK`), a `:command` server spawns a process (`PROCESS`). Gate inside

--- a/crates/sema-mcp/src/builtins.rs
+++ b/crates/sema-mcp/src/builtins.rs
@@ -164,24 +164,37 @@ fn connect_http(config_json: &serde_json::Value) -> Result<Value, SemaError> {
 
     let mut client = block_on(McpClient::connect_http(McpHttpConfig {
         url: url.to_string(),
-        headers,
+        headers: headers.clone(),
     }))
     .map_err(|err| SemaError::eval(format!("mcp/connect: {err}")))?;
 
     if let Err(err) = block_on(client.initialize()) {
-        // A `401` means the server requires OAuth; run the login flow, attach the
-        // token, and retry. Any other error is fatal.
-        let Some(challenge) = client.http_challenge() else {
+        if let Some(challenge) = client.http_challenge() {
+            // A `401` means the server requires OAuth; run the login flow, attach
+            // the token, and retry.
+            let token = obtain_access_token(url, &challenge, preconfigured_client_id.as_deref())?;
+            client.set_bearer_token(&token);
+            if let Err(err) = block_on(client.initialize()) {
+                let _ = block_on(client.close());
+                return Err(SemaError::eval(format!(
+                    "mcp/connect: handshake failed after authorization: {err}"
+                )));
+            }
+        } else if matches!(client.http_last_status(), Some(404) | Some(405)) {
+            // The Streamable-HTTP POST was rejected — fall back to the deprecated
+            // 2024-11-05 HTTP+SSE transport (POST→4xx→GET-`endpoint`).
+            let _ = block_on(client.close());
+            let mut legacy = block_on(McpClient::connect_legacy_sse(McpHttpConfig {
+                url: url.to_string(),
+                headers,
+            }))
+            .map_err(|e| SemaError::eval(format!("mcp/connect: {e}")))?;
+            block_on(legacy.initialize())
+                .map_err(|e| SemaError::eval(format!("mcp/connect (legacy SSE): {e}")))?;
+            return register_connection(legacy);
+        } else {
             let _ = block_on(client.close());
             return Err(SemaError::eval(format!("mcp/connect: {err}")));
-        };
-        let token = obtain_access_token(url, &challenge, preconfigured_client_id.as_deref())?;
-        client.set_bearer_token(&token);
-        if let Err(err) = block_on(client.initialize()) {
-            let _ = block_on(client.close());
-            return Err(SemaError::eval(format!(
-                "mcp/connect: handshake failed after authorization: {err}"
-            )));
         }
     }
     register_connection(client)

--- a/crates/sema-mcp/src/builtins.rs
+++ b/crates/sema-mcp/src/builtins.rs
@@ -39,6 +39,9 @@ static HANDLE_COUNTER: AtomicU64 = AtomicU64::new(1);
 
 struct McpConnection {
     client: McpClient,
+    /// Stable server identity (url, or `stdio\0command args`) used to key the
+    /// cassette so tool calls record/replay deterministically across runs.
+    identity: String,
 }
 
 fn block_on<F: Future>(future: F) -> F::Output {
@@ -76,9 +79,9 @@ fn gate(sandbox: &Sandbox, cap: Caps) -> Result<(), SemaError> {
 }
 
 /// Register a live connection under a fresh opaque handle and return the handle.
-fn register_connection(client: McpClient) -> Result<Value, SemaError> {
+fn register_connection(client: McpClient, identity: String) -> Result<Value, SemaError> {
     let handle = next_handle();
-    let connection = Rc::new(RefCell::new(McpConnection { client }));
+    let connection = Rc::new(RefCell::new(McpConnection { client, identity }));
     CONNECTIONS.with(|connections| {
         connections.borrow_mut().insert(handle.clone(), connection);
     });
@@ -123,6 +126,7 @@ fn connect_stdio(config_json: &serde_json::Value) -> Result<Value, SemaError> {
         .and_then(|value| value.as_str())
         .map(std::path::PathBuf::from);
 
+    let identity = format!("stdio\0{command}\0{}", args_vec.join(" "));
     let mut client = block_on(McpClient::connect(McpClientConfig {
         command: command.to_string(),
         args: args_vec,
@@ -134,7 +138,7 @@ fn connect_stdio(config_json: &serde_json::Value) -> Result<Value, SemaError> {
         let _ = block_on(client.close());
         return Err(SemaError::eval(format!("mcp/connect: {err}")));
     }
-    register_connection(client)
+    register_connection(client, identity)
 }
 
 /// Connect to a remote Streamable-HTTP MCP server (`:url` + optional
@@ -199,7 +203,7 @@ fn connect_http(config_json: &serde_json::Value) -> Result<Value, SemaError> {
             return Err(SemaError::eval(format!("mcp/connect: {err}")));
         }
     }
-    register_connection(client)
+    register_connection(client, url.to_string())
 }
 
 /// Connect over the deprecated 2024-11-05 HTTP+SSE transport. `headers` carries
@@ -213,7 +217,7 @@ fn connect_legacy(url: &str, headers: HashMap<String, String>) -> Result<Value, 
     .map_err(|e| SemaError::eval(format!("mcp/connect: {e}")))?;
     block_on(legacy.initialize())
         .map_err(|e| SemaError::eval(format!("mcp/connect (legacy SSE): {e}")))?;
-    register_connection(legacy)
+    register_connection(legacy, url.to_string())
 }
 
 /// Run (or reuse) the OAuth login for a remote server that answered `401`, and
@@ -289,13 +293,58 @@ fn lookup_connection(handle: &str) -> Result<Rc<RefCell<McpConnection>>, SemaErr
     })
 }
 
+/// Cassette key for one MCP `tools/call`: a hash of the server identity + tool +
+/// (canonical) arguments. Stable across runs so record/replay correlate.
+fn cassette_key(identity: &str, tool: &str, args: &serde_json::Value) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(b"mcp-call\0");
+    hasher.update(identity.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(tool.as_bytes());
+    hasher.update(b"\0");
+    // serde_json serializes object keys sorted (BTreeMap) → deterministic.
+    hasher.update(serde_json::to_string(args).unwrap_or_default().as_bytes());
+    format!("mcp-{:x}", hasher.finalize())
+}
+
+/// Invoke a tool, routing through the cassette when one is active: a replay hit
+/// returns the recorded result without touching the network; otherwise the real
+/// call runs and its result is recorded.
 fn call_tool_via_connection(
     handle: &str,
     tool_name: &str,
     arguments_json: serde_json::Value,
 ) -> Result<serde_json::Value, SemaError> {
     let connection = lookup_connection(handle)?;
+    let key = cassette_key(&connection.borrow().identity, tool_name, &arguments_json);
 
+    match sema_core::mcp_cassette_decide(&key) {
+        Some(sema_core::McpCassetteDecision::Replay(recorded)) => return Ok(recorded),
+        Some(sema_core::McpCassetteDecision::Miss) => {
+            return Err(SemaError::eval(
+                "mcp/call: no cassette recording for this call (replay miss)".to_string(),
+            )
+            .with_hint(
+                "re-record the tape with SEMA_LLM_CASSETTE_MODE=record, or the call arguments \
+                 drifted from what was recorded",
+            ));
+        }
+        // Record mode or no cassette → perform the real call, then record it.
+        _ => {}
+    }
+
+    let result = call_tool_real(&connection, tool_name, arguments_json)?;
+    sema_core::mcp_cassette_record(&key, &result);
+    Ok(result)
+}
+
+/// The real (network) tool call, with one mid-session re-auth retry.
+fn call_tool_real(
+    connection: &Rc<RefCell<McpConnection>>,
+    tool_name: &str,
+    arguments_json: serde_json::Value,
+) -> Result<serde_json::Value, SemaError> {
     let first = {
         let mut conn = connection.borrow_mut();
         block_on(conn.client.call_tool(tool_name, arguments_json.clone()))

--- a/crates/sema-mcp/src/builtins.rs
+++ b/crates/sema-mcp/src/builtins.rs
@@ -144,7 +144,7 @@ fn connect_http(config_json: &serde_json::Value) -> Result<Value, SemaError> {
         .get("url")
         .and_then(|value| value.as_str())
         .ok_or_else(|| SemaError::eval("mcp/connect requires a :url entry for http transport"))?;
-    let headers = config_json
+    let mut headers = config_json
         .get("headers")
         .and_then(|value| value.as_object())
         .map(|object| {
@@ -171,33 +171,49 @@ fn connect_http(config_json: &serde_json::Value) -> Result<Value, SemaError> {
     if let Err(err) = block_on(client.initialize()) {
         if let Some(challenge) = client.http_challenge() {
             // A `401` means the server requires OAuth; run the login flow, attach
-            // the token, and retry.
+            // the token, and retry. Some authenticated servers (e.g. Asana) gate
+            // *all* requests behind auth and only reveal that they actually speak
+            // the legacy HTTP+SSE transport once authorized — so a `404`/`405` on
+            // the authenticated Streamable POST means "retry over legacy SSE with
+            // the token attached", not a hard failure.
             let token = obtain_access_token(url, &challenge, preconfigured_client_id.as_deref())?;
+            headers.insert("Authorization".to_string(), format!("Bearer {token}"));
             client.set_bearer_token(&token);
-            if let Err(err) = block_on(client.initialize()) {
+            if let Err(err2) = block_on(client.initialize()) {
+                let status = client.http_last_status();
                 let _ = block_on(client.close());
+                if matches!(status, Some(404) | Some(405)) {
+                    return connect_legacy(url, headers);
+                }
                 return Err(SemaError::eval(format!(
-                    "mcp/connect: handshake failed after authorization: {err}"
+                    "mcp/connect: handshake failed after authorization: {err2}"
                 )));
             }
         } else if matches!(client.http_last_status(), Some(404) | Some(405)) {
-            // The Streamable-HTTP POST was rejected — fall back to the deprecated
-            // 2024-11-05 HTTP+SSE transport (POST→4xx→GET-`endpoint`).
+            // Unauthenticated server that only speaks the deprecated 2024-11-05
+            // HTTP+SSE transport (POST→4xx→GET-`endpoint`).
             let _ = block_on(client.close());
-            let mut legacy = block_on(McpClient::connect_legacy_sse(McpHttpConfig {
-                url: url.to_string(),
-                headers,
-            }))
-            .map_err(|e| SemaError::eval(format!("mcp/connect: {e}")))?;
-            block_on(legacy.initialize())
-                .map_err(|e| SemaError::eval(format!("mcp/connect (legacy SSE): {e}")))?;
-            return register_connection(legacy);
+            return connect_legacy(url, headers);
         } else {
             let _ = block_on(client.close());
             return Err(SemaError::eval(format!("mcp/connect: {err}")));
         }
     }
     register_connection(client)
+}
+
+/// Connect over the deprecated 2024-11-05 HTTP+SSE transport. `headers` carries
+/// any bearer token obtained during the OAuth flow, so authenticated legacy
+/// servers (e.g. Asana) work.
+fn connect_legacy(url: &str, headers: HashMap<String, String>) -> Result<Value, SemaError> {
+    let mut legacy = block_on(McpClient::connect_legacy_sse(McpHttpConfig {
+        url: url.to_string(),
+        headers,
+    }))
+    .map_err(|e| SemaError::eval(format!("mcp/connect: {e}")))?;
+    block_on(legacy.initialize())
+        .map_err(|e| SemaError::eval(format!("mcp/connect (legacy SSE): {e}")))?;
+    register_connection(legacy)
 }
 
 /// Run (or reuse) the OAuth login for a remote server that answered `401`, and

--- a/crates/sema-mcp/src/builtins.rs
+++ b/crates/sema-mcp/src/builtins.rs
@@ -155,16 +155,73 @@ fn connect_http(config_json: &serde_json::Value) -> Result<Value, SemaError> {
         })
         .unwrap_or_default();
 
+    // A user-configured pre-registered client id: `:auth {:client-id "…"}`.
+    let preconfigured_client_id = config_json
+        .get("auth")
+        .and_then(|auth| auth.get("client-id"))
+        .and_then(|value| value.as_str())
+        .map(str::to_string);
+
     let mut client = block_on(McpClient::connect_http(McpHttpConfig {
         url: url.to_string(),
         headers,
     }))
     .map_err(|err| SemaError::eval(format!("mcp/connect: {err}")))?;
+
     if let Err(err) = block_on(client.initialize()) {
-        let _ = block_on(client.close());
-        return Err(SemaError::eval(format!("mcp/connect: {err}")));
+        // A `401` means the server requires OAuth; run the login flow, attach the
+        // token, and retry. Any other error is fatal.
+        let Some(challenge) = client.http_challenge() else {
+            let _ = block_on(client.close());
+            return Err(SemaError::eval(format!("mcp/connect: {err}")));
+        };
+        let token = obtain_access_token(url, &challenge, preconfigured_client_id.as_deref())?;
+        client.set_bearer_token(&token);
+        if let Err(err) = block_on(client.initialize()) {
+            let _ = block_on(client.close());
+            return Err(SemaError::eval(format!(
+                "mcp/connect: handshake failed after authorization: {err}"
+            )));
+        }
     }
     register_connection(client)
+}
+
+/// Run (or reuse) the OAuth login for a remote server that answered `401`, and
+/// return an access token. Uses the default credential store (keychain or file)
+/// and a real loopback + system-browser flow.
+fn obtain_access_token(
+    url: &str,
+    challenge_header: &str,
+    preconfigured_client_id: Option<&str>,
+) -> Result<String, SemaError> {
+    use crate::oauth::{discovery, login, loopback, store};
+
+    let challenge = discovery::parse_www_authenticate(challenge_header);
+    let http = reqwest::Client::new();
+    let credential_store = store::default_store();
+    let driver = loopback::LoopbackDriver::new(std::time::Duration::from_secs(300))
+        .map_err(|e| SemaError::eval(format!("mcp/connect: {e}")))?;
+
+    let config = login::LoginConfig {
+        mcp_url: url,
+        resource_metadata_url: challenge.resource_metadata.as_deref(),
+        requested_scope: challenge.scope.as_deref(),
+        preconfigured_client_id,
+    };
+
+    block_on(login::ensure_access_token(
+        &http,
+        credential_store.as_ref(),
+        &config,
+        &driver,
+    ))
+    .map_err(|e| {
+        SemaError::eval(format!("mcp/connect: OAuth login failed: {e}")).with_hint(
+            "a browser should have opened to complete login; or pass a token via \
+             :headers {\"Authorization\" \"Bearer …\"}",
+        )
+    })
 }
 
 fn config_to_json(args: &[Value]) -> Result<serde_json::Value, SemaError> {

--- a/crates/sema-mcp/src/builtins.rs
+++ b/crates/sema-mcp/src/builtins.rs
@@ -24,7 +24,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use sema_core::{check_arity, Caps, Env, NativeFn, Sandbox, SemaError, ToolDefinition, Value};
 use tokio::runtime::Runtime;
 
-use crate::client::{McpClient, McpClientConfig};
+use crate::client::{McpClient, McpClientConfig, McpHttpConfig};
 
 thread_local! {
     // Keep MCP connections in a thread-local map so each Sema evaluator can own its own
@@ -67,25 +67,104 @@ fn register_fn(env: &Env, name: &str, f: impl Fn(&[Value]) -> Result<Value, Sema
     env.set_str(name, Value::native_fn(NativeFn::simple(name, f)));
 }
 
-/// Register a builtin that is refused unless `cap` is granted (mirrors
-/// `sema_stdlib`'s `register_fn_gated`). Unrestricted sandboxes skip the check.
-fn register_fn_gated(
-    env: &Env,
-    sandbox: &Sandbox,
-    cap: Caps,
-    name: &str,
-    f: impl Fn(&[Value]) -> Result<Value, SemaError> + 'static,
-) {
-    if sandbox.is_unrestricted() {
-        register_fn(env, name, f);
-    } else {
-        let sandbox = sandbox.clone();
-        let fn_name = name.to_string();
-        register_fn(env, name, move |args| {
-            sandbox.check(cap, &fn_name)?;
-            f(args)
-        });
+/// Refuse a `mcp/connect` unless `cap` is granted. Unrestricted sandboxes pass.
+fn gate(sandbox: &Sandbox, cap: Caps) -> Result<(), SemaError> {
+    if !sandbox.is_unrestricted() {
+        sandbox.check(cap, "mcp/connect")?;
     }
+    Ok(())
+}
+
+/// Register a live connection under a fresh opaque handle and return the handle.
+fn register_connection(client: McpClient) -> Result<Value, SemaError> {
+    let handle = next_handle();
+    let connection = Rc::new(RefCell::new(McpConnection { client }));
+    CONNECTIONS.with(|connections| {
+        connections.borrow_mut().insert(handle.clone(), connection);
+    });
+    Ok(Value::string(&handle))
+}
+
+/// Connect to a stdio MCP server (`:command` + optional `:args`/`:env`/`:cwd`),
+/// run the handshake, and register the connection.
+fn connect_stdio(config_json: &serde_json::Value) -> Result<Value, SemaError> {
+    let command = config_json
+        .get("command")
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| {
+            SemaError::eval("mcp/connect requires a :command (stdio) or :url (http) entry")
+                .with_hint(
+                    "stdio: {:command \"python3\" :args [\"-c\" \"script\"]}; \
+                     http: {:url \"https://…/mcp\"}",
+                )
+        })?;
+    let args_vec = config_json
+        .get("args")
+        .and_then(|value| value.as_array())
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(|value| value.as_str().map(str::to_string))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let env_map = config_json
+        .get("env")
+        .and_then(|value| value.as_object())
+        .map(|object| {
+            object
+                .iter()
+                .filter_map(|(key, value)| value.as_str().map(|s| (key.to_string(), s.to_string())))
+                .collect::<HashMap<_, _>>()
+        })
+        .unwrap_or_default();
+    let cwd = config_json
+        .get("cwd")
+        .and_then(|value| value.as_str())
+        .map(std::path::PathBuf::from);
+
+    let mut client = block_on(McpClient::connect(McpClientConfig {
+        command: command.to_string(),
+        args: args_vec,
+        env: (!env_map.is_empty()).then_some(env_map),
+        cwd,
+    }))
+    .map_err(|err| SemaError::eval(format!("mcp/connect: {err}")))?;
+    if let Err(err) = block_on(client.initialize()) {
+        let _ = block_on(client.close());
+        return Err(SemaError::eval(format!("mcp/connect: {err}")));
+    }
+    register_connection(client)
+}
+
+/// Connect to a remote Streamable-HTTP MCP server (`:url` + optional
+/// `:headers`), run the handshake, and register the connection.
+fn connect_http(config_json: &serde_json::Value) -> Result<Value, SemaError> {
+    let url = config_json
+        .get("url")
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| SemaError::eval("mcp/connect requires a :url entry for http transport"))?;
+    let headers = config_json
+        .get("headers")
+        .and_then(|value| value.as_object())
+        .map(|object| {
+            object
+                .iter()
+                .filter_map(|(key, value)| value.as_str().map(|s| (key.to_string(), s.to_string())))
+                .collect::<HashMap<_, _>>()
+        })
+        .unwrap_or_default();
+
+    let mut client = block_on(McpClient::connect_http(McpHttpConfig {
+        url: url.to_string(),
+        headers,
+    }))
+    .map_err(|err| SemaError::eval(format!("mcp/connect: {err}")))?;
+    if let Err(err) = block_on(client.initialize()) {
+        let _ = block_on(client.close());
+        return Err(SemaError::eval(format!("mcp/connect: {err}")));
+    }
+    register_connection(client)
 }
 
 fn config_to_json(args: &[Value]) -> Result<serde_json::Value, SemaError> {
@@ -213,61 +292,23 @@ fn schema_to_params(schema: &serde_json::Value) -> (Value, Vec<String>) {
 }
 
 pub fn register_mcp_builtins(env: &Env, sandbox: &Sandbox) {
-    register_fn_gated(env, sandbox, Caps::PROCESS, "mcp/connect", |args| {
-        let config_json = config_to_json(args)?;
-        let command = config_json
-            .get("command")
-            .and_then(|value| value.as_str())
-            .ok_or_else(|| {
-                SemaError::eval("mcp/connect requires a :command entry for stdio transport")
-                    .with_hint("use {:command \"python3\" :args [\"-c\" \"script\"]}")
-            })?;
-        let args_vec = config_json
-            .get("args")
-            .and_then(|value| value.as_array())
-            .map(|values| {
-                values
-                    .iter()
-                    .filter_map(|value| value.as_str().map(str::to_string))
-                    .collect::<Vec<_>>()
-            })
-            .unwrap_or_default();
-        let env_map = config_json
-            .get("env")
-            .and_then(|value| value.as_object())
-            .map(|object| {
-                object
-                    .iter()
-                    .filter_map(|(key, value)| {
-                        value.as_str().map(|s| (key.to_string(), s.to_string()))
-                    })
-                    .collect::<HashMap<_, _>>()
-            })
-            .unwrap_or_default();
-        let cwd = config_json
-            .get("cwd")
-            .and_then(|value| value.as_str())
-            .map(std::path::PathBuf::from);
-
-        let mut client = block_on(McpClient::connect(McpClientConfig {
-            command: command.to_string(),
-            args: args_vec,
-            env: (!env_map.is_empty()).then_some(env_map),
-            cwd,
-        }))
-        .map_err(|err| SemaError::eval(format!("mcp/connect: {err}")))?;
-        if let Err(err) = block_on(client.initialize()) {
-            let _ = block_on(client.close());
-            return Err(SemaError::eval(format!("mcp/connect: {err}")));
-        }
-
-        let handle = next_handle();
-        let connection = Rc::new(RefCell::new(McpConnection { client }));
-        CONNECTIONS.with(|connections| {
-            connections.borrow_mut().insert(handle.clone(), connection);
+    // `mcp/connect` picks its transport from the config map at runtime, so the
+    // capability it needs is not fixed: a `:url` server is network I/O
+    // (`NETWORK`), a `:command` server spawns a process (`PROCESS`). Gate inside
+    // the handler rather than via a single fixed-capability wrapper.
+    {
+        let sandbox = sandbox.clone();
+        register_fn(env, "mcp/connect", move |args| {
+            let config_json = config_to_json(args)?;
+            if config_json.get("url").and_then(|v| v.as_str()).is_some() {
+                gate(&sandbox, Caps::NETWORK)?;
+                connect_http(&config_json)
+            } else {
+                gate(&sandbox, Caps::PROCESS)?;
+                connect_stdio(&config_json)
+            }
         });
-        Ok(Value::string(&handle))
-    });
+    }
 
     register_fn(env, "mcp/tools", |args| {
         check_arity!(args, "mcp/tools", 1);

--- a/crates/sema-mcp/src/builtins.rs
+++ b/crates/sema-mcp/src/builtins.rs
@@ -329,7 +329,9 @@ fn call_tool_via_connection(
     };
 
     let mut conn = connection.borrow_mut();
-    conn.client.set_bearer_token(&token);
+    // Streamable HTTP swaps the header; legacy SSE reconnects its stream.
+    block_on(conn.client.reauthorize_bearer(&token))
+        .map_err(|e| SemaError::eval(format!("mcp/call: {e}")))?;
     block_on(conn.client.call_tool(tool_name, arguments_json))
         .map_err(|err| SemaError::eval(format!("mcp/call: {err}")))
 }

--- a/crates/sema-mcp/src/builtins.rs
+++ b/crates/sema-mcp/src/builtins.rs
@@ -295,9 +295,66 @@ fn call_tool_via_connection(
     arguments_json: serde_json::Value,
 ) -> Result<serde_json::Value, SemaError> {
     let connection = lookup_connection(handle)?;
-    let mut connection = connection.borrow_mut();
-    block_on(connection.client.call_tool(tool_name, arguments_json))
+
+    let first = {
+        let mut conn = connection.borrow_mut();
+        block_on(conn.client.call_tool(tool_name, arguments_json.clone()))
+    };
+    let err = match first {
+        Ok(value) => return Ok(value),
+        Err(err) => err,
+    };
+
+    // A mid-session `401` (token expired) or `403 insufficient_scope` (needs
+    // step-up) on a remote HTTP server means "re-authorize and retry once".
+    let (status, challenge, url) = {
+        let conn = connection.borrow();
+        (
+            conn.client.http_last_status(),
+            conn.client.http_challenge(),
+            conn.client.http_url(),
+        )
+    };
+    if !matches!(status, Some(401) | Some(403)) {
+        return Err(SemaError::eval(format!("mcp/call: {err}")));
+    }
+    let Some(url) = url else {
+        return Err(SemaError::eval(format!("mcp/call: {err}")));
+    };
+    let token = match reauthorize(&url, status, challenge.as_deref()) {
+        Ok(Some(token)) => token,
+        // Not an auth challenge we handle, or re-auth failed — surface the
+        // original error.
+        _ => return Err(SemaError::eval(format!("mcp/call: {err}"))),
+    };
+
+    let mut conn = connection.borrow_mut();
+    conn.client.set_bearer_token(&token);
+    block_on(conn.client.call_tool(tool_name, arguments_json))
         .map_err(|err| SemaError::eval(format!("mcp/call: {err}")))
+}
+
+/// React to a mid-session auth challenge (refresh on `401`, step-up re-scope on
+/// `403 insufficient_scope`) and return a fresh access token to retry with.
+fn reauthorize(
+    url: &str,
+    status: Option<u16>,
+    challenge: Option<&str>,
+) -> Result<Option<String>, SemaError> {
+    let http = reqwest::Client::new();
+    let store = crate::oauth::store::default_store();
+    let driver = crate::oauth::loopback::LoopbackDriver::new(std::time::Duration::from_secs(300))
+        .map_err(|e| SemaError::eval(format!("mcp/call: {e}")))?;
+    block_on(crate::oauth::login::reauth_on_challenge(
+        &http,
+        store.as_ref(),
+        url,
+        status,
+        challenge,
+        None,
+        &driver,
+    ))
+    .map_err(|e| SemaError::eval(format!("mcp/call: re-authorization failed: {e}")))
 }
 
 /// Concatenate the `text` blocks of a `tools/call` result, if any.

--- a/crates/sema-mcp/src/builtins.rs
+++ b/crates/sema-mcp/src/builtins.rs
@@ -1,0 +1,374 @@
+//! Sema-facing MCP *client* builtins: connect to an external MCP server and
+//! consume its tools from Sema code.
+//!
+//! Two layers, matching `docs/plans/2026-06-21-mcp-client-spike.md`:
+//!
+//! - **Layer 1 (protocol primitive):** `mcp/connect`, `mcp/tools`, `mcp/call`,
+//!   `mcp/close` — a transport + RPC client, agent-agnostic, like `http/*`.
+//! - **Layer 2 (agent adapter):** `mcp/tools->sema` turns an MCP server's tools
+//!   into the exact value shape `deftool` produces, so `defagent` consumes them
+//!   with zero agent-loop changes.
+//!
+//! `mcp/connect` spawns a child process, so it is gated on the `PROCESS`
+//! capability — a sandbox that denies process spawning cannot open MCP
+//! connections, and the other builtins only ever act on a handle that connect
+//! already vetted. MCP tools then run with the *server's* authority, not Sema's
+//! sandbox: connecting to an untrusted server is like running untrusted code.
+
+use std::cell::RefCell;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::future::Future;
+use std::rc::Rc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use sema_core::{check_arity, Caps, Env, NativeFn, Sandbox, SemaError, ToolDefinition, Value};
+use tokio::runtime::Runtime;
+
+use crate::client::{McpClient, McpClientConfig};
+
+thread_local! {
+    // Keep MCP connections in a thread-local map so each Sema evaluator can own its own
+    // client state without introducing cross-thread sharing.
+    static CONNECTIONS: RefCell<HashMap<String, Rc<RefCell<McpConnection>>>> =
+        RefCell::new(HashMap::new());
+    // Reuse one current-thread Tokio runtime for all MCP builtins in this evaluator context.
+    static TOKIO_RT: RefCell<Option<Runtime>> = const { RefCell::new(None) };
+}
+
+static HANDLE_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+struct McpConnection {
+    client: McpClient,
+}
+
+fn block_on<F: Future>(future: F) -> F::Output {
+    TOKIO_RT.with(|runtime| {
+        let mut runtime = runtime.borrow_mut();
+        if runtime.is_none() {
+            *runtime = Some(
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("failed to create Tokio runtime for MCP builtin"),
+            );
+        }
+        runtime
+            .as_mut()
+            .expect("initialized Tokio runtime for MCP builtin")
+            .block_on(future)
+    })
+}
+
+fn next_handle() -> String {
+    format!("mcp-{}", HANDLE_COUNTER.fetch_add(1, Ordering::SeqCst))
+}
+
+fn register_fn(env: &Env, name: &str, f: impl Fn(&[Value]) -> Result<Value, SemaError> + 'static) {
+    env.set_str(name, Value::native_fn(NativeFn::simple(name, f)));
+}
+
+/// Register a builtin that is refused unless `cap` is granted (mirrors
+/// `sema_stdlib`'s `register_fn_gated`). Unrestricted sandboxes skip the check.
+fn register_fn_gated(
+    env: &Env,
+    sandbox: &Sandbox,
+    cap: Caps,
+    name: &str,
+    f: impl Fn(&[Value]) -> Result<Value, SemaError> + 'static,
+) {
+    if sandbox.is_unrestricted() {
+        register_fn(env, name, f);
+    } else {
+        let sandbox = sandbox.clone();
+        let fn_name = name.to_string();
+        register_fn(env, name, move |args| {
+            sandbox.check(cap, &fn_name)?;
+            f(args)
+        });
+    }
+}
+
+fn config_to_json(args: &[Value]) -> Result<serde_json::Value, SemaError> {
+    check_arity!(args, "mcp/connect", 1);
+    let config = &args[0];
+    let map = config.as_map_ref().ok_or_else(|| {
+        SemaError::type_error("map", config.type_name())
+            .with_hint("mcp/connect expects a single config map; use {:command ...}")
+    })?;
+    let mut config_json = serde_json::Map::new();
+    for (key, value) in map.iter() {
+        let key_str = key
+            .as_keyword()
+            .or_else(|| key.as_str().map(|s| s.to_string()))
+            .unwrap_or_else(|| key.to_string());
+        config_json.insert(key_str, sema_core::value_to_json_lossy(value));
+    }
+    Ok(serde_json::Value::Object(config_json))
+}
+
+fn require_handle<'a>(args: &'a [Value], fn_name: &str) -> Result<&'a str, SemaError> {
+    args[0].as_str().ok_or_else(|| {
+        SemaError::type_error("string", args[0].type_name()).with_hint(format!(
+            "{fn_name} expects the opaque handle returned by mcp/connect"
+        ))
+    })
+}
+
+fn lookup_connection(handle: &str) -> Result<Rc<RefCell<McpConnection>>, SemaError> {
+    CONNECTIONS.with(|connections| {
+        connections.borrow().get(handle).cloned().ok_or_else(|| {
+            SemaError::eval(format!(
+                "mcp connection {handle} is not registered; it may have been closed"
+            ))
+        })
+    })
+}
+
+fn call_tool_via_connection(
+    handle: &str,
+    tool_name: &str,
+    arguments_json: serde_json::Value,
+) -> Result<serde_json::Value, SemaError> {
+    let connection = lookup_connection(handle)?;
+    let mut connection = connection.borrow_mut();
+    block_on(connection.client.call_tool(tool_name, arguments_json))
+        .map_err(|err| SemaError::eval(format!("mcp/call: {err}")))
+}
+
+/// Concatenate the `text` blocks of a `tools/call` result, if any.
+fn result_text(result: &serde_json::Value) -> Option<String> {
+    let content = result.get("content")?.as_array()?;
+    let parts: Vec<String> = content
+        .iter()
+        .filter(|item| item.get("type").and_then(|t| t.as_str()) == Some("text"))
+        .filter_map(|item| {
+            item.get("text")
+                .and_then(|t| t.as_str())
+                .map(str::to_string)
+        })
+        .collect();
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join("\n"))
+    }
+}
+
+/// Normalize a `tools/call` result into a Sema value: plain text collapses to a
+/// string (what an agent wants to feed back to the model), anything richer
+/// (images, resources, `structuredContent`) is handed over as the full map.
+fn result_to_value(result: &serde_json::Value) -> Value {
+    match result_text(result) {
+        Some(text) => Value::string(&text),
+        None => sema_core::json_to_value(result),
+    }
+}
+
+fn result_is_error(result: &serde_json::Value) -> bool {
+    result
+        .get("isError")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+}
+
+/// Invert an MCP `inputSchema` (JSON Schema) into the `{param-name -> spec}` map
+/// that `deftool` produces, so the agent loop's schema handling treats an MCP
+/// tool exactly like a local one. Returns the params map plus the parameter
+/// names in the map's own key order — the order the agent loop passes them to a
+/// native handler, which the handler needs to rebuild the arguments object.
+fn schema_to_params(schema: &serde_json::Value) -> (Value, Vec<String>) {
+    let required: HashSet<&str> = schema
+        .get("required")
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
+        .unwrap_or_default();
+
+    let mut params: BTreeMap<Value, Value> = BTreeMap::new();
+    if let Some(props) = schema.get("properties").and_then(|v| v.as_object()) {
+        for (name, spec) in props {
+            let mut entry: BTreeMap<Value, Value> = BTreeMap::new();
+            let ty = spec
+                .get("type")
+                .and_then(|v| v.as_str())
+                .unwrap_or("string");
+            entry.insert(Value::keyword("type"), Value::keyword(ty));
+            if let Some(desc) = spec.get("description").and_then(|v| v.as_str()) {
+                entry.insert(Value::keyword("description"), Value::string(desc));
+            }
+            if let Some(enum_vals) = spec.get("enum").and_then(|v| v.as_array()) {
+                let items: Vec<Value> = enum_vals.iter().map(sema_core::json_to_value).collect();
+                entry.insert(Value::keyword("enum"), Value::list(items));
+            }
+            // deftool marks a param optional with `:optional #t`; anything not in
+            // the schema's `required` list is optional.
+            if !required.contains(name.as_str()) {
+                entry.insert(Value::keyword("optional"), Value::bool(true));
+            }
+            params.insert(Value::keyword(name), Value::map(entry));
+        }
+    }
+
+    let ordered: Vec<String> = params.keys().filter_map(|k| k.as_keyword()).collect();
+    (Value::map(params), ordered)
+}
+
+pub fn register_mcp_builtins(env: &Env, sandbox: &Sandbox) {
+    register_fn_gated(env, sandbox, Caps::PROCESS, "mcp/connect", |args| {
+        let config_json = config_to_json(args)?;
+        let command = config_json
+            .get("command")
+            .and_then(|value| value.as_str())
+            .ok_or_else(|| {
+                SemaError::eval("mcp/connect requires a :command entry for stdio transport")
+                    .with_hint("use {:command \"python3\" :args [\"-c\" \"script\"]}")
+            })?;
+        let args_vec = config_json
+            .get("args")
+            .and_then(|value| value.as_array())
+            .map(|values| {
+                values
+                    .iter()
+                    .filter_map(|value| value.as_str().map(str::to_string))
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        let env_map = config_json
+            .get("env")
+            .and_then(|value| value.as_object())
+            .map(|object| {
+                object
+                    .iter()
+                    .filter_map(|(key, value)| {
+                        value.as_str().map(|s| (key.to_string(), s.to_string()))
+                    })
+                    .collect::<HashMap<_, _>>()
+            })
+            .unwrap_or_default();
+        let cwd = config_json
+            .get("cwd")
+            .and_then(|value| value.as_str())
+            .map(std::path::PathBuf::from);
+
+        let mut client = block_on(McpClient::connect(McpClientConfig {
+            command: command.to_string(),
+            args: args_vec,
+            env: (!env_map.is_empty()).then_some(env_map),
+            cwd,
+        }))
+        .map_err(|err| SemaError::eval(format!("mcp/connect: {err}")))?;
+        if let Err(err) = block_on(client.initialize()) {
+            let _ = block_on(client.close());
+            return Err(SemaError::eval(format!("mcp/connect: {err}")));
+        }
+
+        let handle = next_handle();
+        let connection = Rc::new(RefCell::new(McpConnection { client }));
+        CONNECTIONS.with(|connections| {
+            connections.borrow_mut().insert(handle.clone(), connection);
+        });
+        Ok(Value::string(&handle))
+    });
+
+    register_fn(env, "mcp/tools", |args| {
+        check_arity!(args, "mcp/tools", 1);
+        let handle = require_handle(args, "mcp/tools")?;
+        let connection = lookup_connection(handle)?;
+        let mut connection = connection.borrow_mut();
+        let tools = block_on(connection.client.list_tools())
+            .map_err(|err| SemaError::eval(format!("mcp/tools: {err}")))?;
+        let items = tools
+            .into_iter()
+            .map(|tool| {
+                let mut entry = BTreeMap::new();
+                entry.insert(Value::keyword("name"), Value::string(&tool.name));
+                entry.insert(
+                    Value::keyword("description"),
+                    Value::string(&tool.description),
+                );
+                entry.insert(
+                    Value::keyword("input-schema"),
+                    sema_core::json_to_value(&tool.input_schema),
+                );
+                Value::map(entry)
+            })
+            .collect();
+        Ok(Value::list(items))
+    });
+
+    register_fn(env, "mcp/tools->sema", |args| {
+        check_arity!(args, "mcp/tools->sema", 1);
+        let handle = require_handle(args, "mcp/tools->sema")?;
+        let connection = lookup_connection(handle)?;
+        let mut connection = connection.borrow_mut();
+        let tools = block_on(connection.client.list_tools())
+            .map_err(|err| SemaError::eval(format!("mcp/tools->sema: {err}")))?;
+
+        let mut items = Vec::new();
+        for tool in tools {
+            let (parameters, ordered) = schema_to_params(&tool.input_schema);
+            let tool_name = tool.name.clone();
+            let connection_handle = handle.to_string();
+            let handler_name = format!("mcp/{tool_name}");
+            let handler = Value::native_fn(NativeFn::simple(&handler_name, move |args| {
+                // The agent loop passes arguments positionally in `ordered` order
+                // (see `json_args_to_sema`); rebuild the named arguments object,
+                // dropping the ones the model left unset (nil).
+                let mut arguments = serde_json::Map::new();
+                for (name, value) in ordered.iter().zip(args.iter()) {
+                    if value.is_nil() {
+                        continue;
+                    }
+                    arguments.insert(name.clone(), sema_core::value_to_json_lossy(value));
+                }
+                let result = call_tool_via_connection(
+                    &connection_handle,
+                    &tool_name,
+                    serde_json::Value::Object(arguments),
+                )?;
+                // Surface a tool-reported failure as an error so the agent loop
+                // feeds it back to the model instead of treating it as success.
+                if result_is_error(&result) {
+                    let detail = result_text(&result).unwrap_or_else(|| result.to_string());
+                    return Err(SemaError::eval(format!(
+                        "mcp tool `{tool_name}` returned an error: {detail}"
+                    )));
+                }
+                Ok(result_to_value(&result))
+            }));
+            items.push(Value::tool_def(ToolDefinition {
+                name: tool.name,
+                description: tool.description,
+                parameters,
+                handler,
+            }));
+        }
+        Ok(Value::list(items))
+    });
+
+    register_fn(env, "mcp/call", |args| {
+        check_arity!(args, "mcp/call", 3);
+        let handle = require_handle(args, "mcp/call")?;
+        let tool_name = args[1].as_str().ok_or_else(|| {
+            SemaError::type_error("string", args[1].type_name())
+                .with_hint("mcp/call expects the tool name as a string")
+        })?;
+        let arguments_json = sema_core::value_to_json_lossy(&args[2]);
+        let result = call_tool_via_connection(handle, tool_name, arguments_json)?;
+        Ok(result_to_value(&result))
+    });
+
+    register_fn(env, "mcp/close", |args| {
+        check_arity!(args, "mcp/close", 1);
+        let handle = require_handle(args, "mcp/close")?;
+        let connection = CONNECTIONS.with(|connections| connections.borrow_mut().remove(handle));
+        let Some(connection) = connection else {
+            return Err(SemaError::eval(format!(
+                "mcp connection {handle} is not registered; it may have already been closed"
+            )));
+        };
+        let mut connection = connection.borrow_mut();
+        block_on(connection.client.close())
+            .map_err(|err| SemaError::eval(format!("mcp/close: {err}")))?;
+        Ok(Value::nil())
+    });
+}

--- a/crates/sema-mcp/src/builtins.rs
+++ b/crates/sema-mcp/src/builtins.rs
@@ -124,16 +124,26 @@ fn connect_stdio(config_json: &serde_json::Value) -> Result<Value, SemaError> {
                      http: {:url \"https://…/mcp\"}",
                 )
         })?;
-    let args_vec = config_json
-        .get("args")
-        .and_then(|value| value.as_array())
-        .map(|values| {
-            values
-                .iter()
-                .filter_map(|value| value.as_str().map(str::to_string))
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
+    // Every `:args` element must be a string — silently dropping a non-string
+    // would launch the server with a different command line than the user wrote.
+    let args_vec: Vec<String> = match config_json.get("args") {
+        None => Vec::new(),
+        Some(serde_json::Value::Array(values)) => {
+            let mut out = Vec::with_capacity(values.len());
+            for value in values {
+                let s = value.as_str().ok_or_else(|| {
+                    SemaError::eval("mcp/connect: every :args element must be a string")
+                })?;
+                out.push(s.to_string());
+            }
+            out
+        }
+        Some(_) => {
+            return Err(SemaError::eval(
+                "mcp/connect: :args must be a list of strings",
+            ));
+        }
+    };
     let env_map = config_json
         .get("env")
         .and_then(|value| value.as_object())

--- a/crates/sema-mcp/src/client.rs
+++ b/crates/sema-mcp/src/client.rs
@@ -86,6 +86,7 @@ pub struct McpClient {
 enum Transport {
     Stdio(StdioTransport),
     Http(HttpTransport),
+    LegacySse(LegacySseTransport),
 }
 
 impl McpClient {
@@ -106,6 +107,18 @@ impl McpClient {
         let transport = HttpTransport::new(config)?;
         Ok(Self {
             transport: Transport::Http(transport),
+            next_id: 1,
+            timeout: DEFAULT_REQUEST_TIMEOUT,
+        })
+    }
+
+    /// Connect over the deprecated 2024-11-05 HTTP+SSE transport: open the SSE
+    /// stream and read the `endpoint` event that names the POST URL. Does not
+    /// perform the handshake — call [`McpClient::initialize`] next.
+    pub async fn connect_legacy_sse(config: McpHttpConfig) -> Result<Self, String> {
+        let transport = LegacySseTransport::connect(config, DEFAULT_REQUEST_TIMEOUT).await?;
+        Ok(Self {
+            transport: Transport::LegacySse(transport),
             next_id: 1,
             timeout: DEFAULT_REQUEST_TIMEOUT,
         })
@@ -162,6 +175,7 @@ impl McpClient {
         match &mut self.transport {
             Transport::Stdio(t) => t.shutdown().await,
             Transport::Http(t) => t.shutdown().await,
+            Transport::LegacySse(_) => Ok(()),
         }
     }
 
@@ -170,7 +184,16 @@ impl McpClient {
     pub fn http_challenge(&self) -> Option<String> {
         match &self.transport {
             Transport::Http(t) => t.last_challenge.clone(),
-            Transport::Stdio(_) => None,
+            _ => None,
+        }
+    }
+
+    /// The HTTP status code of the most recent request, when it was not a
+    /// success (HTTP transport only) — used to detect a legacy-SSE server.
+    pub fn http_last_status(&self) -> Option<u16> {
+        match &self.transport {
+            Transport::Http(t) => t.last_status,
+            _ => None,
         }
     }
 
@@ -185,7 +208,7 @@ impl McpClient {
     pub fn http_url(&self) -> Option<String> {
         match &self.transport {
             Transport::Http(t) => Some(t.url.clone()),
-            Transport::Stdio(_) => None,
+            _ => None,
         }
     }
 
@@ -203,6 +226,7 @@ impl McpClient {
         match &mut self.transport {
             Transport::Stdio(t) => t.request(id, method, params, self.timeout).await,
             Transport::Http(t) => t.request(id, method, params, self.timeout).await,
+            Transport::LegacySse(t) => t.request(id, method, params, self.timeout).await,
         }
     }
 
@@ -214,6 +238,7 @@ impl McpClient {
         match &mut self.transport {
             Transport::Stdio(t) => t.notify(method, params).await,
             Transport::Http(t) => t.notify(method, params).await,
+            Transport::LegacySse(t) => t.notify(method, params).await,
         }
     }
 }
@@ -431,6 +456,9 @@ struct HttpTransport {
     /// The `WWW-Authenticate` header from the most recent `401`, so the auth
     /// layer can discover where to log in and retry.
     last_challenge: Option<String>,
+    /// The status code of the most recent non-success response, so a caller can
+    /// detect a `404`/`405` that signals a legacy (HTTP+SSE) server.
+    last_status: Option<u16>,
 }
 
 impl HttpTransport {
@@ -448,6 +476,7 @@ impl HttpTransport {
             session_id: None,
             protocol_version: None,
             last_challenge: None,
+            last_status: None,
         })
     }
 
@@ -512,6 +541,7 @@ impl HttpTransport {
         self.capture_session(&response);
 
         let status = response.status();
+        self.last_status = (!status.is_success()).then_some(status.as_u16());
         if status.as_u16() == 404 {
             // Session was terminated/expired; per the spec the client must start
             // a fresh session with a new `initialize`. Surface it so the caller
@@ -669,6 +699,166 @@ impl HttpTransport {
             }
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Legacy HTTP+SSE transport (deprecated 2024-11-05 two-endpoint shape)
+// ---------------------------------------------------------------------------
+
+/// The deprecated two-endpoint transport: a long-lived `GET` SSE stream carries
+/// every server→client message, and the client `POST`s requests to a separate
+/// URL announced by the stream's first `endpoint` event. Kept for backwards
+/// compatibility with `2024-11-05` servers.
+struct LegacySseTransport {
+    client: reqwest::Client,
+    base_url: String,
+    post_url: String,
+    headers: HashMap<String, String>,
+    #[allow(clippy::type_complexity)]
+    stream: std::pin::Pin<Box<dyn futures::Stream<Item = Result<Vec<u8>, reqwest::Error>> + Send>>,
+    buffer: String,
+}
+
+impl LegacySseTransport {
+    async fn connect(config: McpHttpConfig, timeout: Duration) -> Result<Self, String> {
+        if config.url.is_empty() {
+            return Err("mcp/connect (legacy sse) requires a non-empty :url".to_string());
+        }
+        let client = reqwest::Client::builder()
+            .build()
+            .map_err(|err| format!("failed to build HTTP client: {err}"))?;
+        let mut builder = client
+            .get(&config.url)
+            .header("Accept", "text/event-stream");
+        for (key, value) in &config.headers {
+            builder = builder.header(key.as_str(), value.as_str());
+        }
+        let response = tokio::time::timeout(timeout, builder.send())
+            .await
+            .map_err(|_| "legacy SSE connect timed out".to_string())?
+            .map_err(|err| format!("legacy SSE GET failed: {err}"))?;
+        if !response.status().is_success() {
+            return Err(format!(
+                "legacy SSE GET returned HTTP {}",
+                response.status().as_u16()
+            ));
+        }
+        let stream = response.bytes_stream().map(|r| r.map(|b| b.to_vec()));
+        let mut transport = Self {
+            client,
+            base_url: config.url.clone(),
+            post_url: String::new(),
+            headers: config.headers,
+            stream: Box::pin(stream),
+            buffer: String::new(),
+        };
+
+        // The first meaningful event names the POST endpoint.
+        loop {
+            let (event, data) = transport.next_event(timeout).await?;
+            if event == "endpoint" {
+                transport.post_url = resolve_url(&transport.base_url, data.trim())?;
+                return Ok(transport);
+            }
+        }
+    }
+
+    async fn request(
+        &mut self,
+        id: i64,
+        method: &str,
+        params: Option<serde_json::Value>,
+        timeout: Duration,
+    ) -> Result<serde_json::Value, String> {
+        let body = encode_request(id, method, params)?;
+        self.post(body).await?;
+        // The response arrives on the shared SSE stream; skip unrelated messages.
+        loop {
+            let (_event, data) = self.next_event(timeout).await?;
+            if let Ok(response) = serde_json::from_str::<JsonRpcResponse>(&data) {
+                if response_matches_id(&response, id) {
+                    return extract_result(response);
+                }
+            }
+        }
+    }
+
+    async fn notify(
+        &mut self,
+        method: &str,
+        params: Option<serde_json::Value>,
+    ) -> Result<(), String> {
+        let body = serde_json::to_string(&notification_value(method, params))
+            .map_err(|err| format!("failed to encode MCP notification: {err}"))?;
+        self.post(body).await
+    }
+
+    async fn post(&self, body: String) -> Result<(), String> {
+        let mut builder = self
+            .client
+            .post(&self.post_url)
+            .header("Content-Type", "application/json")
+            .body(body);
+        for (key, value) in &self.headers {
+            builder = builder.header(key.as_str(), value.as_str());
+        }
+        let response = builder
+            .send()
+            .await
+            .map_err(|err| format!("legacy SSE POST failed: {err}"))?;
+        if !response.status().is_success() {
+            return Err(format!(
+                "legacy SSE POST returned HTTP {}",
+                response.status().as_u16()
+            ));
+        }
+        Ok(())
+    }
+
+    /// Read the SSE stream until one complete event, returning its `event` type
+    /// (defaulting to `message`) and joined `data`.
+    async fn next_event(&mut self, timeout: Duration) -> Result<(String, String), String> {
+        let mut event_type = String::new();
+        let mut data_lines: Vec<String> = Vec::new();
+        loop {
+            while let Some(newline) = self.buffer.find('\n') {
+                let line = self.buffer[..newline].trim_end_matches('\r').to_string();
+                self.buffer.drain(..=newline);
+                if line.is_empty() {
+                    if !data_lines.is_empty() || !event_type.is_empty() {
+                        let event = if event_type.is_empty() {
+                            "message".to_string()
+                        } else {
+                            std::mem::take(&mut event_type)
+                        };
+                        return Ok((event, data_lines.join("\n")));
+                    }
+                    continue;
+                }
+                if let Some(rest) = line.strip_prefix("event:") {
+                    event_type = rest.trim().to_string();
+                } else if let Some(rest) = line.strip_prefix("data:") {
+                    data_lines.push(rest.strip_prefix(' ').unwrap_or(rest).to_string());
+                }
+            }
+            let next = tokio::time::timeout(timeout, self.stream.next())
+                .await
+                .map_err(|_| "legacy SSE stream stalled".to_string())?;
+            match next {
+                Some(Ok(chunk)) => self.buffer.push_str(&String::from_utf8_lossy(&chunk)),
+                Some(Err(err)) => return Err(format!("legacy SSE read error: {err}")),
+                None => return Err("legacy SSE stream closed unexpectedly".to_string()),
+            }
+        }
+    }
+}
+
+/// Resolve a possibly-relative `endpoint` value against the SSE URL's origin.
+fn resolve_url(base: &str, target: &str) -> Result<String, String> {
+    let base = url::Url::parse(base).map_err(|e| format!("invalid legacy SSE base URL: {e}"))?;
+    base.join(target)
+        .map(|u| u.to_string())
+        .map_err(|e| format!("could not resolve legacy endpoint `{target}`: {e}"))
 }
 
 /// Interpret an accumulated SSE event's `data` as a JSON-RPC message. Returns

--- a/crates/sema-mcp/src/client.rs
+++ b/crates/sema-mcp/src/client.rs
@@ -165,6 +165,30 @@ impl McpClient {
         }
     }
 
+    /// The `WWW-Authenticate` challenge from the most recent HTTP `401`, if the
+    /// last request was refused for lack of authorization (HTTP transport only).
+    pub fn http_challenge(&self) -> Option<String> {
+        match &self.transport {
+            Transport::Http(t) => t.last_challenge.clone(),
+            Transport::Stdio(_) => None,
+        }
+    }
+
+    /// Attach a bearer token to all subsequent HTTP requests (no-op for stdio).
+    pub fn set_bearer_token(&mut self, token: &str) {
+        if let Transport::Http(t) = &mut self.transport {
+            t.set_bearer(token);
+        }
+    }
+
+    /// The remote server URL (HTTP transport only), for keying the token store.
+    pub fn http_url(&self) -> Option<String> {
+        match &self.transport {
+            Transport::Http(t) => Some(t.url.clone()),
+            Transport::Stdio(_) => None,
+        }
+    }
+
     /// Send a request under a fresh JSON-RPC id and return its result.
     async fn request(
         &mut self,
@@ -404,6 +428,9 @@ struct HttpTransport {
     /// The protocol version negotiated in `InitializeResult`, sent back as the
     /// `MCP-Protocol-Version` header on all following requests.
     protocol_version: Option<String>,
+    /// The `WWW-Authenticate` header from the most recent `401`, so the auth
+    /// layer can discover where to log in and retry.
+    last_challenge: Option<String>,
 }
 
 impl HttpTransport {
@@ -420,7 +447,14 @@ impl HttpTransport {
             headers: config.headers,
             session_id: None,
             protocol_version: None,
+            last_challenge: None,
         })
+    }
+
+    /// Attach a bearer token to every subsequent request.
+    fn set_bearer(&mut self, token: &str) {
+        self.headers
+            .insert("Authorization".to_string(), format!("Bearer {token}"));
     }
 
     /// Attach the session / protocol-version / caller headers that apply once
@@ -484,6 +518,18 @@ impl HttpTransport {
             // reconnects rather than silently retrying against a dead session.
             return Err(format!(
                 "MCP session expired (HTTP 404) on `{method}`; reconnect required"
+            ));
+        }
+        if status.as_u16() == 401 {
+            // Record the challenge so the auth layer can discover the
+            // authorization server, obtain a token, and retry.
+            self.last_challenge = response
+                .headers()
+                .get("www-authenticate")
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_string);
+            return Err(format!(
+                "MCP server requires authorization (HTTP 401) on `{method}`"
             ));
         }
         if !status.is_success() {

--- a/crates/sema-mcp/src/client.rs
+++ b/crates/sema-mcp/src/client.rs
@@ -1,33 +1,39 @@
-//! Minimal MCP *client* over the stdio transport.
+//! MCP *client* transports.
 //!
 //! Sema is primarily an MCP *server* (see `server.rs`); this is the reverse
-//! direction — spawn an external MCP server as a child process and speak
-//! JSON-RPC to it over stdin/stdout so Sema code can consume its tools. It
-//! mirrors `server.rs`'s line-delimited JSON-RPC loop, inverted.
+//! direction — connect to an external MCP server and speak JSON-RPC to it so
+//! Sema code can consume its tools. Two transports live behind one [`McpClient`]:
 //!
-//! Scope is deliberately the stdio transport only (spike milestone M1/M2). The
-//! Streamable-HTTP transport and the OAuth 2.1 login flow for authenticated
-//! remote servers are separate, larger milestones (see
-//! `docs/plans/2026-06-21-mcp-client-spike.md`). For stdio there is no auth
-//! handshake: a server that needs a credential reads it from the environment
-//! Sema hands the child, so pass tokens through the `:env` map on `mcp/connect`.
+//! - **stdio** ([`McpClient::connect`]): spawn the server as a child process and
+//!   exchange line-delimited JSON-RPC over stdin/stdout. No auth handshake — a
+//!   server that needs a credential reads it from the environment Sema hands the
+//!   child, so pass tokens through the `:env` map on `mcp/connect`.
+//! - **Streamable HTTP** ([`McpClient::connect_http`]): POST each JSON-RPC message
+//!   to a remote server's single MCP endpoint; the response is either a single
+//!   JSON object or an SSE stream. Session continuity rides the `Mcp-Session-Id`
+//!   header and the negotiated `MCP-Protocol-Version` header. A caller-supplied
+//!   `:headers` map carries a static bearer token; the full OAuth 2.1 login flow
+//!   for servers that require it is a later milestone (see
+//!   `docs/plans/2026-06-21-mcp-client-spike.md`).
 
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Duration;
 
+use futures::StreamExt;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 
 use crate::protocol::{JsonRpcRequest, JsonRpcResponse, Tool};
 
-/// How long to wait for a single response line before giving up, so a wedged
-/// server surfaces as an error instead of hanging the calling Sema thread
-/// forever. Generous because a `tools/call` can legitimately be slow.
+/// How long to wait for a single response before giving up, so a wedged server
+/// surfaces as an error instead of hanging the calling Sema thread forever.
+/// Generous because a `tools/call` can legitimately be slow.
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
 
-/// The MCP protocol revision this client advertises during `initialize`.
-const PROTOCOL_VERSION: &str = "2024-11-05";
+/// The MCP protocol revision this client advertises during `initialize` — the
+/// latest revision we implement (a client SHOULD offer the newest it supports).
+const PROTOCOL_VERSION: &str = "2025-11-25";
 
 /// Spec for launching a stdio MCP server. `env` entries are added to (not
 /// replacing) the inherited environment — the natural place to pass a token a
@@ -51,54 +57,55 @@ impl McpClientConfig {
     }
 }
 
-/// A live connection to a stdio MCP server. Dropping it kills the child.
+/// Spec for connecting to a remote MCP server over Streamable HTTP. `headers`
+/// are attached to every request — the place to pass a caller-supplied bearer
+/// token (`{"Authorization" "Bearer …"}`) until the OAuth flow lands.
+#[derive(Debug, Clone, Default)]
+pub struct McpHttpConfig {
+    pub url: String,
+    pub headers: HashMap<String, String>,
+}
+
+impl McpHttpConfig {
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            headers: HashMap::new(),
+        }
+    }
+}
+
+/// A live connection to an MCP server. Dropping it terminates the underlying
+/// stdio child (HTTP sessions are best-effort DELETE'd via [`McpClient::close`]).
 pub struct McpClient {
-    child: Child,
-    stdin: ChildStdin,
-    reader: BufReader<ChildStdout>,
+    transport: Transport,
     next_id: i64,
     timeout: Duration,
 }
 
+enum Transport {
+    Stdio(StdioTransport),
+    Http(HttpTransport),
+}
+
 impl McpClient {
-    /// Spawn the server process and wire up its stdio. Does not perform the
+    /// Spawn a stdio server and wire up its stdio. Does not perform the
     /// `initialize` handshake — call [`McpClient::initialize`] next.
     pub async fn connect(config: McpClientConfig) -> Result<Self, String> {
-        let mut command = Command::new(&config.command);
-        command.args(&config.args);
-        if let Some(env) = config.env {
-            for (key, value) in env {
-                command.env(key, value);
-            }
-        }
-        if let Some(cwd) = config.cwd {
-            command.current_dir(cwd);
-        }
-        command.stdin(std::process::Stdio::piped());
-        command.stdout(std::process::Stdio::piped());
-        // Let the server's stderr flow to ours so its diagnostics are visible.
-        command.stderr(std::process::Stdio::inherit());
-
-        let mut child = command.spawn().map_err(|err| {
-            format!(
-                "failed to spawn MCP server process `{}`: {err}",
-                config.command
-            )
-        })?;
-
-        let stdin = child
-            .stdin
-            .take()
-            .ok_or_else(|| "failed to open MCP server stdin".to_string())?;
-        let stdout = child
-            .stdout
-            .take()
-            .ok_or_else(|| "failed to open MCP server stdout".to_string())?;
-
+        let transport = StdioTransport::spawn(config).await?;
         Ok(Self {
-            child,
-            stdin,
-            reader: BufReader::new(stdout),
+            transport: Transport::Stdio(transport),
+            next_id: 1,
+            timeout: DEFAULT_REQUEST_TIMEOUT,
+        })
+    }
+
+    /// Prepare a Streamable-HTTP connection. Does not perform the `initialize`
+    /// handshake — call [`McpClient::initialize`] next.
+    pub async fn connect_http(config: McpHttpConfig) -> Result<Self, String> {
+        let transport = HttpTransport::new(config)?;
+        Ok(Self {
+            transport: Transport::Http(transport),
             next_id: 1,
             timeout: DEFAULT_REQUEST_TIMEOUT,
         })
@@ -152,17 +159,13 @@ impl McpClient {
     }
 
     pub async fn close(&mut self) -> Result<(), String> {
-        self.child
-            .start_kill()
-            .map_err(|err| format!("failed to terminate MCP server process: {err}"))?;
-        self.child
-            .wait()
-            .await
-            .map_err(|err| format!("failed to wait for MCP server process: {err}"))?;
-        Ok(())
+        match &mut self.transport {
+            Transport::Stdio(t) => t.shutdown().await,
+            Transport::Http(t) => t.shutdown().await,
+        }
     }
 
-    /// Send a request and return its result, correlating on the JSON-RPC id.
+    /// Send a request under a fresh JSON-RPC id and return its result.
     async fn request(
         &mut self,
         method: &str,
@@ -173,34 +176,154 @@ impl McpClient {
             .next_id
             .checked_add(1)
             .ok_or_else(|| "MCP request ID overflow".to_string())?;
-
-        let request = JsonRpcRequest {
-            jsonrpc: "2.0".to_string(),
-            method: method.to_string(),
-            params,
-            id: Some(serde_json::Value::Number(serde_json::Number::from(id))),
-        };
-        let line = serde_json::to_string(&request)
-            .map_err(|err| format!("failed to encode MCP request: {err}"))?;
-        self.write_line(&line).await?;
-        self.read_response(id, method).await
+        match &mut self.transport {
+            Transport::Stdio(t) => t.request(id, method, params, self.timeout).await,
+            Transport::Http(t) => t.request(id, method, params, self.timeout).await,
+        }
     }
 
-    /// Send a JSON-RPC notification (no id, no reply). Notifications must omit
-    /// the `id` field entirely, so this is built inline rather than reusing the
-    /// request struct (whose `id` always serializes).
     async fn notify(
         &mut self,
         method: &str,
         params: Option<serde_json::Value>,
     ) -> Result<(), String> {
-        let mut message = serde_json::json!({ "jsonrpc": "2.0", "method": method });
-        if let Some(params) = params {
-            message["params"] = params;
+        match &mut self.transport {
+            Transport::Stdio(t) => t.notify(method, params).await,
+            Transport::Http(t) => t.notify(method, params).await,
         }
-        let line = serde_json::to_string(&message)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// JSON-RPC helpers shared by both transports
+// ---------------------------------------------------------------------------
+
+fn response_matches_id(response: &JsonRpcResponse, expected_id: i64) -> bool {
+    response
+        .id
+        .as_ref()
+        .and_then(|id| id.as_i64())
+        .map(|id| id == expected_id)
+        .unwrap_or(false)
+}
+
+/// Turn a correlated JSON-RPC response into its `result`, mapping an RPC-level
+/// error into an `Err`.
+fn extract_result(response: JsonRpcResponse) -> Result<serde_json::Value, String> {
+    if let Some(error) = response.error {
+        return Err(format!("MCP RPC error {}: {}", error.code, error.message));
+    }
+    response
+        .result
+        .ok_or_else(|| "MCP response did not include a result".to_string())
+}
+
+fn encode_request(
+    id: i64,
+    method: &str,
+    params: Option<serde_json::Value>,
+) -> Result<String, String> {
+    let request = JsonRpcRequest {
+        jsonrpc: "2.0".to_string(),
+        method: method.to_string(),
+        params,
+        id: Some(serde_json::Value::Number(serde_json::Number::from(id))),
+    };
+    serde_json::to_string(&request).map_err(|err| format!("failed to encode MCP request: {err}"))
+}
+
+/// Build a JSON-RPC notification (no `id`). Notifications must omit the `id`
+/// field entirely, so this is built by hand rather than reusing the request
+/// struct (whose `id` always serializes).
+fn notification_value(method: &str, params: Option<serde_json::Value>) -> serde_json::Value {
+    let mut message = serde_json::json!({ "jsonrpc": "2.0", "method": method });
+    if let Some(params) = params {
+        message["params"] = params;
+    }
+    message
+}
+
+// ---------------------------------------------------------------------------
+// stdio transport
+// ---------------------------------------------------------------------------
+
+struct StdioTransport {
+    child: Child,
+    stdin: ChildStdin,
+    reader: BufReader<ChildStdout>,
+}
+
+impl StdioTransport {
+    async fn spawn(config: McpClientConfig) -> Result<Self, String> {
+        let mut command = Command::new(&config.command);
+        command.args(&config.args);
+        if let Some(env) = config.env {
+            for (key, value) in env {
+                command.env(key, value);
+            }
+        }
+        if let Some(cwd) = config.cwd {
+            command.current_dir(cwd);
+        }
+        command.stdin(std::process::Stdio::piped());
+        command.stdout(std::process::Stdio::piped());
+        // Let the server's stderr flow to ours so its diagnostics are visible.
+        command.stderr(std::process::Stdio::inherit());
+
+        let mut child = command.spawn().map_err(|err| {
+            format!(
+                "failed to spawn MCP server process `{}`: {err}",
+                config.command
+            )
+        })?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| "failed to open MCP server stdin".to_string())?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| "failed to open MCP server stdout".to_string())?;
+
+        Ok(Self {
+            child,
+            stdin,
+            reader: BufReader::new(stdout),
+        })
+    }
+
+    async fn request(
+        &mut self,
+        id: i64,
+        method: &str,
+        params: Option<serde_json::Value>,
+        timeout: Duration,
+    ) -> Result<serde_json::Value, String> {
+        let line = encode_request(id, method, params)?;
+        self.write_line(&line).await?;
+        self.read_response(id, method, timeout).await
+    }
+
+    async fn notify(
+        &mut self,
+        method: &str,
+        params: Option<serde_json::Value>,
+    ) -> Result<(), String> {
+        let line = serde_json::to_string(&notification_value(method, params))
             .map_err(|err| format!("failed to encode MCP notification: {err}"))?;
         self.write_line(&line).await
+    }
+
+    async fn shutdown(&mut self) -> Result<(), String> {
+        self.child
+            .start_kill()
+            .map_err(|err| format!("failed to terminate MCP server process: {err}"))?;
+        self.child
+            .wait()
+            .await
+            .map_err(|err| format!("failed to wait for MCP server process: {err}"))?;
+        Ok(())
     }
 
     async fn write_line(&mut self, line: &str) -> Result<(), String> {
@@ -222,15 +345,16 @@ impl McpClient {
         &mut self,
         expected_id: i64,
         method: &str,
+        timeout: Duration,
     ) -> Result<serde_json::Value, String> {
         loop {
             let mut line = String::new();
-            let read = tokio::time::timeout(self.timeout, self.reader.read_line(&mut line))
+            let read = tokio::time::timeout(timeout, self.reader.read_line(&mut line))
                 .await
                 .map_err(|_| {
                     format!(
                         "MCP server did not respond to `{method}` within {}s",
-                        self.timeout.as_secs()
+                        timeout.as_secs()
                     )
                 })?
                 .map_err(|err| format!("failed to read MCP response: {err}"))?;
@@ -250,30 +374,274 @@ impl McpClient {
                 Err(_) => continue,
             };
 
-            let matches_id = response
-                .id
-                .as_ref()
-                .and_then(|id| id.as_i64())
-                .map(|id| id == expected_id)
-                .unwrap_or(false);
-            if !matches_id {
+            if !response_matches_id(&response, expected_id) {
                 continue;
             }
-
-            if let Some(error) = response.error {
-                return Err(format!("MCP RPC error {}: {}", error.code, error.message));
-            }
-            return response
-                .result
-                .ok_or_else(|| "MCP response did not include a result".to_string());
+            return extract_result(response);
         }
     }
 }
 
-impl Drop for McpClient {
+impl Drop for StdioTransport {
     fn drop(&mut self) {
         // Best-effort: don't leak the child if the handle is dropped without
         // an explicit `close`.
         let _ = self.child.start_kill();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Streamable HTTP transport
+// ---------------------------------------------------------------------------
+
+struct HttpTransport {
+    client: reqwest::Client,
+    url: String,
+    headers: HashMap<String, String>,
+    /// Assigned by the server on the `initialize` response; echoed on every
+    /// subsequent request so the server can associate them with the session.
+    session_id: Option<String>,
+    /// The protocol version negotiated in `InitializeResult`, sent back as the
+    /// `MCP-Protocol-Version` header on all following requests.
+    protocol_version: Option<String>,
+}
+
+impl HttpTransport {
+    fn new(config: McpHttpConfig) -> Result<Self, String> {
+        if config.url.is_empty() {
+            return Err("mcp/connect (http) requires a non-empty :url".to_string());
+        }
+        let client = reqwest::Client::builder()
+            .build()
+            .map_err(|err| format!("failed to build HTTP client: {err}"))?;
+        Ok(Self {
+            client,
+            url: config.url,
+            headers: config.headers,
+            session_id: None,
+            protocol_version: None,
+        })
+    }
+
+    /// Attach the session / protocol-version / caller headers that apply once
+    /// they are known. On the first `initialize` request `session_id` and
+    /// `protocol_version` are still `None`, so nothing session-specific is sent.
+    fn apply_headers(&self, mut builder: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        if let Some(session_id) = &self.session_id {
+            builder = builder.header("Mcp-Session-Id", session_id);
+        }
+        if let Some(version) = &self.protocol_version {
+            builder = builder.header("MCP-Protocol-Version", version);
+        }
+        for (key, value) in &self.headers {
+            builder = builder.header(key.as_str(), value.as_str());
+        }
+        builder
+    }
+
+    fn capture_session(&mut self, response: &reqwest::Response) {
+        if let Some(value) = response
+            .headers()
+            .get("mcp-session-id")
+            .and_then(|v| v.to_str().ok())
+        {
+            self.session_id = Some(value.to_string());
+        }
+    }
+
+    async fn request(
+        &mut self,
+        id: i64,
+        method: &str,
+        params: Option<serde_json::Value>,
+        timeout: Duration,
+    ) -> Result<serde_json::Value, String> {
+        let body = encode_request(id, method, params)?;
+        let builder = self
+            .client
+            .post(&self.url)
+            .header("Accept", "application/json, text/event-stream")
+            .header("Content-Type", "application/json")
+            .body(body);
+        let builder = self.apply_headers(builder);
+
+        let response = tokio::time::timeout(timeout, builder.send())
+            .await
+            .map_err(|_| {
+                format!(
+                    "MCP server did not respond to `{method}` within {}s",
+                    timeout.as_secs()
+                )
+            })?
+            .map_err(|err| format!("failed to send MCP request: {err}"))?;
+
+        self.capture_session(&response);
+
+        let status = response.status();
+        if status.as_u16() == 404 {
+            // Session was terminated/expired; per the spec the client must start
+            // a fresh session with a new `initialize`. Surface it so the caller
+            // reconnects rather than silently retrying against a dead session.
+            return Err(format!(
+                "MCP session expired (HTTP 404) on `{method}`; reconnect required"
+            ));
+        }
+        if !status.is_success() {
+            let detail = response.text().await.unwrap_or_default();
+            return Err(format!(
+                "MCP server returned HTTP {} on `{method}`: {}",
+                status.as_u16(),
+                detail.trim()
+            ));
+        }
+
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+
+        let result = if content_type.contains("text/event-stream") {
+            self.read_sse_response(response, id, timeout).await?
+        } else {
+            let text = response
+                .text()
+                .await
+                .map_err(|err| format!("failed to read MCP response body: {err}"))?;
+            let response: JsonRpcResponse = serde_json::from_str(text.trim())
+                .map_err(|err| format!("failed to decode MCP response: {err}"))?;
+            if !response_matches_id(&response, id) {
+                return Err(format!(
+                    "MCP response id mismatch on `{method}` (expected {id})"
+                ));
+            }
+            extract_result(response)?
+        };
+
+        // Record the negotiated protocol version so it rides subsequent requests.
+        if method == "initialize" {
+            if let Some(version) = result.get("protocolVersion").and_then(|v| v.as_str()) {
+                self.protocol_version = Some(version.to_string());
+            }
+        }
+        Ok(result)
+    }
+
+    async fn notify(
+        &mut self,
+        method: &str,
+        params: Option<serde_json::Value>,
+    ) -> Result<(), String> {
+        let body = serde_json::to_string(&notification_value(method, params))
+            .map_err(|err| format!("failed to encode MCP notification: {err}"))?;
+        let builder = self
+            .client
+            .post(&self.url)
+            .header("Accept", "application/json, text/event-stream")
+            .header("Content-Type", "application/json")
+            .body(body);
+        let builder = self.apply_headers(builder);
+
+        let response = builder
+            .send()
+            .await
+            .map_err(|err| format!("failed to send MCP notification: {err}"))?;
+        self.capture_session(&response);
+        let status = response.status();
+        // A notification is accepted with `202 Accepted` (no body); tolerate any
+        // 2xx in case a server answers `200`.
+        if !status.is_success() {
+            let detail = response.text().await.unwrap_or_default();
+            return Err(format!(
+                "MCP server rejected notification `{method}`: HTTP {} {}",
+                status.as_u16(),
+                detail.trim()
+            ));
+        }
+        Ok(())
+    }
+
+    async fn shutdown(&mut self) -> Result<(), String> {
+        // Best-effort session teardown: DELETE with the session id. A server that
+        // doesn't allow client-driven termination answers `405`, which is fine.
+        if self.session_id.is_some() {
+            let builder = self.client.delete(&self.url);
+            let builder = self.apply_headers(builder);
+            let _ = builder.send().await;
+        }
+        Ok(())
+    }
+
+    /// Read the POST-initiated SSE stream until the JSON-RPC response correlated
+    /// to `expected_id` arrives, ignoring any interleaved server→client
+    /// notifications/requests the server may emit before it.
+    async fn read_sse_response(
+        &mut self,
+        response: reqwest::Response,
+        expected_id: i64,
+        timeout: Duration,
+    ) -> Result<serde_json::Value, String> {
+        let mut stream = response.bytes_stream();
+        let mut buffer = String::new();
+        let mut data_lines: Vec<String> = Vec::new();
+
+        loop {
+            let next = tokio::time::timeout(timeout, stream.next())
+                .await
+                .map_err(|_| {
+                    format!("MCP SSE stream stalled waiting for response id {expected_id}")
+                })?;
+            let Some(chunk) = next else {
+                // Stream ended. Give any un-terminated trailing event one last
+                // chance before declaring the response missing.
+                if let Some(result) = try_take_sse_event(&mut data_lines, expected_id)? {
+                    return Ok(result);
+                }
+                return Err("MCP SSE stream ended before the response arrived".to_string());
+            };
+            let chunk = chunk.map_err(|err| format!("failed to read MCP SSE stream: {err}"))?;
+            buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+            while let Some(newline) = buffer.find('\n') {
+                let line = buffer[..newline].trim_end_matches('\r').to_string();
+                buffer.drain(..=newline);
+
+                if line.is_empty() {
+                    // Event boundary — try to correlate the accumulated data.
+                    if let Some(result) = try_take_sse_event(&mut data_lines, expected_id)? {
+                        return Ok(result);
+                    }
+                    continue;
+                }
+                if let Some(rest) = line.strip_prefix("data:") {
+                    // A `data:` value may have a single leading space per the SSE grammar.
+                    data_lines.push(rest.strip_prefix(' ').unwrap_or(rest).to_string());
+                }
+                // `id:` / `event:` / `retry:` / comment lines are ignored for now;
+                // event-id resumption (`Last-Event-ID`) is a later refinement.
+            }
+        }
+    }
+}
+
+/// Interpret an accumulated SSE event's `data` as a JSON-RPC message. Returns
+/// `Ok(Some(result))` when it is the correlated response, `Ok(None)` when it is
+/// an unrelated message to skip, and `Err` for an RPC-level error on our id.
+fn try_take_sse_event(
+    data_lines: &mut Vec<String>,
+    expected_id: i64,
+) -> Result<Option<serde_json::Value>, String> {
+    if data_lines.is_empty() {
+        return Ok(None);
+    }
+    let data = std::mem::take(data_lines).join("\n");
+    match serde_json::from_str::<JsonRpcResponse>(&data) {
+        Ok(response) if response_matches_id(&response, expected_id) => {
+            extract_result(response).map(Some)
+        }
+        // A server->client notification/request, or a response for a different
+        // id — not ours; keep reading.
+        _ => Ok(None),
     }
 }

--- a/crates/sema-mcp/src/client.rs
+++ b/crates/sema-mcp/src/client.rs
@@ -179,21 +179,24 @@ impl McpClient {
         }
     }
 
-    /// The `WWW-Authenticate` challenge from the most recent HTTP `401`, if the
-    /// last request was refused for lack of authorization (HTTP transport only).
+    /// The `WWW-Authenticate` challenge from the most recent HTTP `401`/`403`, if
+    /// the last request was refused for auth (Streamable HTTP or legacy SSE).
     pub fn http_challenge(&self) -> Option<String> {
         match &self.transport {
             Transport::Http(t) => t.last_challenge.clone(),
-            _ => None,
+            Transport::LegacySse(t) => t.last_challenge.clone(),
+            Transport::Stdio(_) => None,
         }
     }
 
-    /// The HTTP status code of the most recent request, when it was not a
-    /// success (HTTP transport only) — used to detect a legacy-SSE server.
+    /// The HTTP status code of the most recent request when it was not a success
+    /// (Streamable HTTP or legacy SSE) — used to detect a legacy server (`404`/
+    /// `405`) or a mid-session auth challenge (`401`/`403`).
     pub fn http_last_status(&self) -> Option<u16> {
         match &self.transport {
             Transport::Http(t) => t.last_status,
-            _ => None,
+            Transport::LegacySse(t) => t.last_status,
+            Transport::Stdio(_) => None,
         }
     }
 
@@ -204,11 +207,41 @@ impl McpClient {
         }
     }
 
-    /// The remote server URL (HTTP transport only), for keying the token store.
+    /// Update the bearer token after a mid-session re-authorization and make the
+    /// connection ready to retry. Streamable HTTP just swaps the header (requests
+    /// are independent); the legacy transport must **reconnect** — its SSE stream
+    /// was opened with the stale token — so it re-opens the stream with the new
+    /// token and re-runs the handshake. No-op for stdio.
+    pub async fn reauthorize_bearer(&mut self, token: &str) -> Result<(), String> {
+        // Capture legacy reconnect params without holding a borrow across the
+        // transport reassignment below.
+        let legacy = match &self.transport {
+            Transport::LegacySse(t) => Some((t.base_url.clone(), t.headers.clone())),
+            _ => None,
+        };
+        match &mut self.transport {
+            Transport::Http(t) => {
+                t.set_bearer(token);
+                return Ok(());
+            }
+            Transport::Stdio(_) => return Ok(()),
+            Transport::LegacySse(_) => {}
+        }
+        let (url, mut headers) = legacy.expect("legacy transport");
+        headers.insert("Authorization".to_string(), format!("Bearer {token}"));
+        let fresh =
+            LegacySseTransport::connect(McpHttpConfig { url, headers }, self.timeout).await?;
+        self.transport = Transport::LegacySse(fresh);
+        self.next_id = 1;
+        self.initialize().await.map(|_| ())
+    }
+
+    /// The remote server URL (HTTP or legacy SSE), for keying the token store.
     pub fn http_url(&self) -> Option<String> {
         match &self.transport {
             Transport::Http(t) => Some(t.url.clone()),
-            _ => None,
+            Transport::LegacySse(t) => Some(t.base_url.clone()),
+            Transport::Stdio(_) => None,
         }
     }
 
@@ -722,6 +755,11 @@ struct LegacySseTransport {
     #[allow(clippy::type_complexity)]
     stream: std::pin::Pin<Box<dyn futures::Stream<Item = Result<Vec<u8>, reqwest::Error>> + Send>>,
     buffer: String,
+    /// Status + `WWW-Authenticate` of the most recent POST failure, so a mid-
+    /// session `401`/`403` on a legacy server can be re-authorized like an HTTP
+    /// one (parity — many servers still run this transport).
+    last_status: Option<u16>,
+    last_challenge: Option<String>,
 }
 
 impl LegacySseTransport {
@@ -756,6 +794,8 @@ impl LegacySseTransport {
             headers: config.headers,
             stream: Box::pin(stream),
             buffer: String::new(),
+            last_status: None,
+            last_challenge: None,
         };
 
         // The first meaningful event names the POST endpoint.
@@ -798,7 +838,7 @@ impl LegacySseTransport {
         self.post(body).await
     }
 
-    async fn post(&self, body: String) -> Result<(), String> {
+    async fn post(&mut self, body: String) -> Result<(), String> {
         let mut builder = self
             .client
             .post(&self.post_url)
@@ -811,11 +851,19 @@ impl LegacySseTransport {
             .send()
             .await
             .map_err(|err| format!("legacy SSE POST failed: {err}"))?;
-        if !response.status().is_success() {
-            return Err(format!(
-                "legacy SSE POST returned HTTP {}",
-                response.status().as_u16()
-            ));
+        let status = response.status();
+        self.last_status = (!status.is_success()).then_some(status.as_u16());
+        self.last_challenge = if status.is_success() {
+            None
+        } else {
+            response
+                .headers()
+                .get("www-authenticate")
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_string)
+        };
+        if !status.is_success() {
+            return Err(format!("legacy SSE POST returned HTTP {}", status.as_u16()));
         }
         Ok(())
     }

--- a/crates/sema-mcp/src/client.rs
+++ b/crates/sema-mcp/src/client.rs
@@ -1,0 +1,279 @@
+//! Minimal MCP *client* over the stdio transport.
+//!
+//! Sema is primarily an MCP *server* (see `server.rs`); this is the reverse
+//! direction — spawn an external MCP server as a child process and speak
+//! JSON-RPC to it over stdin/stdout so Sema code can consume its tools. It
+//! mirrors `server.rs`'s line-delimited JSON-RPC loop, inverted.
+//!
+//! Scope is deliberately the stdio transport only (spike milestone M1/M2). The
+//! Streamable-HTTP transport and the OAuth 2.1 login flow for authenticated
+//! remote servers are separate, larger milestones (see
+//! `docs/plans/2026-06-21-mcp-client-spike.md`). For stdio there is no auth
+//! handshake: a server that needs a credential reads it from the environment
+//! Sema hands the child, so pass tokens through the `:env` map on `mcp/connect`.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+
+use crate::protocol::{JsonRpcRequest, JsonRpcResponse, Tool};
+
+/// How long to wait for a single response line before giving up, so a wedged
+/// server surfaces as an error instead of hanging the calling Sema thread
+/// forever. Generous because a `tools/call` can legitimately be slow.
+const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// The MCP protocol revision this client advertises during `initialize`.
+const PROTOCOL_VERSION: &str = "2024-11-05";
+
+/// Spec for launching a stdio MCP server. `env` entries are added to (not
+/// replacing) the inherited environment — the natural place to pass a token a
+/// server expects (e.g. `GITHUB_TOKEN`).
+#[derive(Debug, Clone, Default)]
+pub struct McpClientConfig {
+    pub command: String,
+    pub args: Vec<String>,
+    pub env: Option<HashMap<String, String>>,
+    pub cwd: Option<PathBuf>,
+}
+
+impl McpClientConfig {
+    pub fn new(command: impl Into<String>) -> Self {
+        Self {
+            command: command.into(),
+            args: Vec::new(),
+            env: None,
+            cwd: None,
+        }
+    }
+}
+
+/// A live connection to a stdio MCP server. Dropping it kills the child.
+pub struct McpClient {
+    child: Child,
+    stdin: ChildStdin,
+    reader: BufReader<ChildStdout>,
+    next_id: i64,
+    timeout: Duration,
+}
+
+impl McpClient {
+    /// Spawn the server process and wire up its stdio. Does not perform the
+    /// `initialize` handshake — call [`McpClient::initialize`] next.
+    pub async fn connect(config: McpClientConfig) -> Result<Self, String> {
+        let mut command = Command::new(&config.command);
+        command.args(&config.args);
+        if let Some(env) = config.env {
+            for (key, value) in env {
+                command.env(key, value);
+            }
+        }
+        if let Some(cwd) = config.cwd {
+            command.current_dir(cwd);
+        }
+        command.stdin(std::process::Stdio::piped());
+        command.stdout(std::process::Stdio::piped());
+        // Let the server's stderr flow to ours so its diagnostics are visible.
+        command.stderr(std::process::Stdio::inherit());
+
+        let mut child = command.spawn().map_err(|err| {
+            format!(
+                "failed to spawn MCP server process `{}`: {err}",
+                config.command
+            )
+        })?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| "failed to open MCP server stdin".to_string())?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| "failed to open MCP server stdout".to_string())?;
+
+        Ok(Self {
+            child,
+            stdin,
+            reader: BufReader::new(stdout),
+            next_id: 1,
+            timeout: DEFAULT_REQUEST_TIMEOUT,
+        })
+    }
+
+    /// Perform the MCP `initialize` handshake and send the mandatory
+    /// `notifications/initialized` follow-up. Per the spec a server need not
+    /// answer any other request until it has received that notification, so
+    /// skipping it (as a naive client would) hangs against conformant servers.
+    pub async fn initialize(&mut self) -> Result<serde_json::Value, String> {
+        let result = self
+            .request(
+                "initialize",
+                Some(serde_json::json!({
+                    "protocolVersion": PROTOCOL_VERSION,
+                    "capabilities": {},
+                    "clientInfo": {
+                        "name": "sema-mcp-client",
+                        "version": env!("CARGO_PKG_VERSION")
+                    }
+                })),
+            )
+            .await?;
+        self.notify("notifications/initialized", None).await?;
+        Ok(result)
+    }
+
+    pub async fn list_tools(&mut self) -> Result<Vec<Tool>, String> {
+        let result = self.request("tools/list", None).await?;
+        let tools = result
+            .get("tools")
+            .ok_or_else(|| "tools/list result did not include a tools array".to_string())?;
+        serde_json::from_value(tools.clone())
+            .map_err(|err| format!("failed to decode tools/list response: {err}"))
+    }
+
+    /// Call a tool and return the raw `tools/call` result object. The result is
+    /// left as untyped JSON on purpose so every content shape a server may emit
+    /// (text, image, resource links, `structuredContent`, …) passes through to
+    /// Sema losslessly rather than being narrowed to a fixed enum.
+    pub async fn call_tool(
+        &mut self,
+        name: &str,
+        arguments: serde_json::Value,
+    ) -> Result<serde_json::Value, String> {
+        self.request(
+            "tools/call",
+            Some(serde_json::json!({ "name": name, "arguments": arguments })),
+        )
+        .await
+    }
+
+    pub async fn close(&mut self) -> Result<(), String> {
+        self.child
+            .start_kill()
+            .map_err(|err| format!("failed to terminate MCP server process: {err}"))?;
+        self.child
+            .wait()
+            .await
+            .map_err(|err| format!("failed to wait for MCP server process: {err}"))?;
+        Ok(())
+    }
+
+    /// Send a request and return its result, correlating on the JSON-RPC id.
+    async fn request(
+        &mut self,
+        method: &str,
+        params: Option<serde_json::Value>,
+    ) -> Result<serde_json::Value, String> {
+        let id = self.next_id;
+        self.next_id = self
+            .next_id
+            .checked_add(1)
+            .ok_or_else(|| "MCP request ID overflow".to_string())?;
+
+        let request = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            method: method.to_string(),
+            params,
+            id: Some(serde_json::Value::Number(serde_json::Number::from(id))),
+        };
+        let line = serde_json::to_string(&request)
+            .map_err(|err| format!("failed to encode MCP request: {err}"))?;
+        self.write_line(&line).await?;
+        self.read_response(id, method).await
+    }
+
+    /// Send a JSON-RPC notification (no id, no reply). Notifications must omit
+    /// the `id` field entirely, so this is built inline rather than reusing the
+    /// request struct (whose `id` always serializes).
+    async fn notify(
+        &mut self,
+        method: &str,
+        params: Option<serde_json::Value>,
+    ) -> Result<(), String> {
+        let mut message = serde_json::json!({ "jsonrpc": "2.0", "method": method });
+        if let Some(params) = params {
+            message["params"] = params;
+        }
+        let line = serde_json::to_string(&message)
+            .map_err(|err| format!("failed to encode MCP notification: {err}"))?;
+        self.write_line(&line).await
+    }
+
+    async fn write_line(&mut self, line: &str) -> Result<(), String> {
+        self.stdin
+            .write_all(format!("{line}\n").as_bytes())
+            .await
+            .map_err(|err| format!("failed to write MCP message: {err}"))?;
+        self.stdin
+            .flush()
+            .await
+            .map_err(|err| format!("failed to flush MCP message: {err}"))
+    }
+
+    /// Read lines until the response whose id matches `expected_id` arrives,
+    /// skipping any interleaved notifications or unrelated messages the server
+    /// emits (logging, progress, …) — a single blind `read_line` would mistake
+    /// the first such notification for the response.
+    async fn read_response(
+        &mut self,
+        expected_id: i64,
+        method: &str,
+    ) -> Result<serde_json::Value, String> {
+        loop {
+            let mut line = String::new();
+            let read = tokio::time::timeout(self.timeout, self.reader.read_line(&mut line))
+                .await
+                .map_err(|_| {
+                    format!(
+                        "MCP server did not respond to `{method}` within {}s",
+                        self.timeout.as_secs()
+                    )
+                })?
+                .map_err(|err| format!("failed to read MCP response: {err}"))?;
+
+            if read == 0 {
+                return Err("MCP server closed the connection before responding".to_string());
+            }
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            let response: JsonRpcResponse = match serde_json::from_str(trimmed) {
+                Ok(response) => response,
+                // Not a response shape (e.g. a server->client notification/request);
+                // ignore it and keep waiting for our correlated reply.
+                Err(_) => continue,
+            };
+
+            let matches_id = response
+                .id
+                .as_ref()
+                .and_then(|id| id.as_i64())
+                .map(|id| id == expected_id)
+                .unwrap_or(false);
+            if !matches_id {
+                continue;
+            }
+
+            if let Some(error) = response.error {
+                return Err(format!("MCP RPC error {}: {}", error.code, error.message));
+            }
+            return response
+                .result
+                .ok_or_else(|| "MCP response did not include a result".to_string());
+        }
+    }
+}
+
+impl Drop for McpClient {
+    fn drop(&mut self) {
+        // Best-effort: don't leak the child if the handle is dropped without
+        // an explicit `close`.
+        let _ = self.child.start_kill();
+    }
+}

--- a/crates/sema-mcp/src/client.rs
+++ b/crates/sema-mcp/src/client.rs
@@ -451,12 +451,13 @@ impl StdioTransport {
 
             let response: JsonRpcResponse = match serde_json::from_str(trimmed) {
                 Ok(response) => response,
-                // Not a response shape (e.g. a server->client notification/request);
-                // ignore it and keep waiting for our correlated reply.
+                // Not JSON-RPC at all; ignore and keep waiting.
                 Err(_) => continue,
             };
 
-            if !response_matches_id(&response, expected_id) {
+            // Skip server->client requests/notifications (they carry `method`) even
+            // when their id collides with ours — only a real response ends the wait.
+            if !response.is_response() || !response_matches_id(&response, expected_id) {
                 continue;
             }
             return extract_result(response);
@@ -625,7 +626,7 @@ impl HttpTransport {
                 .map_err(|err| format!("failed to read MCP response body: {err}"))?;
             let response: JsonRpcResponse = serde_json::from_str(text.trim())
                 .map_err(|err| format!("failed to decode MCP response: {err}"))?;
-            if !response_matches_id(&response, id) {
+            if !response.is_response() || !response_matches_id(&response, id) {
                 return Err(format!(
                     "MCP response id mismatch on `{method}` (expected {id})"
                 ));
@@ -697,7 +698,7 @@ impl HttpTransport {
         timeout: Duration,
     ) -> Result<serde_json::Value, String> {
         let mut stream = response.bytes_stream();
-        let mut buffer = String::new();
+        let mut buffer: Vec<u8> = Vec::new();
         let mut data_lines: Vec<String> = Vec::new();
 
         loop {
@@ -715,12 +716,9 @@ impl HttpTransport {
                 return Err("MCP SSE stream ended before the response arrived".to_string());
             };
             let chunk = chunk.map_err(|err| format!("failed to read MCP SSE stream: {err}"))?;
-            buffer.push_str(&String::from_utf8_lossy(&chunk));
+            buffer.extend_from_slice(&chunk);
 
-            while let Some(newline) = buffer.find('\n') {
-                let line = buffer[..newline].trim_end_matches('\r').to_string();
-                buffer.drain(..=newline);
-
+            while let Some(line) = take_line(&mut buffer) {
                 if line.is_empty() {
                     // Event boundary — try to correlate the accumulated data.
                     if let Some(result) = try_take_sse_event(&mut data_lines, expected_id)? {
@@ -754,7 +752,7 @@ struct LegacySseTransport {
     headers: HashMap<String, String>,
     #[allow(clippy::type_complexity)]
     stream: std::pin::Pin<Box<dyn futures::Stream<Item = Result<Vec<u8>, reqwest::Error>> + Send>>,
-    buffer: String,
+    buffer: Vec<u8>,
     /// Status + `WWW-Authenticate` of the most recent POST failure, so a mid-
     /// session `401`/`403` on a legacy server can be re-authorized like an HTTP
     /// one (parity — many servers still run this transport).
@@ -793,7 +791,7 @@ impl LegacySseTransport {
             post_url: String::new(),
             headers: config.headers,
             stream: Box::pin(stream),
-            buffer: String::new(),
+            buffer: Vec::new(),
             last_status: None,
             last_challenge: None,
         };
@@ -821,7 +819,7 @@ impl LegacySseTransport {
         loop {
             let (_event, data) = self.next_event(timeout).await?;
             if let Ok(response) = serde_json::from_str::<JsonRpcResponse>(&data) {
-                if response_matches_id(&response, id) {
+                if response.is_response() && response_matches_id(&response, id) {
                     return extract_result(response);
                 }
             }
@@ -874,9 +872,7 @@ impl LegacySseTransport {
         let mut event_type = String::new();
         let mut data_lines: Vec<String> = Vec::new();
         loop {
-            while let Some(newline) = self.buffer.find('\n') {
-                let line = self.buffer[..newline].trim_end_matches('\r').to_string();
-                self.buffer.drain(..=newline);
+            while let Some(line) = take_line(&mut self.buffer) {
                 if line.is_empty() {
                     if !data_lines.is_empty() || !event_type.is_empty() {
                         let event = if event_type.is_empty() {
@@ -898,7 +894,7 @@ impl LegacySseTransport {
                 .await
                 .map_err(|_| "legacy SSE stream stalled".to_string())?;
             match next {
-                Some(Ok(chunk)) => self.buffer.push_str(&String::from_utf8_lossy(&chunk)),
+                Some(Ok(chunk)) => self.buffer.extend_from_slice(&chunk),
                 Some(Err(err)) => return Err(format!("legacy SSE read error: {err}")),
                 None => return Err("legacy SSE stream closed unexpectedly".to_string()),
             }
@@ -914,6 +910,22 @@ fn resolve_url(base: &str, target: &str) -> Result<String, String> {
         .map_err(|e| format!("could not resolve legacy endpoint `{target}`: {e}"))
 }
 
+/// Pull the next complete line (through the `\n`) from a raw byte buffer,
+/// returning it without the trailing CR/LF, decoded as UTF-8. `None` when no
+/// complete line is buffered yet. Framing on the `\n` *byte* (which never
+/// appears inside a multi-byte UTF-8 sequence) and decoding whole lines — never
+/// arbitrary network chunks — keeps multi-byte characters intact across chunk
+/// boundaries.
+fn take_line(buffer: &mut Vec<u8>) -> Option<String> {
+    let newline = buffer.iter().position(|&b| b == b'\n')?;
+    let mut line: Vec<u8> = buffer.drain(..=newline).collect();
+    line.pop(); // drop '\n'
+    if line.last() == Some(&b'\r') {
+        line.pop();
+    }
+    Some(String::from_utf8_lossy(&line).into_owned())
+}
+
 /// Interpret an accumulated SSE event's `data` as a JSON-RPC message. Returns
 /// `Ok(Some(result))` when it is the correlated response, `Ok(None)` when it is
 /// an unrelated message to skip, and `Err` for an RPC-level error on our id.
@@ -926,11 +938,46 @@ fn try_take_sse_event(
     }
     let data = std::mem::take(data_lines).join("\n");
     match serde_json::from_str::<JsonRpcResponse>(&data) {
-        Ok(response) if response_matches_id(&response, expected_id) => {
+        Ok(response) if response.is_response() && response_matches_id(&response, expected_id) => {
             extract_result(response).map(Some)
         }
         // A server->client notification/request, or a response for a different
         // id — not ours; keep reading.
         _ => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::take_line;
+
+    #[test]
+    fn take_line_reassembles_utf8_split_across_chunks() {
+        // Feed the bytes one at a time (worst-case chunk boundaries). `take_line`
+        // must yield nothing until the '\n', then decode the whole line intact —
+        // the emoji (4 bytes) and accented chars must NOT become U+FFFD.
+        let full = "data: {\"text\":\"😀 café 日本\"}\n".as_bytes();
+        let mut buf: Vec<u8> = Vec::new();
+        for &b in &full[..full.len() - 1] {
+            buf.push(b);
+            assert!(
+                take_line(&mut buf).is_none(),
+                "no complete line before the newline"
+            );
+        }
+        buf.push(*full.last().unwrap());
+        assert_eq!(
+            take_line(&mut buf).as_deref(),
+            Some("data: {\"text\":\"😀 café 日本\"}")
+        );
+        assert!(take_line(&mut buf).is_none());
+    }
+
+    #[test]
+    fn take_line_strips_crlf_and_yields_lines_in_order() {
+        let mut buf = b"first\r\nsecond\n".to_vec();
+        assert_eq!(take_line(&mut buf).as_deref(), Some("first"));
+        assert_eq!(take_line(&mut buf).as_deref(), Some("second"));
+        assert!(take_line(&mut buf).is_none());
     }
 }

--- a/crates/sema-mcp/src/client.rs
+++ b/crates/sema-mcp/src/client.rs
@@ -542,6 +542,18 @@ impl HttpTransport {
 
         let status = response.status();
         self.last_status = (!status.is_success()).then_some(status.as_u16());
+        // Record any `WWW-Authenticate` challenge (cleared on success) so the auth
+        // layer can re-authorize and retry — a `401` (token missing/expired) or a
+        // `403 insufficient_scope` (needs step-up). Reflects the current response.
+        self.last_challenge = if status.is_success() {
+            None
+        } else {
+            response
+                .headers()
+                .get("www-authenticate")
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_string)
+        };
         if status.as_u16() == 404 {
             // Session was terminated/expired; per the spec the client must start
             // a fresh session with a new `initialize`. Surface it so the caller
@@ -551,13 +563,6 @@ impl HttpTransport {
             ));
         }
         if status.as_u16() == 401 {
-            // Record the challenge so the auth layer can discover the
-            // authorization server, obtain a token, and retry.
-            self.last_challenge = response
-                .headers()
-                .get("www-authenticate")
-                .and_then(|v| v.to_str().ok())
-                .map(str::to_string);
             return Err(format!(
                 "MCP server requires authorization (HTTP 401) on `{method}`"
             ));

--- a/crates/sema-mcp/src/client_auth.rs
+++ b/crates/sema-mcp/src/client_auth.rs
@@ -1,0 +1,65 @@
+//! CLI entry points for MCP client authentication (`sema mcp login/logout`).
+//!
+//! `login` runs the OAuth flow eagerly (before any `mcp/connect`) so a token is
+//! cached and later connects are silent; `logout` clears the stored credentials
+//! for a server. Both use the default credential store (keychain or `0600` file).
+
+use std::time::Duration;
+
+use crate::oauth;
+
+const LOGIN_TIMEOUT: Duration = Duration::from_secs(300);
+
+fn runtime() -> Result<tokio::runtime::Runtime, String> {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| format!("failed to create runtime: {e}"))
+}
+
+/// Authenticate to a remote MCP server and cache the resulting token. Uses the
+/// browser loopback flow by default; `use_device` selects the RFC 8628 device
+/// flow for headless boxes.
+pub fn mcp_login(url: &str, use_device: bool, client_id: Option<&str>) -> Result<(), String> {
+    let rt = runtime()?;
+    rt.block_on(async {
+        let http = reqwest::Client::new();
+        let store = oauth::store::default_store();
+        let config = oauth::login::LoginConfig {
+            mcp_url: url,
+            resource_metadata_url: None,
+            requested_scope: None,
+            preconfigured_client_id: client_id,
+        };
+        let existing = store.load(url).and_then(|c| c.client_info);
+
+        let creds = if use_device {
+            oauth::device::device_login(&http, &config, existing, &|device| {
+                eprintln!(
+                    "\nTo authorize, visit:\n  {}\nand enter the code: {}\n",
+                    device.verification_uri, device.user_code
+                );
+                if let Some(complete) = &device.verification_uri_complete {
+                    eprintln!("(or open directly: {complete})\n");
+                }
+                eprintln!("Waiting for approval…");
+            })
+            .await?
+        } else {
+            let driver = oauth::loopback::LoopbackDriver::new(LOGIN_TIMEOUT)?;
+            eprintln!("Opening your browser to authorize {url} …");
+            oauth::login::login(&http, &config, existing, &driver).await?
+        };
+
+        store.save(&creds)?;
+        eprintln!("Authenticated to {url}. Token cached.");
+        Ok(())
+    })
+}
+
+/// Remove any cached credentials for a remote MCP server.
+pub fn mcp_logout(url: &str) -> Result<(), String> {
+    oauth::store::default_store().delete(url)?;
+    eprintln!("Cleared cached credentials for {url}.");
+    Ok(())
+}

--- a/crates/sema-mcp/src/lib.rs
+++ b/crates/sema-mcp/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod builtin_docs;
 pub mod builtins;
 pub mod client;
+pub mod client_auth;
 pub mod docs_search;
 pub mod notebook;
 pub mod oauth;
@@ -10,4 +11,5 @@ pub mod tools;
 
 pub use builtins::register_mcp_builtins;
 pub use client::{McpClient, McpClientConfig, McpHttpConfig};
+pub use client_auth::{mcp_login, mcp_logout};
 pub use server::{run_mcp_server, run_mcp_server_on};

--- a/crates/sema-mcp/src/lib.rs
+++ b/crates/sema-mcp/src/lib.rs
@@ -8,5 +8,5 @@ pub mod server;
 pub mod tools;
 
 pub use builtins::register_mcp_builtins;
-pub use client::{McpClient, McpClientConfig};
+pub use client::{McpClient, McpClientConfig, McpHttpConfig};
 pub use server::{run_mcp_server, run_mcp_server_on};

--- a/crates/sema-mcp/src/lib.rs
+++ b/crates/sema-mcp/src/lib.rs
@@ -3,6 +3,7 @@ pub mod builtins;
 pub mod client;
 pub mod docs_search;
 pub mod notebook;
+pub mod oauth;
 pub mod protocol;
 pub mod server;
 pub mod tools;

--- a/crates/sema-mcp/src/lib.rs
+++ b/crates/sema-mcp/src/lib.rs
@@ -1,8 +1,12 @@
 pub mod builtin_docs;
+pub mod builtins;
+pub mod client;
 pub mod docs_search;
 pub mod notebook;
 pub mod protocol;
 pub mod server;
 pub mod tools;
 
+pub use builtins::register_mcp_builtins;
+pub use client::{McpClient, McpClientConfig};
 pub use server::{run_mcp_server, run_mcp_server_on};

--- a/crates/sema-mcp/src/oauth/device.rs
+++ b/crates/sema-mcp/src/oauth/device.rs
@@ -1,0 +1,183 @@
+//! OAuth 2.0 Device Authorization Grant (RFC 8628) — the headless alternative to
+//! the loopback browser flow. The user is shown a short `user_code` and a
+//! `verification_uri` to visit on any device; meanwhile the client polls the
+//! token endpoint until the user approves. No PKCE (there is no redirect to
+//! intercept); a refresh token requires the `offline_access` scope on many
+//! providers.
+
+use std::time::{Duration, Instant};
+
+use serde::Deserialize;
+
+use super::flow::{self, TokenResponse};
+use super::login::{discover, LoginConfig};
+use super::store::{now_unix, ClientInfo, StoredCredentials, TokenSet};
+
+pub const DEVICE_CODE_GRANT: &str = "urn:ietf:params:oauth:grant-type:device_code";
+
+/// The device-authorization response (RFC 8628 §3.2).
+#[derive(Debug, Clone, Deserialize)]
+pub struct DeviceAuthorization {
+    pub device_code: String,
+    pub user_code: String,
+    pub verification_uri: String,
+    #[serde(default)]
+    pub verification_uri_complete: Option<String>,
+    #[serde(default = "default_expires_in")]
+    pub expires_in: u64,
+    #[serde(default = "default_interval")]
+    pub interval: u64,
+}
+
+fn default_expires_in() -> u64 {
+    900
+}
+fn default_interval() -> u64 {
+    5
+}
+
+/// Request a device + user code from the device-authorization endpoint.
+pub async fn request_device_code(
+    client: &reqwest::Client,
+    device_endpoint: &str,
+    client_id: &str,
+    scopes: &[String],
+    resource: &str,
+) -> Result<DeviceAuthorization, String> {
+    let scope = scopes.join(" ");
+    let mut form = vec![("client_id", client_id), ("resource", resource)];
+    if !scope.is_empty() {
+        form.push(("scope", scope.as_str()));
+    }
+    let body = url::form_urlencoded::Serializer::new(String::new())
+        .extend_pairs(form.iter().map(|(k, v)| (*k, *v)))
+        .finish();
+    let resp = client
+        .post(device_endpoint)
+        .header("Accept", "application/json")
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| format!("device authorization request failed: {e}"))?;
+    if !resp.status().is_success() {
+        let status = resp.status().as_u16();
+        let detail = resp.text().await.unwrap_or_default();
+        return Err(format!(
+            "device authorization failed: HTTP {status} {}",
+            detail.trim()
+        ));
+    }
+    resp.json::<DeviceAuthorization>()
+        .await
+        .map_err(|e| format!("device authorization response did not decode: {e}"))
+}
+
+/// Poll the token endpoint until the user approves (or the code expires),
+/// honoring `authorization_pending` / `slow_down` per RFC 8628 §3.5.
+pub async fn poll_for_token(
+    client: &reqwest::Client,
+    token_endpoint: &str,
+    client_id: &str,
+    device_code: &str,
+    resource: &str,
+    mut interval: u64,
+    expires_in: u64,
+) -> Result<TokenResponse, String> {
+    let deadline = Instant::now() + Duration::from_secs(expires_in);
+    loop {
+        let form = vec![
+            ("grant_type", DEVICE_CODE_GRANT),
+            ("device_code", device_code),
+            ("client_id", client_id),
+            ("resource", resource),
+        ];
+        match flow::post_token(client, token_endpoint, form, None).await {
+            Ok(token) => return Ok(token),
+            Err(err) if err.starts_with("authorization_pending") => {}
+            Err(err) if err.starts_with("slow_down") => interval += 5,
+            Err(err) => return Err(err),
+        }
+        if Instant::now() >= deadline {
+            return Err("device authorization expired before it was approved".to_string());
+        }
+        tokio::time::sleep(Duration::from_secs(interval)).await;
+    }
+}
+
+/// Full headless login via the device grant. `display` shows the user the code +
+/// verification URL (RFC 8628 §3.3).
+pub async fn device_login(
+    client: &reqwest::Client,
+    config: &LoginConfig<'_>,
+    existing_client_info: Option<ClientInfo>,
+    display: &dyn Fn(&DeviceAuthorization),
+) -> Result<StoredCredentials, String> {
+    let discovered = discover(client, config).await?;
+    let device_endpoint = discovered
+        .authorization_server
+        .device_authorization_endpoint
+        .clone()
+        .ok_or_else(|| {
+            "authorization server does not advertise a device authorization endpoint".to_string()
+        })?;
+
+    let client_info = match (config.preconfigured_client_id, existing_client_info) {
+        (Some(id), _) => ClientInfo {
+            client_id: id.to_string(),
+            client_secret: None,
+        },
+        (None, Some(info)) => info,
+        (None, None) => {
+            let reg = discovered
+                .authorization_server
+                .registration_endpoint
+                .as_deref()
+                .ok_or_else(|| {
+                    "no client id and no dynamic registration endpoint; pass :auth {:client-id …}"
+                        .to_string()
+                })?;
+            flow::register_client(client, reg, "http://127.0.0.1/callback", "Sema MCP client")
+                .await?
+        }
+    };
+
+    let scopes: Vec<String> = config
+        .requested_scope
+        .map(|s| s.split_whitespace().map(String::from).collect::<Vec<_>>())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| discovered.protected_resource.scopes_supported.clone());
+
+    let device = request_device_code(
+        client,
+        &device_endpoint,
+        &client_info.client_id,
+        &scopes,
+        &discovered.resource,
+    )
+    .await?;
+    display(&device);
+
+    let token = poll_for_token(
+        client,
+        &discovered.authorization_server.token_endpoint,
+        &client_info.client_id,
+        &device.device_code,
+        &discovered.resource,
+        device.interval,
+        device.expires_in,
+    )
+    .await?;
+
+    Ok(StoredCredentials {
+        server_url: config.mcp_url.to_string(),
+        tokens: TokenSet::from_response(
+            token.access_token,
+            token.refresh_token,
+            token.expires_in,
+            token.scope,
+            now_unix(),
+        ),
+        client_info: Some(client_info),
+    })
+}

--- a/crates/sema-mcp/src/oauth/discovery.rs
+++ b/crates/sema-mcp/src/oauth/discovery.rs
@@ -1,0 +1,285 @@
+//! OAuth authorization-server discovery for MCP (spec `2025-11-25`).
+//!
+//! The client learns *where* to authenticate by walking a metadata chain:
+//! a `401` from the MCP server carries `WWW-Authenticate: Bearer
+//! resource_metadata="…"`; that URL (RFC 9728 Protected Resource Metadata)
+//! lists the authorization server(s); each server publishes its endpoints via
+//! RFC 8414 / OpenID Connect Discovery metadata. All of this is plain `GET`s of
+//! `.well-known/*` documents, so it is driven with our own reqwest client.
+
+use serde::Deserialize;
+use url::Url;
+
+/// The auth-params parsed from a `401`'s `WWW-Authenticate: Bearer …` header.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WwwAuthenticate {
+    /// RFC 9728 `resource_metadata` — the Protected Resource Metadata URL.
+    pub resource_metadata: Option<String>,
+    /// RFC 6750 `scope` — when present, authoritative for the failing request.
+    pub scope: Option<String>,
+    /// RFC 6750 `error` (e.g. `insufficient_scope`).
+    pub error: Option<String>,
+}
+
+/// Parse a `WWW-Authenticate` header value, pulling the `Bearer` auth-params we
+/// care about. Tolerant of ordering, spacing, and unrelated params.
+pub fn parse_www_authenticate(header: &str) -> WwwAuthenticate {
+    let mut out = WwwAuthenticate::default();
+    // Drop the leading scheme token (`Bearer`) if present, then split the
+    // comma-separated `key="value"` / `key=value` auth-params.
+    let params = header.trim().strip_prefix("Bearer").unwrap_or(header).trim();
+    for part in params.split(',') {
+        let Some((key, value)) = part.split_once('=') else {
+            continue;
+        };
+        let key = key.trim().to_ascii_lowercase();
+        let value = value.trim().trim_matches('"').to_string();
+        match key.as_str() {
+            "resource_metadata" => out.resource_metadata = Some(value),
+            "scope" => out.scope = Some(value),
+            "error" => out.error = Some(value),
+            _ => {}
+        }
+    }
+    out
+}
+
+/// RFC 9728 Protected Resource Metadata (only the fields we consume).
+#[derive(Debug, Clone, Deserialize)]
+pub struct ProtectedResourceMetadata {
+    pub resource: String,
+    #[serde(default)]
+    pub authorization_servers: Vec<String>,
+    #[serde(default)]
+    pub scopes_supported: Vec<String>,
+}
+
+/// RFC 8414 / OIDC Authorization Server Metadata (only the fields we consume).
+#[derive(Debug, Clone, Deserialize)]
+pub struct AuthorizationServerMetadata {
+    pub issuer: String,
+    pub authorization_endpoint: String,
+    pub token_endpoint: String,
+    #[serde(default)]
+    pub registration_endpoint: Option<String>,
+    #[serde(default)]
+    pub device_authorization_endpoint: Option<String>,
+    #[serde(default)]
+    pub code_challenge_methods_supported: Vec<String>,
+    #[serde(default)]
+    pub grant_types_supported: Vec<String>,
+    #[serde(default)]
+    pub scopes_supported: Vec<String>,
+}
+
+impl AuthorizationServerMetadata {
+    /// RFC 7636 gate: the client MUST verify PKCE-S256 support before using this
+    /// server. Metadata that omits `code_challenge_methods_supported` entirely is
+    /// treated (per OIDC discovery rules) as not advertising PKCE.
+    pub fn supports_pkce_s256(&self) -> bool {
+        self.code_challenge_methods_supported
+            .iter()
+            .any(|m| m.eq_ignore_ascii_case("S256"))
+    }
+
+    pub fn supports_device_flow(&self) -> bool {
+        self.device_authorization_endpoint.is_some()
+            && (self.grant_types_supported.is_empty()
+                || self
+                    .grant_types_supported
+                    .iter()
+                    .any(|g| g == "urn:ietf:params:oauth:grant-type:device_code"))
+    }
+}
+
+/// Candidate Protected Resource Metadata URLs to probe when the `401` did not
+/// advertise one (RFC 9728 §3.1): the well-known suffix is inserted between the
+/// host and the resource's path, then the origin-root form.
+pub fn protected_resource_metadata_urls(mcp_endpoint: &str) -> Vec<String> {
+    well_known_urls(mcp_endpoint, "oauth-protected-resource")
+}
+
+/// Candidate Authorization Server Metadata URLs for an issuer (RFC 8414 + OIDC
+/// Discovery), in the spec's probe order.
+pub fn authorization_server_metadata_urls(issuer: &str) -> Vec<String> {
+    let Ok(url) = Url::parse(issuer) else {
+        return Vec::new();
+    };
+    let origin = origin_of(&url);
+    let path = url.path().trim_end_matches('/');
+    if path.is_empty() {
+        // Issuer without a path component.
+        vec![
+            format!("{origin}/.well-known/oauth-authorization-server"),
+            format!("{origin}/.well-known/openid-configuration"),
+        ]
+    } else {
+        // Issuer with a path: RFC 8414 / OIDC path-insertion, then OIDC append.
+        vec![
+            format!("{origin}/.well-known/oauth-authorization-server{path}"),
+            format!("{origin}/.well-known/openid-configuration{path}"),
+            format!("{origin}{path}/.well-known/openid-configuration"),
+        ]
+    }
+}
+
+/// Insert `/.well-known/<suffix>` between the host and path of `target`, then the
+/// origin-root variant.
+fn well_known_urls(target: &str, suffix: &str) -> Vec<String> {
+    let Ok(url) = Url::parse(target) else {
+        return Vec::new();
+    };
+    let origin = origin_of(&url);
+    let path = url.path().trim_end_matches('/');
+    let root = format!("{origin}/.well-known/{suffix}");
+    if path.is_empty() {
+        vec![root]
+    } else {
+        vec![format!("{origin}/.well-known/{suffix}{path}"), root]
+    }
+}
+
+/// `scheme://host[:port]` with no trailing slash.
+fn origin_of(url: &Url) -> String {
+    let mut origin = format!("{}://{}", url.scheme(), url.host_str().unwrap_or(""));
+    if let Some(port) = url.port() {
+        origin.push_str(&format!(":{port}"));
+    }
+    origin
+}
+
+/// Fetch Protected Resource Metadata. Tries the `401`-advertised URL first (when
+/// present), then the well-known fallbacks derived from the MCP endpoint.
+pub async fn fetch_protected_resource_metadata(
+    client: &reqwest::Client,
+    mcp_endpoint: &str,
+    advertised_url: Option<&str>,
+) -> Result<ProtectedResourceMetadata, String> {
+    let mut candidates = Vec::new();
+    if let Some(url) = advertised_url {
+        candidates.push(url.to_string());
+    }
+    candidates.extend(protected_resource_metadata_urls(mcp_endpoint));
+
+    fetch_first_json(client, &candidates, "protected resource metadata").await
+}
+
+/// Fetch Authorization Server Metadata for an issuer, probing the well-known
+/// variants in order.
+pub async fn fetch_authorization_server_metadata(
+    client: &reqwest::Client,
+    issuer: &str,
+) -> Result<AuthorizationServerMetadata, String> {
+    let candidates = authorization_server_metadata_urls(issuer);
+    fetch_first_json(client, &candidates, "authorization server metadata").await
+}
+
+/// GET each candidate URL in turn, returning the first that decodes as `T`.
+async fn fetch_first_json<T: serde::de::DeserializeOwned>(
+    client: &reqwest::Client,
+    candidates: &[String],
+    what: &str,
+) -> Result<T, String> {
+    let mut last_err = format!("no {what} URL candidates");
+    for url in candidates {
+        match client.get(url).header("Accept", "application/json").send().await {
+            Ok(resp) if resp.status().is_success() => match resp.json::<T>().await {
+                Ok(value) => return Ok(value),
+                Err(err) => last_err = format!("{what} at {url} did not decode: {err}"),
+            },
+            Ok(resp) => last_err = format!("{what} at {url}: HTTP {}", resp.status().as_u16()),
+            Err(err) => last_err = format!("{what} at {url}: {err}"),
+        }
+    }
+    Err(format!("failed to discover {what}: {last_err}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_www_authenticate_params() {
+        let h = r#"Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource", scope="files:read", error="insufficient_scope""#;
+        let parsed = parse_www_authenticate(h);
+        assert_eq!(
+            parsed.resource_metadata.as_deref(),
+            Some("https://mcp.example.com/.well-known/oauth-protected-resource")
+        );
+        assert_eq!(parsed.scope.as_deref(), Some("files:read"));
+        assert_eq!(parsed.error.as_deref(), Some("insufficient_scope"));
+    }
+
+    #[test]
+    fn parses_www_authenticate_without_scheme_or_quotes() {
+        let parsed = parse_www_authenticate("resource_metadata=https://x/y");
+        assert_eq!(parsed.resource_metadata.as_deref(), Some("https://x/y"));
+        assert!(parsed.scope.is_none());
+    }
+
+    #[test]
+    fn prm_urls_are_path_aware_then_root() {
+        let urls = protected_resource_metadata_urls("https://example.com/public/mcp");
+        assert_eq!(
+            urls,
+            vec![
+                "https://example.com/.well-known/oauth-protected-resource/public/mcp".to_string(),
+                "https://example.com/.well-known/oauth-protected-resource".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn prm_urls_root_only_for_bare_host() {
+        let urls = protected_resource_metadata_urls("https://example.com");
+        assert_eq!(
+            urls,
+            vec!["https://example.com/.well-known/oauth-protected-resource".to_string()]
+        );
+    }
+
+    #[test]
+    fn as_urls_for_issuer_with_path() {
+        let urls = authorization_server_metadata_urls("https://auth.example.com/tenant1");
+        assert_eq!(
+            urls,
+            vec![
+                "https://auth.example.com/.well-known/oauth-authorization-server/tenant1"
+                    .to_string(),
+                "https://auth.example.com/.well-known/openid-configuration/tenant1".to_string(),
+                "https://auth.example.com/tenant1/.well-known/openid-configuration".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn as_urls_for_bare_issuer() {
+        let urls = authorization_server_metadata_urls("https://auth.example.com");
+        assert_eq!(
+            urls,
+            vec![
+                "https://auth.example.com/.well-known/oauth-authorization-server".to_string(),
+                "https://auth.example.com/.well-known/openid-configuration".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn pkce_gate_requires_s256() {
+        let mut md = AuthorizationServerMetadata {
+            issuer: "https://a".into(),
+            authorization_endpoint: "https://a/authorize".into(),
+            token_endpoint: "https://a/token".into(),
+            registration_endpoint: None,
+            device_authorization_endpoint: None,
+            code_challenge_methods_supported: vec![],
+            grant_types_supported: vec![],
+            scopes_supported: vec![],
+        };
+        assert!(!md.supports_pkce_s256(), "empty methods = no PKCE");
+        md.code_challenge_methods_supported = vec!["plain".into()];
+        assert!(!md.supports_pkce_s256(), "plain only = no S256");
+        md.code_challenge_methods_supported = vec!["S256".into()];
+        assert!(md.supports_pkce_s256());
+    }
+}

--- a/crates/sema-mcp/src/oauth/discovery.rs
+++ b/crates/sema-mcp/src/oauth/discovery.rs
@@ -27,7 +27,11 @@ pub fn parse_www_authenticate(header: &str) -> WwwAuthenticate {
     let mut out = WwwAuthenticate::default();
     // Drop the leading scheme token (`Bearer`) if present, then split the
     // comma-separated `key="value"` / `key=value` auth-params.
-    let params = header.trim().strip_prefix("Bearer").unwrap_or(header).trim();
+    let params = header
+        .trim()
+        .strip_prefix("Bearer")
+        .unwrap_or(header)
+        .trim();
     for part in params.split(',') {
         let Some((key, value)) = part.split_once('=') else {
             continue;
@@ -182,7 +186,12 @@ async fn fetch_first_json<T: serde::de::DeserializeOwned>(
 ) -> Result<T, String> {
     let mut last_err = format!("no {what} URL candidates");
     for url in candidates {
-        match client.get(url).header("Accept", "application/json").send().await {
+        match client
+            .get(url)
+            .header("Accept", "application/json")
+            .send()
+            .await
+        {
             Ok(resp) if resp.status().is_success() => match resp.json::<T>().await {
                 Ok(value) => return Ok(value),
                 Err(err) => last_err = format!("{what} at {url} did not decode: {err}"),

--- a/crates/sema-mcp/src/oauth/flow.rs
+++ b/crates/sema-mcp/src/oauth/flow.rs
@@ -1,0 +1,255 @@
+//! OAuth 2.1 protocol HTTP: Dynamic Client Registration, the authorization-URL
+//! construction, and the token-endpoint exchanges (auth-code, refresh, device).
+//!
+//! These are the plain form-encoded / JSON requests of RFC 6749 / 7591 / 8628,
+//! driven directly with our reqwest client. The `resource` parameter (RFC 8707,
+//! the canonical MCP server URI) is a hard MUST on both the authorization and
+//! token requests and is threaded through every builder here — `oauth2`'s client
+//! won't add it, so we always set it explicitly.
+
+use serde::Deserialize;
+use url::Url;
+
+use super::store::ClientInfo;
+
+/// A token-endpoint success response (subset we consume).
+#[derive(Debug, Clone, Deserialize)]
+pub struct TokenResponse {
+    pub access_token: String,
+    #[serde(default)]
+    pub refresh_token: Option<String>,
+    #[serde(default)]
+    pub expires_in: Option<u64>,
+    #[serde(default)]
+    pub scope: Option<String>,
+}
+
+/// Build the authorization-request URL (RFC 6749 §4.1.1 + PKCE + RFC 8707).
+/// Pure so it is unit-testable without a browser.
+pub fn build_authorize_url(
+    authorization_endpoint: &str,
+    client_id: &str,
+    redirect_uri: &str,
+    code_challenge: &str,
+    state: &str,
+    scopes: &[String],
+    resource: &str,
+) -> Result<String, String> {
+    let mut url = Url::parse(authorization_endpoint)
+        .map_err(|e| format!("invalid authorization_endpoint: {e}"))?;
+    {
+        let mut q = url.query_pairs_mut();
+        q.append_pair("response_type", "code");
+        q.append_pair("client_id", client_id);
+        q.append_pair("redirect_uri", redirect_uri);
+        q.append_pair("code_challenge", code_challenge);
+        q.append_pair("code_challenge_method", "S256");
+        q.append_pair("state", state);
+        // RFC 8707: bind the token audience to this MCP server.
+        q.append_pair("resource", resource);
+        if !scopes.is_empty() {
+            q.append_pair("scope", &scopes.join(" "));
+        }
+    }
+    Ok(url.to_string())
+}
+
+/// Dynamic Client Registration (RFC 7591): register a public client with the
+/// loopback redirect URI and return its issued `client_id`.
+pub async fn register_client(
+    client: &reqwest::Client,
+    registration_endpoint: &str,
+    redirect_uri: &str,
+    client_name: &str,
+) -> Result<ClientInfo, String> {
+    let body = serde_json::json!({
+        "client_name": client_name,
+        "redirect_uris": [redirect_uri],
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+        "token_endpoint_auth_method": "none",
+    });
+    let resp = client
+        .post(registration_endpoint)
+        .header("Accept", "application/json")
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("dynamic client registration request failed: {e}"))?;
+    if !resp.status().is_success() {
+        let status = resp.status().as_u16();
+        let detail = resp.text().await.unwrap_or_default();
+        return Err(format!(
+            "dynamic client registration failed: HTTP {status} {}",
+            detail.trim()
+        ));
+    }
+
+    #[derive(Deserialize)]
+    struct RegistrationResponse {
+        client_id: String,
+        #[serde(default)]
+        client_secret: Option<String>,
+    }
+    let reg: RegistrationResponse = resp
+        .json()
+        .await
+        .map_err(|e| format!("dynamic client registration response did not decode: {e}"))?;
+    Ok(ClientInfo {
+        client_id: reg.client_id,
+        client_secret: reg.client_secret,
+    })
+}
+
+/// Exchange an authorization `code` (+ PKCE verifier) for tokens.
+#[allow(clippy::too_many_arguments)]
+pub async fn exchange_code(
+    client: &reqwest::Client,
+    token_endpoint: &str,
+    client_id: &str,
+    client_secret: Option<&str>,
+    code: &str,
+    redirect_uri: &str,
+    code_verifier: &str,
+    resource: &str,
+) -> Result<TokenResponse, String> {
+    let form = vec![
+        ("grant_type", "authorization_code"),
+        ("code", code),
+        ("redirect_uri", redirect_uri),
+        ("code_verifier", code_verifier),
+        ("client_id", client_id),
+        ("resource", resource),
+    ];
+    post_token(client, token_endpoint, form, client_secret).await
+}
+
+/// Exchange a refresh token for a fresh access token (and possibly a rotated
+/// refresh token, which the caller MUST persist).
+pub async fn refresh_tokens(
+    client: &reqwest::Client,
+    token_endpoint: &str,
+    client_id: &str,
+    client_secret: Option<&str>,
+    refresh_token: &str,
+    resource: &str,
+) -> Result<TokenResponse, String> {
+    let form = vec![
+        ("grant_type", "refresh_token"),
+        ("refresh_token", refresh_token),
+        ("client_id", client_id),
+        ("resource", resource),
+    ];
+    post_token(client, token_endpoint, form, client_secret).await
+}
+
+/// POST a form to the token endpoint and decode the response, mapping an OAuth
+/// error object (`{"error": "...", "error_description": "..."}`) to an `Err`
+/// that preserves the error code so callers can branch (`invalid_grant`, …).
+pub async fn post_token(
+    client: &reqwest::Client,
+    token_endpoint: &str,
+    form: Vec<(&str, &str)>,
+    client_secret: Option<&str>,
+) -> Result<TokenResponse, String> {
+    let mut builder = client
+        .post(token_endpoint)
+        .header("Accept", "application/json")
+        .header("Content-Type", "application/x-www-form-urlencoded");
+    // Confidential clients authenticate with HTTP Basic; public clients send
+    // only client_id in the form (already present).
+    if let Some(secret) = client_secret {
+        let client_id = form
+            .iter()
+            .find(|(k, _)| *k == "client_id")
+            .map(|(_, v)| *v)
+            .unwrap_or("");
+        builder = builder.basic_auth(client_id, Some(secret));
+    }
+    let body = url::form_urlencoded::Serializer::new(String::new())
+        .extend_pairs(form.iter().map(|(k, v)| (*k, *v)))
+        .finish();
+    let resp = builder
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| format!("token request failed: {e}"))?;
+
+    let status = resp.status();
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| format!("token response body error: {e}"))?;
+
+    if !status.is_success() {
+        // Prefer the structured OAuth error code when present.
+        #[derive(Deserialize)]
+        struct OAuthError {
+            error: String,
+            #[serde(default)]
+            error_description: Option<String>,
+        }
+        if let Ok(err) = serde_json::from_str::<OAuthError>(&text) {
+            return Err(match err.error_description {
+                Some(desc) => format!("{}: {desc}", err.error),
+                None => err.error,
+            });
+        }
+        return Err(format!(
+            "token endpoint HTTP {}: {}",
+            status.as_u16(),
+            text.trim()
+        ));
+    }
+
+    serde_json::from_str::<TokenResponse>(&text)
+        .map_err(|e| format!("token response did not decode: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn authorize_url_has_all_required_params() {
+        let url = build_authorize_url(
+            "https://auth.example.com/authorize",
+            "client-123",
+            "http://127.0.0.1:5599/callback",
+            "CHALLENGE",
+            "STATE",
+            &["files:read".to_string(), "files:write".to_string()],
+            "https://mcp.example.com/mcp",
+        )
+        .unwrap();
+        let parsed = Url::parse(&url).unwrap();
+        let pairs: std::collections::HashMap<_, _> = parsed.query_pairs().into_owned().collect();
+        assert_eq!(pairs["response_type"], "code");
+        assert_eq!(pairs["client_id"], "client-123");
+        assert_eq!(pairs["redirect_uri"], "http://127.0.0.1:5599/callback");
+        assert_eq!(pairs["code_challenge"], "CHALLENGE");
+        assert_eq!(pairs["code_challenge_method"], "S256");
+        assert_eq!(pairs["state"], "STATE");
+        // RFC 8707 resource MUST be present.
+        assert_eq!(pairs["resource"], "https://mcp.example.com/mcp");
+        assert_eq!(pairs["scope"], "files:read files:write");
+    }
+
+    #[test]
+    fn authorize_url_omits_empty_scope() {
+        let url = build_authorize_url(
+            "https://a/authorize",
+            "c",
+            "http://127.0.0.1:1/callback",
+            "ch",
+            "st",
+            &[],
+            "https://mcp/mcp",
+        )
+        .unwrap();
+        assert!(
+            !url.contains("scope="),
+            "no scope param when none requested"
+        );
+    }
+}

--- a/crates/sema-mcp/src/oauth/login.rs
+++ b/crates/sema-mcp/src/oauth/login.rs
@@ -1,0 +1,165 @@
+//! End-to-end OAuth login orchestration: discover → obtain a client_id →
+//! authorization-code + PKCE → tokens. Ties together `discovery`, `flow`, and a
+//! [`RedirectDriver`] (loopback browser or device/paste). The result is a
+//! [`StoredCredentials`] the caller persists and attaches to MCP requests.
+
+use super::discovery::{self, AuthorizationServerMetadata, ProtectedResourceMetadata};
+use super::loopback::RedirectDriver;
+use super::store::{ClientInfo, StoredCredentials, TokenSet};
+use super::{flow, new_pkce_session};
+
+/// Inputs for a login attempt against one MCP server.
+pub struct LoginConfig<'a> {
+    /// The MCP server endpoint URL (`:url`).
+    pub mcp_url: &'a str,
+    /// The `resource_metadata` URL advertised by the server's `401`, if any.
+    pub resource_metadata_url: Option<&'a str>,
+    /// The `scope` advertised by the `401` (authoritative when present).
+    pub requested_scope: Option<&'a str>,
+    /// A pre-registered client_id the user configured (`:auth {:client-id …}`).
+    pub preconfigured_client_id: Option<&'a str>,
+}
+
+/// The discovery outcome, cached so refresh/re-scope can skip re-probing.
+#[derive(Debug, Clone)]
+pub struct Discovered {
+    pub resource: String,
+    pub protected_resource: ProtectedResourceMetadata,
+    pub authorization_server: AuthorizationServerMetadata,
+}
+
+/// Walk the metadata chain: PRM (RFC 9728) → AS metadata (RFC 8414/OIDC), and
+/// enforce the PKCE-S256 gate.
+pub async fn discover(
+    client: &reqwest::Client,
+    config: &LoginConfig<'_>,
+) -> Result<Discovered, String> {
+    let prm = discovery::fetch_protected_resource_metadata(
+        client,
+        config.mcp_url,
+        config.resource_metadata_url,
+    )
+    .await?;
+    let issuer = prm
+        .authorization_servers
+        .first()
+        .ok_or_else(|| "protected resource metadata lists no authorization servers".to_string())?
+        .clone();
+    let as_meta = discovery::fetch_authorization_server_metadata(client, &issuer).await?;
+    if !as_meta.supports_pkce_s256() {
+        return Err(format!(
+            "authorization server `{issuer}` does not advertise PKCE S256 support; refusing to proceed"
+        ));
+    }
+    Ok(Discovered {
+        resource: prm.resource.clone(),
+        protected_resource: prm,
+        authorization_server: as_meta,
+    })
+}
+
+/// Resolve the client_id: a pre-configured one, an existing DCR registration, or
+/// a fresh Dynamic Client Registration.
+async fn resolve_client(
+    client: &reqwest::Client,
+    config: &LoginConfig<'_>,
+    discovered: &Discovered,
+    existing: Option<ClientInfo>,
+    redirect_uri: &str,
+) -> Result<ClientInfo, String> {
+    if let Some(id) = config.preconfigured_client_id {
+        return Ok(ClientInfo {
+            client_id: id.to_string(),
+            client_secret: None,
+        });
+    }
+    if let Some(info) = existing {
+        return Ok(info);
+    }
+    let registration_endpoint = discovered
+        .authorization_server
+        .registration_endpoint
+        .as_deref()
+        .ok_or_else(|| {
+            "server requires a pre-registered client (no dynamic registration endpoint); \
+             pass :auth {:client-id \"…\"}"
+                .to_string()
+        })?;
+    flow::register_client(
+        client,
+        registration_endpoint,
+        redirect_uri,
+        "Sema MCP client",
+    )
+    .await
+}
+
+/// The scopes to request: the `401` challenge scope wins; else the PRM
+/// `scopes_supported`; else none.
+fn resolve_scopes(config: &LoginConfig<'_>, discovered: &Discovered) -> Vec<String> {
+    if let Some(scope) = config.requested_scope {
+        let scopes: Vec<String> = scope.split_whitespace().map(String::from).collect();
+        if !scopes.is_empty() {
+            return scopes;
+        }
+    }
+    discovered.protected_resource.scopes_supported.clone()
+}
+
+/// Run the full login and return persistable credentials.
+pub async fn login(
+    client: &reqwest::Client,
+    config: &LoginConfig<'_>,
+    existing_client_info: Option<ClientInfo>,
+    redirect: &dyn RedirectDriver,
+) -> Result<StoredCredentials, String> {
+    let discovered = discover(client, config).await?;
+    let redirect_uri = redirect.redirect_uri();
+    let client_info = resolve_client(
+        client,
+        config,
+        &discovered,
+        existing_client_info,
+        &redirect_uri,
+    )
+    .await?;
+    let scopes = resolve_scopes(config, &discovered);
+
+    let pkce = new_pkce_session();
+    let authorize_url = flow::build_authorize_url(
+        &discovered.authorization_server.authorization_endpoint,
+        &client_info.client_id,
+        &redirect_uri,
+        &pkce.challenge,
+        &pkce.state,
+        &scopes,
+        &discovered.resource,
+    )?;
+
+    // Blocking browser leg (opens the browser + captures the loopback redirect).
+    let code = redirect.drive(&authorize_url, &pkce.state)?;
+
+    let token = flow::exchange_code(
+        client,
+        &discovered.authorization_server.token_endpoint,
+        &client_info.client_id,
+        client_info.client_secret.as_deref(),
+        &code,
+        &redirect_uri,
+        &pkce.verifier,
+        &discovered.resource,
+    )
+    .await?;
+
+    Ok(StoredCredentials {
+        server_url: config.mcp_url.to_string(),
+        tokens: TokenSet::from_response(
+            token.access_token,
+            token.refresh_token,
+            token.expires_in,
+            token.scope,
+            super::store::now_unix(),
+        ),
+        client_info: Some(client_info),
+    })
+}

--- a/crates/sema-mcp/src/oauth/login.rs
+++ b/crates/sema-mcp/src/oauth/login.rs
@@ -5,8 +5,12 @@
 
 use super::discovery::{self, AuthorizationServerMetadata, ProtectedResourceMetadata};
 use super::loopback::RedirectDriver;
-use super::store::{ClientInfo, StoredCredentials, TokenSet};
+use super::store::{now_unix, ClientInfo, StoredCredentials, TokenSet, TokenStore};
 use super::{flow, new_pkce_session};
+
+/// Seconds of clock skew to treat a token as already expired before its
+/// nominal expiry, so we refresh proactively rather than mid-request.
+const EXPIRY_SKEW_SECS: u64 = 60;
 
 /// Inputs for a login attempt against one MCP server.
 pub struct LoginConfig<'a> {
@@ -158,8 +162,76 @@ pub async fn login(
             token.refresh_token,
             token.expires_in,
             token.scope,
-            super::store::now_unix(),
+            now_unix(),
         ),
         client_info: Some(client_info),
     })
+}
+
+/// Refresh an access token with the stored refresh token (re-discovering the
+/// token endpoint). Preserves the prior refresh token / scope when the response
+/// omits a rotated value.
+pub async fn refresh(
+    client: &reqwest::Client,
+    config: &LoginConfig<'_>,
+    creds: &StoredCredentials,
+) -> Result<TokenSet, String> {
+    let discovered = discover(client, config).await?;
+    let client_info = creds
+        .client_info
+        .as_ref()
+        .ok_or_else(|| "cannot refresh: no client registration stored".to_string())?;
+    let refresh_token = creds
+        .tokens
+        .refresh_token
+        .as_ref()
+        .ok_or_else(|| "cannot refresh: no refresh token stored".to_string())?;
+    let token = flow::refresh_tokens(
+        client,
+        &discovered.authorization_server.token_endpoint,
+        &client_info.client_id,
+        client_info.client_secret.as_deref(),
+        refresh_token,
+        &discovered.resource,
+    )
+    .await?;
+    Ok(TokenSet::from_response(
+        token.access_token,
+        token
+            .refresh_token
+            .or_else(|| creds.tokens.refresh_token.clone()),
+        token.expires_in,
+        token.scope.or_else(|| creds.tokens.scope.clone()),
+        now_unix(),
+    ))
+}
+
+/// Obtain a valid access token for the server, using the store: a still-valid
+/// cached token is returned as-is (silent reconnect); an expired one is
+/// refreshed; otherwise a full browser login runs. New credentials are
+/// persisted, reusing any existing client registration.
+pub async fn ensure_access_token(
+    client: &reqwest::Client,
+    store: &dyn TokenStore,
+    config: &LoginConfig<'_>,
+    redirect: &dyn RedirectDriver,
+) -> Result<String, String> {
+    if let Some(mut creds) = store.load(config.mcp_url) {
+        if !creds.tokens.is_expired(now_unix(), EXPIRY_SKEW_SECS) {
+            return Ok(creds.tokens.access_token);
+        }
+        if creds.tokens.refresh_token.is_some() {
+            if let Ok(tokens) = refresh(client, config, &creds).await {
+                creds.tokens = tokens;
+                store.save(&creds)?;
+                return Ok(creds.tokens.access_token);
+            }
+            // Refresh failed (revoked/expired refresh token) — fall through to a
+            // fresh login.
+        }
+    }
+    let existing_client_info = store.load(config.mcp_url).and_then(|c| c.client_info);
+    let creds = login(client, config, existing_client_info, redirect).await?;
+    store.save(&creds)?;
+    Ok(creds.tokens.access_token)
 }

--- a/crates/sema-mcp/src/oauth/login.rs
+++ b/crates/sema-mcp/src/oauth/login.rs
@@ -32,6 +32,19 @@ pub struct Discovered {
     pub authorization_server: AuthorizationServerMetadata,
 }
 
+/// Whether two URLs share scheme + host + port (same origin). Used to bind the
+/// RFC 8707 `resource` audience to the actual MCP server being connected to.
+fn same_origin(a: &str, b: &str) -> bool {
+    match (url::Url::parse(a), url::Url::parse(b)) {
+        (Ok(a), Ok(b)) => {
+            a.scheme() == b.scheme()
+                && a.host_str() == b.host_str()
+                && a.port_or_known_default() == b.port_or_known_default()
+        }
+        _ => false,
+    }
+}
+
 /// Walk the metadata chain: PRM (RFC 9728) → AS metadata (RFC 8414/OIDC), and
 /// enforce the PKCE-S256 gate.
 pub async fn discover(
@@ -44,12 +57,31 @@ pub async fn discover(
         config.resource_metadata_url,
     )
     .await?;
+    // RFC 9728: the advertised `resource` must be the server we're connecting to.
+    // Reject a PRM that binds our token's audience to a different origin (a
+    // malicious/mis-hosted resource-metadata document).
+    if !same_origin(config.mcp_url, &prm.resource) {
+        return Err(format!(
+            "protected resource metadata `resource` ({}) does not match the server being \
+             connected to ({}); refusing to authorize",
+            prm.resource, config.mcp_url
+        ));
+    }
     let issuer = prm
         .authorization_servers
         .first()
         .ok_or_else(|| "protected resource metadata lists no authorization servers".to_string())?
         .clone();
     let as_meta = discovery::fetch_authorization_server_metadata(client, &issuer).await?;
+    // RFC 8414 §3.3 (mix-up defense): the metadata's `issuer` MUST equal the
+    // issuer identifier we fetched it for.
+    if as_meta.issuer.trim_end_matches('/') != issuer.trim_end_matches('/') {
+        return Err(format!(
+            "authorization server metadata issuer ({}) does not match the requested issuer ({issuer}); \
+             refusing to authorize",
+            as_meta.issuer
+        ));
+    }
     if !as_meta.supports_pkce_s256() {
         return Err(format!(
             "authorization server `{issuer}` does not advertise PKCE S256 support; refusing to proceed"
@@ -323,7 +355,32 @@ pub async fn reauth_on_challenge(
 
 #[cfg(test)]
 mod tests {
-    use super::union_scopes;
+    use super::{same_origin, union_scopes};
+
+    #[test]
+    fn same_origin_binds_resource_to_the_server() {
+        assert!(same_origin(
+            "https://mcp.example.com/mcp",
+            "https://mcp.example.com"
+        ));
+        assert!(same_origin(
+            "https://mcp.example.com:443/mcp",
+            "https://mcp.example.com"
+        ));
+        // Different host, scheme, or port → not the same origin (mix-up defense).
+        assert!(!same_origin(
+            "https://mcp.example.com/mcp",
+            "https://evil.example.com"
+        ));
+        assert!(!same_origin(
+            "https://mcp.example.com/mcp",
+            "http://mcp.example.com"
+        ));
+        assert!(!same_origin(
+            "https://mcp.example.com/mcp",
+            "https://mcp.example.com:8443"
+        ));
+    }
 
     #[test]
     fn union_scopes_dedupes_and_preserves_order() {

--- a/crates/sema-mcp/src/oauth/login.rs
+++ b/crates/sema-mcp/src/oauth/login.rs
@@ -235,3 +235,108 @@ pub async fn ensure_access_token(
     store.save(&creds)?;
     Ok(creds.tokens.access_token)
 }
+
+/// Order-preserving union of two space-separated scope strings.
+pub fn union_scopes(a: Option<&str>, b: Option<&str>) -> Option<String> {
+    let mut out: Vec<String> = Vec::new();
+    for source in [a, b].into_iter().flatten() {
+        for token in source.split_whitespace() {
+            if !out.iter().any(|s| s == token) {
+                out.push(token.to_string());
+            }
+        }
+    }
+    (!out.is_empty()).then(|| out.join(" "))
+}
+
+/// React to a mid-session auth challenge on an already-connected server and
+/// return a fresh access token to retry with, or `None` if the status isn't an
+/// auth challenge we handle. Handles two cases:
+///
+/// - **401** (token missing/expired): refresh with the stored refresh token, or
+///   fall back to a full login.
+/// - **403 `insufficient_scope`**: step-up — re-authorize requesting the *union*
+///   of the previously-granted scopes and the scopes the challenge demands.
+///
+/// New credentials are persisted. `redirect` is only used when a full
+/// (re-)authorization is required.
+pub async fn reauth_on_challenge(
+    client: &reqwest::Client,
+    store: &dyn TokenStore,
+    url: &str,
+    status: Option<u16>,
+    challenge_header: Option<&str>,
+    preconfigured_client_id: Option<&str>,
+    redirect: &dyn RedirectDriver,
+) -> Result<Option<String>, String> {
+    let challenge = challenge_header
+        .map(discovery::parse_www_authenticate)
+        .unwrap_or_default();
+    let existing = store.load(url);
+    let client_info = existing.as_ref().and_then(|c| c.client_info.clone());
+
+    match status {
+        Some(401) => {
+            // Try a refresh first, then fall back to a full login.
+            if let Some(creds) = &existing {
+                if creds.tokens.refresh_token.is_some() {
+                    let config = LoginConfig {
+                        mcp_url: url,
+                        resource_metadata_url: challenge.resource_metadata.as_deref(),
+                        requested_scope: creds.tokens.scope.as_deref(),
+                        preconfigured_client_id,
+                    };
+                    if let Ok(tokens) = refresh(client, &config, creds).await {
+                        let mut updated = creds.clone();
+                        updated.tokens = tokens;
+                        store.save(&updated)?;
+                        return Ok(Some(updated.tokens.access_token));
+                    }
+                }
+            }
+            let config = LoginConfig {
+                mcp_url: url,
+                resource_metadata_url: challenge.resource_metadata.as_deref(),
+                requested_scope: existing.as_ref().and_then(|c| c.tokens.scope.as_deref()),
+                preconfigured_client_id,
+            };
+            let creds = login(client, &config, client_info, redirect).await?;
+            store.save(&creds)?;
+            Ok(Some(creds.tokens.access_token))
+        }
+        Some(403) if challenge.error.as_deref() == Some("insufficient_scope") => {
+            let prior = existing.as_ref().and_then(|c| c.tokens.scope.clone());
+            let union = union_scopes(prior.as_deref(), challenge.scope.as_deref());
+            let config = LoginConfig {
+                mcp_url: url,
+                resource_metadata_url: challenge.resource_metadata.as_deref(),
+                requested_scope: union.as_deref(),
+                preconfigured_client_id,
+            };
+            let creds = login(client, &config, client_info, redirect).await?;
+            store.save(&creds)?;
+            Ok(Some(creds.tokens.access_token))
+        }
+        _ => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::union_scopes;
+
+    #[test]
+    fn union_scopes_dedupes_and_preserves_order() {
+        assert_eq!(
+            union_scopes(Some("read"), Some("read write")).as_deref(),
+            Some("read write")
+        );
+        assert_eq!(
+            union_scopes(Some("a b"), Some("c b")).as_deref(),
+            Some("a b c")
+        );
+        assert_eq!(union_scopes(None, Some("x")).as_deref(), Some("x"));
+        assert_eq!(union_scopes(Some("y"), None).as_deref(), Some("y"));
+        assert_eq!(union_scopes(None, None), None);
+    }
+}

--- a/crates/sema-mcp/src/oauth/loopback.rs
+++ b/crates/sema-mcp/src/oauth/loopback.rs
@@ -74,18 +74,33 @@ impl LoopbackDriver {
     }
 
     fn wait_for_code(&self, expected_state: &str) -> Result<String, String> {
-        let request = self
-            .server
-            .recv_timeout(self.timeout)
-            .map_err(|e| format!("loopback listener error: {e}"))?
-            .ok_or_else(|| "timed out waiting for the OAuth redirect".to_string())?;
+        let deadline = std::time::Instant::now() + self.timeout;
+        loop {
+            let remaining = deadline
+                .checked_duration_since(std::time::Instant::now())
+                .ok_or_else(|| "timed out waiting for the OAuth redirect".to_string())?;
+            let request = self
+                .server
+                .recv_timeout(remaining)
+                .map_err(|e| format!("loopback listener error: {e}"))?
+                .ok_or_else(|| "timed out waiting for the OAuth redirect".to_string())?;
 
-        let result = parse_callback(request.url(), expected_state);
-        let page = if result.is_ok() { DONE_PAGE } else { FAIL_PAGE };
-        let header = tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"text/html"[..])
-            .expect("static header");
-        let _ = request.respond(tiny_http::Response::from_string(page).with_header(header));
-        result
+            // Browsers hit a loopback listener with stray requests (favicon,
+            // preconnect, "/"). Answer those 404 and keep waiting — only the
+            // authorization-server redirect to /callback carries the code.
+            let path = request.url().split('?').next().unwrap_or("");
+            if path != "/callback" {
+                let _ = request.respond(tiny_http::Response::empty(404));
+                continue;
+            }
+
+            let result = parse_callback(request.url(), expected_state);
+            let page = if result.is_ok() { DONE_PAGE } else { FAIL_PAGE };
+            let header = tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"text/html"[..])
+                .expect("static header");
+            let _ = request.respond(tiny_http::Response::from_string(page).with_header(header));
+            return result;
+        }
     }
 }
 

--- a/crates/sema-mcp/src/oauth/loopback.rs
+++ b/crates/sema-mcp/src/oauth/loopback.rs
@@ -1,0 +1,179 @@
+//! RFC 8252 loopback redirect capture + browser launch.
+//!
+//! Bind a throwaway listener on `127.0.0.1:<ephemeral>` *before* opening the
+//! browser, send the user to the authorization URL, and capture the `code` +
+//! `state` the authorization server redirects back. Loopback (not a custom URI
+//! scheme) is the right choice for a CLI: no OS registration, and the redirect
+//! never leaves the machine, so plain HTTP is correct here.
+
+use std::time::Duration;
+
+use url::Url;
+
+/// The page shown in the browser tab after the redirect is captured.
+const DONE_PAGE: &str =
+    "<!doctype html><html><body style=\"font-family:sans-serif\"><h3>Login complete</h3>\
+     <p>You can close this tab and return to the terminal.</p></body></html>";
+const FAIL_PAGE: &str =
+    "<!doctype html><html><body style=\"font-family:sans-serif\"><h3>Login failed</h3>\
+     <p>Return to the terminal for details.</p></body></html>";
+
+/// Drives the user through the browser leg of the flow and returns the captured
+/// authorization `code`. The real implementation opens the browser + runs the
+/// loopback listener; tests substitute an opener that simulates the AS.
+pub trait RedirectDriver {
+    /// The redirect URI the authorization request must use.
+    fn redirect_uri(&self) -> String;
+    /// Send the user to `authorize_url`, capture the redirect, verify `state`,
+    /// and return the authorization `code`.
+    fn drive(&self, authorize_url: &str, expected_state: &str) -> Result<String, String>;
+}
+
+/// A function that sends the user to an authorization URL (opens the system
+/// browser in production; a test may substitute one that drives the redirect).
+pub type BrowserOpener = Box<dyn Fn(&str) -> Result<(), String> + Send + Sync>;
+
+/// Open the system browser at `url`. Returns `Err` on a headless box (no
+/// browser) so callers can fall back to a manual/device flow.
+pub fn open_browser(url: &str) -> Result<(), String> {
+    webbrowser::open(url).map_err(|e| format!("failed to open a browser: {e}"))
+}
+
+/// A bound loopback listener plus the ability to launch the browser. The
+/// `opener` is injectable so tests can simulate the authorization server
+/// redirecting to the loopback URL without a real browser.
+pub struct LoopbackDriver {
+    server: tiny_http::Server,
+    port: u16,
+    opener: BrowserOpener,
+    timeout: Duration,
+}
+
+impl LoopbackDriver {
+    /// Bind a loopback listener that opens the real system browser.
+    pub fn new(timeout: Duration) -> Result<Self, String> {
+        Self::with_opener(timeout, Box::new(open_browser))
+    }
+
+    /// Bind a loopback listener with a custom opener (tests inject one that
+    /// drives the redirect directly).
+    pub fn with_opener(timeout: Duration, opener: BrowserOpener) -> Result<Self, String> {
+        let server = tiny_http::Server::http("127.0.0.1:0")
+            .map_err(|e| format!("failed to bind loopback listener: {e}"))?;
+        let port = server
+            .server_addr()
+            .to_ip()
+            .ok_or_else(|| "loopback listener has no IP address".to_string())?
+            .port();
+        Ok(Self {
+            server,
+            port,
+            opener,
+            timeout,
+        })
+    }
+
+    fn wait_for_code(&self, expected_state: &str) -> Result<String, String> {
+        let request = self
+            .server
+            .recv_timeout(self.timeout)
+            .map_err(|e| format!("loopback listener error: {e}"))?
+            .ok_or_else(|| "timed out waiting for the OAuth redirect".to_string())?;
+
+        let result = parse_callback(request.url(), expected_state);
+        let page = if result.is_ok() { DONE_PAGE } else { FAIL_PAGE };
+        let header = tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"text/html"[..])
+            .expect("static header");
+        let _ = request.respond(tiny_http::Response::from_string(page).with_header(header));
+        result
+    }
+}
+
+impl RedirectDriver for LoopbackDriver {
+    fn redirect_uri(&self) -> String {
+        format!("http://127.0.0.1:{}/callback", self.port)
+    }
+
+    fn drive(&self, authorize_url: &str, expected_state: &str) -> Result<String, String> {
+        // Open the browser and listen concurrently: the opener triggers the
+        // redirect that `wait_for_code` receives, so they must run in parallel.
+        std::thread::scope(|scope| {
+            let url = authorize_url.to_string();
+            let opener = &self.opener;
+            scope.spawn(move || {
+                let _ = opener(&url);
+            });
+            self.wait_for_code(expected_state)
+        })
+    }
+}
+
+/// Parse the loopback callback request URL, validate `state`, and extract the
+/// authorization `code` (mapping an `error` redirect to an `Err`).
+fn parse_callback(request_url: &str, expected_state: &str) -> Result<String, String> {
+    // `request_url` is a path+query like `/callback?code=…&state=…`; give it a
+    // base so the URL parser can read the query.
+    let url = Url::parse(&format!("http://127.0.0.1{request_url}"))
+        .map_err(|e| format!("could not parse redirect URL: {e}"))?;
+    let pairs: std::collections::HashMap<String, String> = url.query_pairs().into_owned().collect();
+
+    if let Some(err) = pairs.get("error") {
+        let desc = pairs
+            .get("error_description")
+            .map(String::as_str)
+            .unwrap_or("");
+        return Err(format!(
+            "authorization server returned error `{err}`{}",
+            if desc.is_empty() {
+                String::new()
+            } else {
+                format!(": {desc}")
+            }
+        ));
+    }
+
+    let state = pairs
+        .get("state")
+        .ok_or_else(|| "redirect is missing the state parameter".to_string())?;
+    if state != expected_state {
+        return Err("OAuth state mismatch (possible CSRF); aborting login".to_string());
+    }
+    pairs
+        .get("code")
+        .cloned()
+        .ok_or_else(|| "redirect is missing the authorization code".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_code_when_state_matches() {
+        let code = parse_callback("/callback?code=abc123&state=xyz", "xyz").unwrap();
+        assert_eq!(code, "abc123");
+    }
+
+    #[test]
+    fn rejects_state_mismatch() {
+        let err = parse_callback("/callback?code=abc&state=evil", "xyz").unwrap_err();
+        assert!(err.contains("state mismatch"), "got: {err}");
+    }
+
+    #[test]
+    fn surfaces_error_redirect() {
+        let err = parse_callback(
+            "/callback?error=access_denied&error_description=user%20said%20no",
+            "xyz",
+        )
+        .unwrap_err();
+        assert!(err.contains("access_denied"), "got: {err}");
+        assert!(err.contains("user said no"), "got: {err}");
+    }
+
+    #[test]
+    fn missing_code_is_error() {
+        let err = parse_callback("/callback?state=xyz", "xyz").unwrap_err();
+        assert!(err.contains("missing the authorization code"), "got: {err}");
+    }
+}

--- a/crates/sema-mcp/src/oauth/mod.rs
+++ b/crates/sema-mcp/src/oauth/mod.rs
@@ -13,6 +13,7 @@
 //! so nothing depends on `oauth2`'s (reqwest-0.12) built-in client.
 
 pub mod discovery;
+pub mod store;
 
 use oauth2::{CsrfToken, PkceCodeChallenge, PkceCodeVerifier};
 

--- a/crates/sema-mcp/src/oauth/mod.rs
+++ b/crates/sema-mcp/src/oauth/mod.rs
@@ -1,0 +1,61 @@
+//! Native OAuth 2.1 client for authenticated remote (HTTP) MCP servers.
+//!
+//! Implements the MCP authorization spec (`2025-11-25`) — an OAuth 2.1
+//! Authorization-Code + PKCE flow over an RFC 8252 loopback redirect, with a
+//! device-authorization (RFC 8628) alternative and a print-URL floor for
+//! headless boxes. The MCP server is only the OAuth *resource server*; a
+//! separate *authorization server* (discovered via RFC 9728 / RFC 8414) issues
+//! tokens. See `docs/plans/2026-06-21-mcp-client-spike.md`.
+//!
+//! Design (Option B, hand-roll + `oauth2`): the `oauth2` crate supplies the
+//! security-sensitive PKCE and CSRF primitives; the plain form-encoded token /
+//! discovery / registration HTTP is driven directly with our own reqwest client
+//! so nothing depends on `oauth2`'s (reqwest-0.12) built-in client.
+
+use oauth2::{CsrfToken, PkceCodeChallenge, PkceCodeVerifier};
+
+/// A freshly generated PKCE pair plus a CSRF `state`, produced by the `oauth2`
+/// crate so we never hand-roll the challenge derivation.
+pub struct PkceSession {
+    pub challenge: String,
+    pub challenge_method: String,
+    pub verifier: String,
+    pub state: String,
+}
+
+/// Generate a PKCE S256 challenge/verifier and a random CSRF `state`.
+pub fn new_pkce_session() -> PkceSession {
+    let (challenge, verifier) = PkceCodeChallenge::new_random_sha256();
+    PkceSession {
+        challenge: challenge.as_str().to_string(),
+        // `new_random_sha256` always yields the S256 method.
+        challenge_method: "S256".to_string(),
+        verifier: verifier.secret().to_string(),
+        state: CsrfToken::new_random().secret().to_string(),
+    }
+}
+
+/// Re-wrap a stored verifier string (kept only for the life of one in-flight
+/// login) as the `oauth2` newtype, for symmetry with `new_pkce_session`.
+pub fn verifier(secret: impl Into<String>) -> PkceCodeVerifier {
+    PkceCodeVerifier::new(secret.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pkce_session_is_well_formed() {
+        let s = new_pkce_session();
+        assert_eq!(s.challenge_method, "S256");
+        // RFC 7636: the verifier is 43–128 chars from the unreserved set.
+        assert!((43..=128).contains(&s.verifier.len()), "verifier len {}", s.verifier.len());
+        assert!(!s.challenge.is_empty());
+        assert!(!s.state.is_empty());
+        // Two sessions must not collide (random verifier + state).
+        let t = new_pkce_session();
+        assert_ne!(s.verifier, t.verifier);
+        assert_ne!(s.state, t.state);
+    }
+}

--- a/crates/sema-mcp/src/oauth/mod.rs
+++ b/crates/sema-mcp/src/oauth/mod.rs
@@ -12,6 +12,8 @@
 //! discovery / registration HTTP is driven directly with our own reqwest client
 //! so nothing depends on `oauth2`'s (reqwest-0.12) built-in client.
 
+pub mod discovery;
+
 use oauth2::{CsrfToken, PkceCodeChallenge, PkceCodeVerifier};
 
 /// A freshly generated PKCE pair plus a CSRF `state`, produced by the `oauth2`

--- a/crates/sema-mcp/src/oauth/mod.rs
+++ b/crates/sema-mcp/src/oauth/mod.rs
@@ -13,6 +13,9 @@
 //! so nothing depends on `oauth2`'s (reqwest-0.12) built-in client.
 
 pub mod discovery;
+pub mod flow;
+pub mod login;
+pub mod loopback;
 pub mod store;
 
 use oauth2::{CsrfToken, PkceCodeChallenge, PkceCodeVerifier};
@@ -53,7 +56,11 @@ mod tests {
         let s = new_pkce_session();
         assert_eq!(s.challenge_method, "S256");
         // RFC 7636: the verifier is 43–128 chars from the unreserved set.
-        assert!((43..=128).contains(&s.verifier.len()), "verifier len {}", s.verifier.len());
+        assert!(
+            (43..=128).contains(&s.verifier.len()),
+            "verifier len {}",
+            s.verifier.len()
+        );
         assert!(!s.challenge.is_empty());
         assert!(!s.state.is_empty());
         // Two sessions must not collide (random verifier + state).

--- a/crates/sema-mcp/src/oauth/mod.rs
+++ b/crates/sema-mcp/src/oauth/mod.rs
@@ -12,6 +12,7 @@
 //! discovery / registration HTTP is driven directly with our own reqwest client
 //! so nothing depends on `oauth2`'s (reqwest-0.12) built-in client.
 
+pub mod device;
 pub mod discovery;
 pub mod flow;
 pub mod login;

--- a/crates/sema-mcp/src/oauth/store.rs
+++ b/crates/sema-mcp/src/oauth/store.rs
@@ -237,6 +237,15 @@ fn keychain_available() -> bool {
 /// file fallback (with a one-time visible warning, since tokens then sit in a
 /// permission-restricted plaintext file).
 pub fn default_store() -> Box<dyn TokenStore> {
+    // Explicit override via `SEMA_MCP_TOKEN_STORE=file|keychain`. `file` is the
+    // handy escape hatch for dev/CI/headless: it skips the keychain entirely,
+    // avoiding repeated macOS Keychain prompts — an ad-hoc-signed dev binary gets
+    // a new code identity on every rebuild, so "Always Allow" never sticks.
+    match std::env::var("SEMA_MCP_TOKEN_STORE").ok().as_deref() {
+        Some("file") => return Box::new(FileStore::new(default_file_path())),
+        Some("keychain") => return Box::new(KeychainStore::new()),
+        _ => {}
+    }
     if keychain_available() {
         Box::new(KeychainStore::new())
     } else {

--- a/crates/sema-mcp/src/oauth/store.rs
+++ b/crates/sema-mcp/src/oauth/store.rs
@@ -1,0 +1,338 @@
+//! Persistent MCP credential store, keyed by canonical server URL.
+//!
+//! Remote MCP auth is Sema's first persistent secret store. Two backends behind
+//! one [`TokenStore`] trait: the OS keychain (primary) and a `0600` JSON file
+//! (fallback for headless Linux/CI where no keychain is reachable). Stored per
+//! server: the token set, the DCR client registration (so we don't re-register
+//! every launch), and the `server_url` itself — validated on read so a stale
+//! entry from a changed endpoint is ignored and re-auth runs.
+
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+/// Current wall-clock time in unix seconds (for token-expiry math).
+pub fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// An access/refresh token set. `expires_at` is absolute unix seconds, computed
+/// from `expires_in` at receipt so expiry survives a restart.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TokenSet {
+    pub access_token: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub refresh_token: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub expires_at: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub scope: Option<String>,
+}
+
+impl TokenSet {
+    /// Build from a token-endpoint response's fields at receipt time `now`.
+    pub fn from_response(
+        access_token: String,
+        refresh_token: Option<String>,
+        expires_in: Option<u64>,
+        scope: Option<String>,
+        now: u64,
+    ) -> Self {
+        Self {
+            access_token,
+            refresh_token,
+            expires_at: expires_in.map(|secs| now.saturating_add(secs)),
+            scope,
+        }
+    }
+
+    /// Whether the access token is expired (or within `skew` seconds of it).
+    /// A token with no expiry information is treated as non-expiring.
+    pub fn is_expired(&self, now: u64, skew: u64) -> bool {
+        match self.expires_at {
+            Some(exp) => now.saturating_add(skew) >= exp,
+            None => false,
+        }
+    }
+}
+
+/// A registered OAuth client (from Dynamic Client Registration or configured).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClientInfo {
+    pub client_id: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub client_secret: Option<String>,
+}
+
+/// Everything persisted for one MCP server.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StoredCredentials {
+    pub server_url: String,
+    pub tokens: TokenSet,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub client_info: Option<ClientInfo>,
+}
+
+/// A credential backend. Implementations MUST validate that a loaded entry's
+/// `server_url` matches the requested key.
+pub trait TokenStore {
+    fn load(&self, server_url: &str) -> Option<StoredCredentials>;
+    fn save(&self, creds: &StoredCredentials) -> Result<(), String>;
+    fn delete(&self, server_url: &str) -> Result<(), String>;
+}
+
+// ---------------------------------------------------------------------------
+// File backend (0600 JSON), keyed by server URL
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct FileDoc {
+    #[serde(default)]
+    servers: std::collections::BTreeMap<String, StoredCredentials>,
+}
+
+pub struct FileStore {
+    path: PathBuf,
+}
+
+impl FileStore {
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    pub fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+
+    fn read_doc(&self) -> FileDoc {
+        match std::fs::read_to_string(&self.path) {
+            Ok(text) => serde_json::from_str(&text).unwrap_or_default(),
+            Err(_) => FileDoc::default(),
+        }
+    }
+
+    fn write_doc(&self, doc: &FileDoc) -> Result<(), String> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("failed to create token store dir: {e}"))?;
+        }
+        let json = serde_json::to_string_pretty(doc)
+            .map_err(|e| format!("failed to encode token store: {e}"))?;
+        std::fs::write(&self.path, json)
+            .map_err(|e| format!("failed to write token store: {e}"))?;
+        // Restrict perms after the write (mode-on-create doesn't apply to an
+        // existing file). No-op on Windows, where we rely on the user profile ACL.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&self.path, std::fs::Permissions::from_mode(0o600))
+                .map_err(|e| format!("failed to secure token store perms: {e}"))?;
+        }
+        Ok(())
+    }
+}
+
+impl TokenStore for FileStore {
+    fn load(&self, server_url: &str) -> Option<StoredCredentials> {
+        self.read_doc()
+            .servers
+            .get(server_url)
+            .filter(|creds| creds.server_url == server_url)
+            .cloned()
+    }
+
+    fn save(&self, creds: &StoredCredentials) -> Result<(), String> {
+        let mut doc = self.read_doc();
+        doc.servers
+            .insert(creds.server_url.clone(), creds.clone());
+        self.write_doc(&doc)
+    }
+
+    fn delete(&self, server_url: &str) -> Result<(), String> {
+        let mut doc = self.read_doc();
+        doc.servers.remove(server_url);
+        self.write_doc(&doc)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Keychain backend
+// ---------------------------------------------------------------------------
+
+const KEYCHAIN_SERVICE: &str = "sema-mcp";
+
+pub struct KeychainStore;
+
+impl KeychainStore {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for KeychainStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TokenStore for KeychainStore {
+    fn load(&self, server_url: &str) -> Option<StoredCredentials> {
+        let entry = keyring::Entry::new(KEYCHAIN_SERVICE, server_url).ok()?;
+        let json = entry.get_password().ok()?;
+        serde_json::from_str::<StoredCredentials>(&json)
+            .ok()
+            .filter(|creds| creds.server_url == server_url)
+    }
+
+    fn save(&self, creds: &StoredCredentials) -> Result<(), String> {
+        let entry = keyring::Entry::new(KEYCHAIN_SERVICE, &creds.server_url)
+            .map_err(|e| format!("keychain entry error: {e}"))?;
+        let json =
+            serde_json::to_string(creds).map_err(|e| format!("failed to encode credentials: {e}"))?;
+        entry
+            .set_password(&json)
+            .map_err(|e| format!("keychain write error: {e}"))
+    }
+
+    fn delete(&self, server_url: &str) -> Result<(), String> {
+        let entry = keyring::Entry::new(KEYCHAIN_SERVICE, server_url)
+            .map_err(|e| format!("keychain entry error: {e}"))?;
+        match entry.delete_credential() {
+            Ok(()) => Ok(()),
+            Err(keyring::Error::NoEntry) => Ok(()),
+            Err(e) => Err(format!("keychain delete error: {e}")),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Default store selection
+// ---------------------------------------------------------------------------
+
+/// The default on-disk path for the file fallback: `<config-dir>/sema/mcp-auth.json`
+/// (honors `$XDG_CONFIG_HOME` on Linux).
+pub fn default_file_path() -> PathBuf {
+    if let Some(dirs) = directories::BaseDirs::new() {
+        dirs.config_dir().join("sema").join("mcp-auth.json")
+    } else {
+        PathBuf::from(".sema-mcp-auth.json")
+    }
+}
+
+/// Probe whether the OS keychain is usable in this environment by round-tripping
+/// a throwaway entry.
+fn keychain_available() -> bool {
+    let Ok(entry) = keyring::Entry::new(KEYCHAIN_SERVICE, "__sema_probe__") else {
+        return false;
+    };
+    let ok = entry.set_password("probe").is_ok() && entry.get_password().is_ok();
+    let _ = entry.delete_credential();
+    ok
+}
+
+/// Pick the credential store: OS keychain when reachable, otherwise the `0600`
+/// file fallback (with a one-time visible warning, since tokens then sit in a
+/// permission-restricted plaintext file).
+pub fn default_store() -> Box<dyn TokenStore> {
+    if keychain_available() {
+        Box::new(KeychainStore::new())
+    } else {
+        let path = default_file_path();
+        eprintln!(
+            "sema: OS keychain unavailable; storing MCP tokens in {} (file perms 0600, plaintext).",
+            path.display()
+        );
+        Box::new(FileStore::new(path))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    fn temp_path() -> PathBuf {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+        std::env::temp_dir().join(format!(
+            "sema-mcp-store-{}-{}/mcp-auth.json",
+            std::process::id(),
+            n
+        ))
+    }
+
+    fn sample(url: &str) -> StoredCredentials {
+        StoredCredentials {
+            server_url: url.to_string(),
+            tokens: TokenSet::from_response(
+                "access-1".into(),
+                Some("refresh-1".into()),
+                Some(3600),
+                Some("files:read".into()),
+                1_000,
+            ),
+            client_info: Some(ClientInfo {
+                client_id: "client-1".into(),
+                client_secret: None,
+            }),
+        }
+    }
+
+    #[test]
+    fn file_store_round_trips() {
+        let store = FileStore::new(temp_path());
+        let creds = sample("https://mcp.example.com/mcp");
+        store.save(&creds).unwrap();
+        assert_eq!(store.load("https://mcp.example.com/mcp"), Some(creds));
+        assert_eq!(store.load("https://other.example.com/mcp"), None);
+    }
+
+    #[test]
+    fn file_store_delete_removes_entry() {
+        let store = FileStore::new(temp_path());
+        let creds = sample("https://mcp.example.com/mcp");
+        store.save(&creds).unwrap();
+        store.delete("https://mcp.example.com/mcp").unwrap();
+        assert_eq!(store.load("https://mcp.example.com/mcp"), None);
+        // Deleting a missing entry is a no-op, not an error.
+        store.delete("https://mcp.example.com/mcp").unwrap();
+    }
+
+    #[test]
+    fn file_store_keeps_multiple_servers_isolated() {
+        let store = FileStore::new(temp_path());
+        let a = sample("https://a.example.com/mcp");
+        let b = sample("https://b.example.com/mcp");
+        store.save(&a).unwrap();
+        store.save(&b).unwrap();
+        assert_eq!(store.load("https://a.example.com/mcp"), Some(a));
+        assert_eq!(store.load("https://b.example.com/mcp"), Some(b));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn file_store_is_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        let store = FileStore::new(temp_path());
+        store.save(&sample("https://mcp.example.com/mcp")).unwrap();
+        let mode = std::fs::metadata(store.path()).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "token file must be owner-only");
+    }
+
+    #[test]
+    fn token_expiry_math() {
+        let mut t = TokenSet::from_response("a".into(), None, Some(3600), None, 1_000);
+        assert_eq!(t.expires_at, Some(4_600));
+        assert!(!t.is_expired(4_000, 60));
+        assert!(t.is_expired(4_600, 0));
+        // within the skew window counts as expired
+        assert!(t.is_expired(4_570, 60));
+        // no expiry info => never expired
+        t.expires_at = None;
+        assert!(!t.is_expired(u64::MAX, 0));
+    }
+}

--- a/crates/sema-mcp/src/oauth/store.rs
+++ b/crates/sema-mcp/src/oauth/store.rs
@@ -108,10 +108,21 @@ impl FileStore {
         &self.path
     }
 
-    fn read_doc(&self) -> FileDoc {
+    /// Read the store. A missing file is an empty store; a file that exists but
+    /// fails to parse is an ERROR (not silently discarded) so a corrupt or
+    /// partially-written file never causes the next `save` to wipe every other
+    /// server's credentials.
+    fn read_doc(&self) -> Result<FileDoc, String> {
         match std::fs::read_to_string(&self.path) {
-            Ok(text) => serde_json::from_str(&text).unwrap_or_default(),
-            Err(_) => FileDoc::default(),
+            Ok(text) => serde_json::from_str(&text).map_err(|e| {
+                format!(
+                    "MCP token store at {} is corrupt ({e}); refusing to overwrite it \
+                     (fix or delete the file, then re-authenticate)",
+                    self.path.display()
+                )
+            }),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(FileDoc::default()),
+            Err(e) => Err(format!("failed to read token store: {e}")),
         }
     }
 
@@ -122,15 +133,34 @@ impl FileStore {
         }
         let json = serde_json::to_string_pretty(doc)
             .map_err(|e| format!("failed to encode token store: {e}"))?;
-        std::fs::write(&self.path, json)
-            .map_err(|e| format!("failed to write token store: {e}"))?;
-        // Restrict perms after the write (mode-on-create doesn't apply to an
-        // existing file). No-op on Windows, where we rely on the user profile ACL.
+
+        // Write to a sibling temp file created 0600 (never a world-readable
+        // window), then atomically rename over the target — which also fixes an
+        // existing wrongly-permissioned file. On Windows we rely on the user
+        // profile ACL and just write in place.
         #[cfg(unix)]
         {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&self.path, std::fs::Permissions::from_mode(0o600))
-                .map_err(|e| format!("failed to secure token store perms: {e}"))?;
+            use std::io::Write;
+            use std::os::unix::fs::OpenOptionsExt;
+            let tmp = self.path.with_extension("json.tmp");
+            let mut file = std::fs::OpenOptions::new()
+                .mode(0o600)
+                .create(true)
+                .truncate(true)
+                .write(true)
+                .open(&tmp)
+                .map_err(|e| format!("failed to open temp token store: {e}"))?;
+            file.write_all(json.as_bytes())
+                .map_err(|e| format!("failed to write token store: {e}"))?;
+            file.sync_all().ok();
+            drop(file);
+            std::fs::rename(&tmp, &self.path)
+                .map_err(|e| format!("failed to replace token store: {e}"))?;
+        }
+        #[cfg(not(unix))]
+        {
+            std::fs::write(&self.path, json)
+                .map_err(|e| format!("failed to write token store: {e}"))?;
         }
         Ok(())
     }
@@ -139,6 +169,7 @@ impl FileStore {
 impl TokenStore for FileStore {
     fn load(&self, server_url: &str) -> Option<StoredCredentials> {
         self.read_doc()
+            .ok()?
             .servers
             .get(server_url)
             .filter(|creds| creds.server_url == server_url)
@@ -146,13 +177,13 @@ impl TokenStore for FileStore {
     }
 
     fn save(&self, creds: &StoredCredentials) -> Result<(), String> {
-        let mut doc = self.read_doc();
+        let mut doc = self.read_doc()?;
         doc.servers.insert(creds.server_url.clone(), creds.clone());
         self.write_doc(&doc)
     }
 
     fn delete(&self, server_url: &str) -> Result<(), String> {
-        let mut doc = self.read_doc();
+        let mut doc = self.read_doc()?;
         doc.servers.remove(server_url);
         self.write_doc(&doc)
     }
@@ -297,6 +328,22 @@ mod tests {
         store.save(&creds).unwrap();
         assert_eq!(store.load("https://mcp.example.com/mcp"), Some(creds));
         assert_eq!(store.load("https://other.example.com/mcp"), None);
+    }
+
+    #[test]
+    fn corrupt_store_is_not_clobbered_on_save() {
+        let store = FileStore::new(temp_path());
+        std::fs::create_dir_all(store.path().parent().unwrap()).unwrap();
+        std::fs::write(store.path(), "{ not valid json").unwrap();
+        // save must refuse (returning Err) rather than wipe the file…
+        assert!(store.save(&sample("https://x.example.com/mcp")).is_err());
+        // …and the file must be untouched.
+        assert_eq!(
+            std::fs::read_to_string(store.path()).unwrap(),
+            "{ not valid json"
+        );
+        // load of a corrupt store yields None (→ re-auth), never a panic.
+        assert!(store.load("https://x.example.com/mcp").is_none());
     }
 
     #[test]

--- a/crates/sema-mcp/src/oauth/store.rs
+++ b/crates/sema-mcp/src/oauth/store.rs
@@ -147,8 +147,7 @@ impl TokenStore for FileStore {
 
     fn save(&self, creds: &StoredCredentials) -> Result<(), String> {
         let mut doc = self.read_doc();
-        doc.servers
-            .insert(creds.server_url.clone(), creds.clone());
+        doc.servers.insert(creds.server_url.clone(), creds.clone());
         self.write_doc(&doc)
     }
 
@@ -191,8 +190,8 @@ impl TokenStore for KeychainStore {
     fn save(&self, creds: &StoredCredentials) -> Result<(), String> {
         let entry = keyring::Entry::new(KEYCHAIN_SERVICE, &creds.server_url)
             .map_err(|e| format!("keychain entry error: {e}"))?;
-        let json =
-            serde_json::to_string(creds).map_err(|e| format!("failed to encode credentials: {e}"))?;
+        let json = serde_json::to_string(creds)
+            .map_err(|e| format!("failed to encode credentials: {e}"))?;
         entry
             .set_password(&json)
             .map_err(|e| format!("keychain write error: {e}"))
@@ -319,7 +318,10 @@ mod tests {
         use std::os::unix::fs::PermissionsExt;
         let store = FileStore::new(temp_path());
         store.save(&sample("https://mcp.example.com/mcp")).unwrap();
-        let mode = std::fs::metadata(store.path()).unwrap().permissions().mode();
+        let mode = std::fs::metadata(store.path())
+            .unwrap()
+            .permissions()
+            .mode();
         assert_eq!(mode & 0o777, 0o600, "token file must be owner-only");
     }
 

--- a/crates/sema-mcp/src/protocol.rs
+++ b/crates/sema-mcp/src/protocol.rs
@@ -4,7 +4,9 @@ use serde::{Deserialize, Serialize};
 pub struct JsonRpcRequest {
     pub jsonrpc: String,
     pub method: String,
-    #[serde(default)]
+    // Omit `params` entirely when absent rather than sending `"params":null` —
+    // some servers (e.g. Asana) reject an explicit null with `400`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub params: Option<serde_json::Value>,
     pub id: Option<serde_json::Value>,
 }
@@ -59,4 +61,38 @@ pub struct CallToolResult {
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum ToolContent {
     Text { text: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_omits_null_params() {
+        // A request with no params must NOT serialize `"params":null` — some
+        // servers (Asana) reject that with a 400.
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            method: "tools/list".to_string(),
+            params: None,
+            id: Some(serde_json::json!(2)),
+        };
+        let encoded = serde_json::to_string(&req).unwrap();
+        assert!(
+            !encoded.contains("params"),
+            "params must be omitted when None: {encoded}"
+        );
+    }
+
+    #[test]
+    fn request_keeps_present_params() {
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            method: "tools/call".to_string(),
+            params: Some(serde_json::json!({ "name": "x" })),
+            id: Some(serde_json::json!(1)),
+        };
+        let encoded = serde_json::to_string(&req).unwrap();
+        assert!(encoded.contains("\"params\""), "got: {encoded}");
+    }
 }

--- a/crates/sema-mcp/src/protocol.rs
+++ b/crates/sema-mcp/src/protocol.rs
@@ -9,7 +9,7 @@ pub struct JsonRpcRequest {
     pub id: Option<serde_json::Value>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JsonRpcResponse {
     pub jsonrpc: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -40,8 +40,11 @@ impl JsonRpcError {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Tool {
     pub name: String,
+    // MCP tool descriptions are optional on the wire; default to empty so a server
+    // that omits one still decodes rather than failing the whole `tools/list`.
+    #[serde(default)]
     pub description: String,
-    #[serde(rename = "inputSchema")]
+    #[serde(rename = "inputSchema", default)]
     pub input_schema: serde_json::Value,
 }
 

--- a/crates/sema-mcp/src/protocol.rs
+++ b/crates/sema-mcp/src/protocol.rs
@@ -19,6 +19,21 @@ pub struct JsonRpcResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<JsonRpcError>,
     pub id: Option<serde_json::Value>,
+    // Present only on server→client *requests*/notifications the client may
+    // receive interleaved on a shared stream. Captured so the client can tell a
+    // request (has `method`) from its own response and never mis-correlate a
+    // colliding id.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub method: Option<String>,
+}
+
+impl JsonRpcResponse {
+    /// True only for a genuine response to one of our requests: it must carry a
+    /// `result` or `error` and must NOT be a server-initiated request/notification
+    /// (which would carry `method`).
+    pub fn is_response(&self) -> bool {
+        self.method.is_none() && (self.result.is_some() || self.error.is_some())
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -82,6 +97,21 @@ mod tests {
             !encoded.contains("params"),
             "params must be omitted when None: {encoded}"
         );
+    }
+
+    #[test]
+    fn is_response_distinguishes_replies_from_server_requests() {
+        let parse = |s: &str| serde_json::from_str::<JsonRpcResponse>(s).unwrap();
+        // A server->client request/notification with a colliding id is NOT our response.
+        assert!(!parse(r#"{"jsonrpc":"2.0","method":"ping","id":3}"#).is_response());
+        assert!(!parse(r#"{"jsonrpc":"2.0","method":"notifications/progress"}"#).is_response());
+        // A real result or error IS our response.
+        assert!(parse(r#"{"jsonrpc":"2.0","result":{"ok":true},"id":3}"#).is_response());
+        assert!(
+            parse(r#"{"jsonrpc":"2.0","error":{"code":-1,"message":"x"},"id":3}"#).is_response()
+        );
+        // Neither result nor error → not a usable response.
+        assert!(!parse(r#"{"jsonrpc":"2.0","id":3}"#).is_response());
     }
 
     #[test]

--- a/crates/sema-mcp/src/server.rs
+++ b/crates/sema-mcp/src/server.rs
@@ -99,6 +99,7 @@ where
                             format!("Internal error: failed to serialize response: {e}"),
                         )),
                         id: resp.id.clone(),
+                        method: None,
                     };
                     // The fallback is a tiny, statically-shaped struct that should
                     // never fail to serialize; if it somehow does, emit a
@@ -136,6 +137,7 @@ where
         result: None,
         error: Some(JsonRpcError::new(-32700, format!("Parse error: {message}"))),
         id: None,
+        method: None,
     };
     if let Ok(s) = serde_json::to_string(&err_resp) {
         writer.write_all(format!("{s}\n").as_bytes()).await.ok();
@@ -209,12 +211,14 @@ fn handle_request(
             result: Some(res),
             error: None,
             id,
+            method: None,
         }),
         Err(err) => Some(JsonRpcResponse {
             jsonrpc: "2.0".to_string(),
             result: None,
             error: Some(err),
             id,
+            method: None,
         }),
     }
 }

--- a/crates/sema-mcp/tests/mcp_client_test.rs
+++ b/crates/sema-mcp/tests/mcp_client_test.rs
@@ -1,0 +1,118 @@
+//! Stdio MCP client tests. The scripted Python server deliberately (a) refuses
+//! `tools/list` until it has received `notifications/initialized`, and (b)
+//! interleaves an id-less notification ahead of each response — so a client that
+//! skips the initialized notification or blindly reads one line per request
+//! fails here.
+
+use sema_mcp::{McpClient, McpClientConfig};
+use serde_json::json;
+
+/// A minimal, correct-ish MCP stdio server used across the tests below.
+const ECHO_SERVER: &str = r#"
+import json
+import sys
+
+initialized = False
+
+def send(msg):
+    sys.stdout.write(json.dumps(msg) + "\n")
+    sys.stdout.flush()
+
+def note(method):
+    # An id-less JSON-RPC notification; a correct client must skip it while
+    # waiting for its correlated response.
+    send({"jsonrpc": "2.0", "method": method, "params": {}})
+
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    request = json.loads(line)
+    method = request.get("method")
+    request_id = request.get("id")
+
+    # Notifications carry no id and expect no response.
+    if request_id is None:
+        if method == "notifications/initialized":
+            initialized = True
+        continue
+
+    if method == "initialize":
+        note("notifications/message")  # interleaved chatter before the reply
+        send({"jsonrpc": "2.0", "id": request_id, "result": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "serverInfo": {"name": "test-server", "version": "1.0"},
+        }})
+    elif method == "tools/list":
+        if not initialized:
+            send({"jsonrpc": "2.0", "id": request_id,
+                  "error": {"code": -32002, "message": "not initialized"}})
+        else:
+            note("notifications/progress")
+            send({"jsonrpc": "2.0", "id": request_id, "result": {"tools": [
+                {"name": "echo", "description": "Echo a string",
+                 "inputSchema": {"type": "object",
+                                 "properties": {"text": {"type": "string"}},
+                                 "required": ["text"]}},
+            ]}})
+    elif method == "tools/call":
+        args = request.get("params", {}).get("arguments", {})
+        send({"jsonrpc": "2.0", "id": request_id, "result": {
+            "content": [{"type": "text", "text": args.get("text", "")}],
+            "isError": False,
+        }})
+    else:
+        send({"jsonrpc": "2.0", "id": request_id,
+              "error": {"code": -32601, "message": "Method not found"}})
+"#;
+
+fn echo_config() -> McpClientConfig {
+    let mut config = McpClientConfig::new("python3");
+    config.args = vec!["-c".to_string(), ECHO_SERVER.to_string()];
+    config
+}
+
+#[tokio::test]
+async fn test_stdio_client_initializes_lists_and_calls() {
+    let mut client = McpClient::connect(echo_config())
+        .await
+        .expect("failed to start MCP stdio client");
+
+    let init = client
+        .initialize()
+        .await
+        .expect("initialize request should succeed");
+    assert_eq!(init["serverInfo"]["name"], "test-server");
+
+    // Succeeds only because initialize() also sent notifications/initialized and
+    // the client skipped the interleaved notifications while correlating.
+    let tools = client
+        .list_tools()
+        .await
+        .expect("tools/list should succeed after initialized notification");
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].name, "echo");
+
+    let result = client
+        .call_tool("echo", json!({ "text": "hello" }))
+        .await
+        .expect("tools/call should succeed");
+    assert_eq!(result["content"][0]["text"], "hello");
+    assert_eq!(result["isError"], false);
+
+    client.close().await.expect("closing should succeed");
+}
+
+#[tokio::test]
+async fn test_stdio_client_reports_missing_command() {
+    let err =
+        match McpClient::connect(McpClientConfig::new("definitely-not-a-real-binary-xyz")).await {
+            Ok(_) => panic!("connecting to a missing binary should fail"),
+            Err(err) => err,
+        };
+    assert!(
+        err.contains("failed to spawn MCP server process"),
+        "unexpected error: {err}"
+    );
+}

--- a/crates/sema-mcp/tests/mcp_http_client_test.rs
+++ b/crates/sema-mcp/tests/mcp_http_client_test.rs
@@ -1,0 +1,190 @@
+//! Streamable-HTTP MCP client tests. A scripted Python server exercises the
+//! wire contract the transport must satisfy: it assigns an `Mcp-Session-Id` on
+//! the `initialize` response and **rejects** any later request that fails to
+//! echo it or the negotiated `MCP-Protocol-Version` (so a client that drops
+//! either header fails here); it returns `tools/list` as a single JSON object
+//! but `tools/call` as an SSE stream with an interleaved notification ahead of
+//! the real response (so a client that mishandles SSE or fails to skip
+//! unrelated messages fails here); and it echoes the caller's `Authorization`
+//! header back through the tool result (so bring-your-own-token is verified).
+
+use std::io::{BufRead, BufReader};
+use std::process::{Child, ChildStdout, Command, Stdio};
+
+use sema_mcp::{McpClient, McpHttpConfig};
+use serde_json::json;
+
+const HTTP_SERVER: &str = r#"
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+SESSION = "sema-test-session"
+PROTOCOL = "2025-11-25"
+state = {"auth": None}
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *args):
+        pass  # keep the test output clean
+
+    def _read_body(self):
+        length = int(self.headers.get("Content-Length", 0))
+        raw = self.rfile.read(length) if length else b""
+        return json.loads(raw) if raw else {}
+
+    def _json(self, payload, extra_headers=None):
+        data = json.dumps(payload).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        for k, v in (extra_headers or {}).items():
+            self.send_header(k, v)
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _bad(self, code):
+        self.send_response(code)
+        self.end_headers()
+
+    def do_DELETE(self):
+        # Client-driven session termination.
+        self.send_response(200)
+        self.end_headers()
+
+    def do_POST(self):
+        msg = self._read_body()
+        method = msg.get("method")
+        rid = msg.get("id")
+
+        # Notifications carry no id and are accepted with 202; they must still
+        # carry the session id once one has been assigned.
+        if rid is None:
+            if self.headers.get("Mcp-Session-Id") != SESSION:
+                return self._bad(400)
+            self.send_response(202)
+            self.end_headers()
+            return
+
+        if method == "initialize":
+            state["auth"] = self.headers.get("Authorization")
+            return self._json(
+                {"jsonrpc": "2.0", "id": rid, "result": {
+                    "protocolVersion": PROTOCOL,
+                    "capabilities": {},
+                    "serverInfo": {"name": "http-test-server", "version": "1.0"}}},
+                extra_headers={"Mcp-Session-Id": SESSION})
+
+        # Every post-init request MUST echo the session id + protocol version.
+        if self.headers.get("Mcp-Session-Id") != SESSION:
+            return self._bad(400)
+        if self.headers.get("MCP-Protocol-Version") != PROTOCOL:
+            return self._bad(400)
+
+        if method == "tools/list":
+            return self._json({"jsonrpc": "2.0", "id": rid, "result": {"tools": [
+                {"name": "echo", "description": "Echo a string",
+                 "inputSchema": {"type": "object",
+                                 "properties": {"text": {"type": "string"}},
+                                 "required": ["text"]}}]}})
+
+        if method == "tools/call":
+            args = msg.get("params", {}).get("arguments", {})
+            text = args.get("text", "")
+            payload = {"jsonrpc": "2.0", "id": rid, "result": {
+                "content": [{"type": "text", "text": text + "|auth=" + str(state["auth"])}],
+                "isError": False}}
+            note = {"jsonrpc": "2.0", "method": "notifications/progress", "params": {}}
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.end_headers()
+            self.wfile.write(b": priming\n\n")
+            self.wfile.write(("data: " + json.dumps(note) + "\n\n").encode())
+            self.wfile.write(("data: " + json.dumps(payload) + "\n\n").encode())
+            self.wfile.flush()
+            return
+
+        return self._json({"jsonrpc": "2.0", "id": rid,
+                           "error": {"code": -32601, "message": "Method not found"}})
+
+server = HTTPServer(("127.0.0.1", 0), Handler)
+print(server.server_address[1], flush=True)
+server.serve_forever()
+"#;
+
+/// Owns the spawned server; killing it on drop keeps the BufReader (and thus the
+/// stdout pipe) alive so the server never takes SIGPIPE mid-test.
+struct ServerGuard {
+    child: Child,
+    _stdout: BufReader<ChildStdout>,
+}
+
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn start_server() -> (ServerGuard, u16) {
+    let mut child = Command::new("python3")
+        .args(["-c", HTTP_SERVER])
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn python3 HTTP MCP server");
+    let stdout = child.stdout.take().expect("server stdout");
+    let mut reader = BufReader::new(stdout);
+    let mut line = String::new();
+    reader
+        .read_line(&mut line)
+        .expect("failed to read server port line");
+    let port: u16 = line.trim().parse().expect("server should print its port");
+    (
+        ServerGuard {
+            child,
+            _stdout: reader,
+        },
+        port,
+    )
+}
+
+#[tokio::test]
+async fn test_http_client_streamable_transport() {
+    let (_server, port) = start_server();
+    let url = format!("http://127.0.0.1:{port}/mcp");
+
+    let mut config = McpHttpConfig::new(url);
+    config
+        .headers
+        .insert("Authorization".to_string(), "Bearer test-token".to_string());
+
+    let mut client = McpClient::connect_http(config)
+        .await
+        .expect("failed to prepare HTTP MCP client");
+
+    let init = client
+        .initialize()
+        .await
+        .expect("initialize over HTTP should succeed");
+    assert_eq!(init["serverInfo"]["name"], "http-test-server");
+    assert_eq!(init["protocolVersion"], "2025-11-25");
+
+    // Succeeds only if the client echoed the assigned Mcp-Session-Id and the
+    // negotiated MCP-Protocol-Version header (the server 400s otherwise).
+    let tools = client
+        .list_tools()
+        .await
+        .expect("tools/list over HTTP should succeed");
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].name, "echo");
+
+    // tools/call arrives as SSE with an interleaved notification the client must
+    // skip; the Authorization header must have round-tripped to the server.
+    let result = client
+        .call_tool("echo", json!({ "text": "hi" }))
+        .await
+        .expect("tools/call over SSE should succeed");
+    assert_eq!(result["content"][0]["text"], "hi|auth=Bearer test-token");
+    assert_eq!(result["isError"], false);
+
+    client.close().await.expect("closing should succeed");
+}

--- a/crates/sema-mcp/tests/mcp_legacy_challenge_test.rs
+++ b/crates/sema-mcp/tests/mcp_legacy_challenge_test.rs
@@ -1,0 +1,180 @@
+//! Legacy HTTP+SSE mid-session auth challenge capture + reconnect. The scripted
+//! server (per-session queues so a reconnect doesn't cross-talk) answers a
+//! `tools/call` for the tool `boom` with `401 insufficient_scope`, and serves
+//! everything else. This proves the legacy transport surfaces the challenge
+//! (`http_last_status`/`http_challenge`/`http_url`, at parity with Streamable
+//! HTTP) and that `reauthorize_bearer` re-opens the stream so calls work again.
+
+use std::io::{BufRead, BufReader};
+use std::process::{Child, ChildStdout, Command, Stdio};
+
+use sema_mcp::{McpClient, McpHttpConfig};
+use serde_json::json;
+
+const SERVER: &str = r#"
+import json, queue, threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse, parse_qs
+
+PORT = None
+sessions = {}
+counter = {"n": 0}
+lock = threading.Lock()
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def do_GET(self):
+        p = urlparse(self.path)
+        if p.path == "/sse":
+            with lock:
+                counter["n"] += 1
+                sid = "s%d" % counter["n"]
+                q = queue.Queue()
+                sessions[sid] = q
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.end_headers()
+            self.wfile.write(("event: endpoint\ndata: /messages?sessionId=%s\n\n" % sid).encode())
+            self.wfile.flush()
+            while True:
+                msg = q.get()
+                if msg is None:
+                    break
+                self.wfile.write(("event: message\ndata: " + json.dumps(msg) + "\n\n").encode())
+                self.wfile.flush()
+            return
+        self.send_response(404)
+        self.end_headers()
+
+    def do_POST(self):
+        p = urlparse(self.path)
+        sid = parse_qs(p.query).get("sessionId", [""])[0]
+        length = int(self.headers.get("Content-Length", 0))
+        raw = self.rfile.read(length) if length else b""
+        if p.path == "/messages":
+            msg = json.loads(raw) if raw else {}
+            method = msg.get("method")
+            rid = msg.get("id")
+            params = msg.get("params", {}) or {}
+            # Simulate a mid-session auth challenge on a specific tool.
+            if method == "tools/call" and params.get("name") == "boom":
+                self.send_response(401)
+                self.send_header("WWW-Authenticate",
+                                 'Bearer error="insufficient_scope", scope="read write"')
+                self.end_headers()
+                return
+            self.send_response(202)
+            self.end_headers()
+            if rid is None:
+                return
+            q = sessions.get(sid)
+            if q is None:
+                return
+            if method == "initialize":
+                q.put({"jsonrpc": "2.0", "id": rid, "result": {
+                    "protocolVersion": "2024-11-05", "capabilities": {},
+                    "serverInfo": {"name": "legacy", "version": "1"}}})
+            elif method == "tools/list":
+                q.put({"jsonrpc": "2.0", "id": rid, "result": {"tools": [
+                    {"name": "echo", "inputSchema": {"type": "object"}},
+                    {"name": "boom", "inputSchema": {"type": "object"}}]}})
+            elif method == "tools/call":
+                text = params.get("arguments", {}).get("text", "")
+                q.put({"jsonrpc": "2.0", "id": rid, "result": {
+                    "content": [{"type": "text", "text": text}], "isError": False}})
+            else:
+                q.put({"jsonrpc": "2.0", "id": rid,
+                       "error": {"code": -32601, "message": "no"}})
+            return
+        self.send_response(404)
+        self.end_headers()
+
+srv = ThreadingHTTPServer(("127.0.0.1", 0), H)
+srv.daemon_threads = True
+PORT = srv.server_address[1]
+print(PORT, flush=True)
+srv.serve_forever()
+"#;
+
+struct ServerGuard {
+    child: Child,
+    _stdout: BufReader<ChildStdout>,
+}
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn start_server() -> (ServerGuard, u16) {
+    let mut child = Command::new("python3")
+        .args(["-c", SERVER])
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn python3 legacy challenge server");
+    let stdout = child.stdout.take().unwrap();
+    let mut reader = BufReader::new(stdout);
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("read port");
+    let port: u16 = line.trim().parse().expect("port");
+    (
+        ServerGuard {
+            child,
+            _stdout: reader,
+        },
+        port,
+    )
+}
+
+#[tokio::test]
+async fn test_legacy_challenge_capture_and_reconnect() {
+    let (_server, port) = start_server();
+    let url = format!("http://127.0.0.1:{port}/sse");
+
+    let mut config = McpHttpConfig::new(url.clone());
+    config
+        .headers
+        .insert("Authorization".to_string(), "Bearer good".to_string());
+    let mut client = McpClient::connect_legacy_sse(config)
+        .await
+        .expect("connect legacy");
+    client.initialize().await.expect("initialize");
+
+    // A normal call works.
+    let ok = client
+        .call_tool("echo", json!({ "text": "hi" }))
+        .await
+        .expect("echo");
+    assert_eq!(ok["content"][0]["text"], "hi");
+
+    // A call the server refuses with 401 — the challenge must be captured and
+    // surfaced exactly like the Streamable-HTTP transport does.
+    let err = client
+        .call_tool("boom", json!({}))
+        .await
+        .expect_err("boom should be refused");
+    assert!(err.contains("401"), "got: {err}");
+    assert_eq!(client.http_last_status(), Some(401));
+    assert!(client
+        .http_challenge()
+        .expect("challenge captured")
+        .contains("insufficient_scope"));
+    assert_eq!(client.http_url().as_deref(), Some(url.as_str()));
+
+    // reauthorize_bearer re-opens the legacy stream with the new token and
+    // re-handshakes, so subsequent calls work again.
+    client
+        .reauthorize_bearer("good2")
+        .await
+        .expect("legacy reconnect");
+    let ok2 = client
+        .call_tool("echo", json!({ "text": "again" }))
+        .await
+        .expect("echo after reconnect");
+    assert_eq!(ok2["content"][0]["text"], "again");
+
+    client.close().await.ok();
+}

--- a/crates/sema-mcp/tests/mcp_legacy_sse_test.rs
+++ b/crates/sema-mcp/tests/mcp_legacy_sse_test.rs
@@ -1,0 +1,134 @@
+//! Deprecated 2024-11-05 HTTP+SSE transport. A threaded Python server holds the
+//! GET SSE stream open (announcing the POST endpoint via the first `endpoint`
+//! event) and pushes each JSON-RPC response onto that stream when a POST arrives
+//! — exactly the two-endpoint shape a client must speak for backwards compat.
+
+use std::io::{BufRead, BufReader};
+use std::process::{Child, ChildStdout, Command, Stdio};
+
+use sema_mcp::{McpClient, McpHttpConfig};
+
+const SERVER: &str = r#"
+import json, queue
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse
+
+PORT = None
+q = queue.Queue()
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def do_GET(self):
+        p = urlparse(self.path)
+        if p.path == "/sse":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Cache-Control", "no-cache")
+            self.end_headers()
+            self.wfile.write(b"event: endpoint\ndata: /messages\n\n")
+            self.wfile.flush()
+            while True:
+                msg = q.get()
+                if msg is None:
+                    break
+                self.wfile.write(("event: message\ndata: " + json.dumps(msg) + "\n\n").encode())
+                self.wfile.flush()
+            return
+        self.send_response(404)
+        self.end_headers()
+
+    def do_POST(self):
+        p = urlparse(self.path)
+        length = int(self.headers.get("Content-Length", 0))
+        raw = self.rfile.read(length) if length else b""
+        if p.path == "/messages":
+            msg = json.loads(raw) if raw else {}
+            method = msg.get("method")
+            rid = msg.get("id")
+            self.send_response(202)
+            self.end_headers()
+            if rid is None:
+                return
+            if method == "initialize":
+                q.put({"jsonrpc": "2.0", "id": rid, "result": {
+                    "protocolVersion": "2024-11-05", "capabilities": {},
+                    "serverInfo": {"name": "legacy-server", "version": "1.0"}}})
+            elif method == "tools/list":
+                q.put({"jsonrpc": "2.0", "id": rid, "result": {"tools": [
+                    {"name": "legacy-echo", "description": "Echo",
+                     "inputSchema": {"type": "object", "properties": {}}}]}})
+            else:
+                q.put({"jsonrpc": "2.0", "id": rid,
+                       "error": {"code": -32601, "message": "Method not found"}})
+            return
+        self.send_response(404)
+        self.end_headers()
+
+srv = ThreadingHTTPServer(("127.0.0.1", 0), H)
+srv.daemon_threads = True
+PORT = srv.server_address[1]
+print(PORT, flush=True)
+srv.serve_forever()
+"#;
+
+struct ServerGuard {
+    child: Child,
+    _stdout: BufReader<ChildStdout>,
+}
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn start_server() -> (ServerGuard, u16) {
+    let mut child = Command::new("python3")
+        .args(["-c", SERVER])
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn python3 legacy SSE server");
+    let stdout = child.stdout.take().unwrap();
+    let mut reader = BufReader::new(stdout);
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("read port");
+    let port: u16 = line.trim().parse().expect("port");
+    (
+        ServerGuard {
+            child,
+            _stdout: reader,
+        },
+        port,
+    )
+}
+
+#[tokio::test]
+async fn test_legacy_http_sse_transport() {
+    let (_server, port) = start_server();
+    let url = format!("http://127.0.0.1:{port}/sse");
+
+    let mut client = McpClient::connect_legacy_sse(McpHttpConfig::new(url))
+        .await
+        .expect("connect over legacy HTTP+SSE");
+
+    let init = client
+        .initialize()
+        .await
+        .expect("initialize over legacy transport");
+    assert_eq!(init["serverInfo"]["name"], "legacy-server");
+
+    let tools = client
+        .list_tools()
+        .await
+        .expect("tools/list over legacy transport");
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].name, "legacy-echo");
+
+    // A second request must correlate correctly on the shared stream too.
+    let tools_again = client.list_tools().await.expect("second tools/list");
+    assert_eq!(tools_again.len(), 1);
+
+    client.close().await.ok();
+}

--- a/crates/sema-mcp/tests/mcp_oauth_connect_test.rs
+++ b/crates/sema-mcp/tests/mcp_oauth_connect_test.rs
@@ -1,0 +1,235 @@
+//! OAuth-gated connect: the MCP endpoint answers `401` (with a
+//! `WWW-Authenticate` challenge) until a valid bearer token is presented. This
+//! exercises the whole connect→auth→retry path plus the "reconnect silently
+//! from cached tokens" property — offline, no browser.
+//!
+//! The Rust side mirrors what `mcp/connect` does for a `:url` server (probe →
+//! 401 → `ensure_access_token` → attach bearer → retry), but injects a
+//! reqwest-blocking "browser" and a temp-file token store so it runs in CI. The
+//! second connection uses an opener that hard-errors, so a green test proves the
+//! cached token was reused without a fresh login.
+
+use std::io::{BufRead, BufReader};
+use std::process::{Child, ChildStdout, Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use sema_mcp::oauth::login::{ensure_access_token, LoginConfig};
+use sema_mcp::oauth::loopback::{BrowserOpener, LoopbackDriver};
+use sema_mcp::oauth::store::FileStore;
+use sema_mcp::{McpClient, McpHttpConfig};
+
+const SERVER: &str = r#"
+import json, hashlib, base64
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import urlparse, parse_qs, urlencode
+
+PORT = None
+codes = {}
+ACCESS = "access-token-xyz"
+REFRESH = "refresh-token-xyz"
+
+def b64url_nopad(b):
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode()
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def base(self):
+        return "http://127.0.0.1:%d" % PORT
+
+    def _json(self, obj, code=200, headers=None):
+        data = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        for k, v in (headers or {}).items():
+            self.send_header(k, v)
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_GET(self):
+        p = urlparse(self.path)
+        if p.path == "/.well-known/oauth-protected-resource":
+            return self._json({"resource": self.base() + "/mcp",
+                               "authorization_servers": [self.base()],
+                               "scopes_supported": ["mcp:tools"]})
+        if p.path == "/.well-known/oauth-authorization-server":
+            return self._json({"issuer": self.base(),
+                               "authorization_endpoint": self.base() + "/authorize",
+                               "token_endpoint": self.base() + "/token",
+                               "registration_endpoint": self.base() + "/register",
+                               "code_challenge_methods_supported": ["S256"],
+                               "grant_types_supported": ["authorization_code", "refresh_token"]})
+        if p.path == "/authorize":
+            q = parse_qs(p.query)
+            redirect_uri = q.get("redirect_uri", [""])[0]
+            state = q.get("state", [""])[0]
+            code = "authcode-123"
+            codes[code] = q.get("code_challenge", [""])[0]
+            loc = redirect_uri + "?" + urlencode({"code": code, "state": state})
+            self.send_response(302)
+            self.send_header("Location", loc)
+            self.end_headers()
+            return
+        self.send_response(404)
+        self.end_headers()
+
+    def do_POST(self):
+        p = urlparse(self.path)
+        length = int(self.headers.get("Content-Length", 0))
+        raw = self.rfile.read(length) if length else b""
+        if p.path == "/register":
+            return self._json({"client_id": "dcr-client-1"}, code=201)
+        if p.path == "/token":
+            body = parse_qs(raw.decode())
+            grant = body.get("grant_type", [""])[0]
+            if grant == "authorization_code":
+                verifier = body.get("code_verifier", [""])[0]
+                code = body.get("code", [""])[0]
+                if b64url_nopad(hashlib.sha256(verifier.encode()).digest()) != codes.get(code):
+                    return self._json({"error": "invalid_grant"}, code=400)
+                return self._json({"access_token": ACCESS, "refresh_token": REFRESH,
+                                   "token_type": "Bearer", "expires_in": 3600, "scope": "mcp:tools"})
+            return self._json({"error": "unsupported_grant_type"}, code=400)
+        if p.path == "/mcp":
+            auth = self.headers.get("Authorization", "")
+            if auth != "Bearer " + ACCESS:
+                # Challenge: point the client at the protected-resource metadata.
+                self.send_response(401)
+                self.send_header("WWW-Authenticate",
+                                 'Bearer resource_metadata="%s/.well-known/oauth-protected-resource"' % self.base())
+                self.end_headers()
+                return
+            msg = json.loads(raw) if raw else {}
+            method = msg.get("method")
+            rid = msg.get("id")
+            if rid is None:
+                self.send_response(202)
+                self.end_headers()
+                return
+            if method == "initialize":
+                return self._json({"jsonrpc": "2.0", "id": rid, "result": {
+                    "protocolVersion": "2025-11-25", "capabilities": {},
+                    "serverInfo": {"name": "gated-server", "version": "1.0"}}},
+                    headers={"Mcp-Session-Id": "sess-1"})
+            if method == "tools/list":
+                return self._json({"jsonrpc": "2.0", "id": rid, "result": {"tools": [
+                    {"name": "ping", "description": "Ping",
+                     "inputSchema": {"type": "object", "properties": {}}}]}})
+            return self._json({"jsonrpc": "2.0", "id": rid,
+                               "error": {"code": -32601, "message": "Method not found"}})
+        self.send_response(404)
+        self.end_headers()
+
+srv = HTTPServer(("127.0.0.1", 0), H)
+PORT = srv.server_address[1]
+print(PORT, flush=True)
+srv.serve_forever()
+"#;
+
+struct ServerGuard {
+    child: Child,
+    _stdout: BufReader<ChildStdout>,
+}
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn start_server() -> (ServerGuard, u16) {
+    let mut child = Command::new("python3")
+        .args(["-c", SERVER])
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn python3 gated server");
+    let stdout = child.stdout.take().unwrap();
+    let mut reader = BufReader::new(stdout);
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("read port");
+    let port: u16 = line.trim().parse().expect("port");
+    (
+        ServerGuard {
+            child,
+            _stdout: reader,
+        },
+        port,
+    )
+}
+
+fn temp_store_path() -> std::path::PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    std::env::temp_dir().join(format!(
+        "sema-mcp-connect-{}-{}/auth.json",
+        std::process::id(),
+        n
+    ))
+}
+
+/// Connect, and if the server challenges with a 401, authenticate via
+/// `ensure_access_token` and retry — the same shape as the `mcp/connect`
+/// builtin, but with an injected opener + store for CI.
+async fn connect_with_auth(url: &str, store: &FileStore, opener: BrowserOpener) -> McpClient {
+    let mut client = McpClient::connect_http(McpHttpConfig::new(url))
+        .await
+        .expect("prepare http client");
+    if client.initialize().await.is_err() {
+        let challenge = client
+            .http_challenge()
+            .expect("initialize failed for a reason other than 401");
+        let parsed = sema_mcp::oauth::discovery::parse_www_authenticate(&challenge);
+        let driver =
+            LoopbackDriver::with_opener(Duration::from_secs(10), opener).expect("bind loopback");
+        let config = LoginConfig {
+            mcp_url: url,
+            resource_metadata_url: parsed.resource_metadata.as_deref(),
+            requested_scope: parsed.scope.as_deref(),
+            preconfigured_client_id: None,
+        };
+        let token = ensure_access_token(&reqwest::Client::new(), store, &config, &driver)
+            .await
+            .expect("ensure_access_token");
+        client.set_bearer_token(&token);
+        client.initialize().await.expect("initialize after auth");
+    }
+    client
+}
+
+fn browser_opener() -> BrowserOpener {
+    Box::new(|url: &str| {
+        reqwest::blocking::Client::new()
+            .get(url)
+            .send()
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    })
+}
+
+#[tokio::test]
+async fn test_oauth_gated_connect_then_cached_reconnect() {
+    let (_server, port) = start_server();
+    let url = format!("http://127.0.0.1:{port}/mcp");
+    let store = FileStore::new(temp_store_path());
+
+    // First connect: 401 -> full login (browser opener drives the redirect) ->
+    // token -> retry -> tools work.
+    let mut client = connect_with_auth(&url, &store, browser_opener()).await;
+    let tools = client.list_tools().await.expect("tools/list after auth");
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].name, "ping");
+    client.close().await.ok();
+
+    // Second connect against the SAME store: the cached token must be reused
+    // without any login. The opener hard-errors, so if a login were attempted
+    // the flow would fail — a green test proves the silent reconnect.
+    let panicking_opener: BrowserOpener =
+        Box::new(|_url: &str| Err("browser must not be opened on a cached reconnect".to_string()));
+    let mut client2 = connect_with_auth(&url, &store, panicking_opener).await;
+    let tools2 = client2.list_tools().await.expect("tools/list on reconnect");
+    assert_eq!(tools2.len(), 1);
+    client2.close().await.ok();
+}

--- a/crates/sema-mcp/tests/mcp_oauth_device_test.rs
+++ b/crates/sema-mcp/tests/mcp_oauth_device_test.rs
@@ -1,0 +1,151 @@
+//! Device-authorization grant (RFC 8628) end-to-end, offline. The scripted AS
+//! advertises a device endpoint, returns `authorization_pending` on the first
+//! poll and tokens on the second, and the client drives `device_login` to
+//! completion — proving the poll/pending loop and the code display.
+
+use std::io::{BufRead, BufReader};
+use std::process::{Child, ChildStdout, Command, Stdio};
+use std::sync::{Arc, Mutex};
+
+use sema_mcp::oauth::device::device_login;
+use sema_mcp::oauth::login::LoginConfig;
+
+const SERVER: &str = r#"
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import urlparse, parse_qs
+
+PORT = None
+polls = {"n": 0}
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def base(self):
+        return "http://127.0.0.1:%d" % PORT
+
+    def _json(self, obj, code=200):
+        data = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_GET(self):
+        p = urlparse(self.path)
+        if p.path == "/.well-known/oauth-protected-resource":
+            return self._json({"resource": self.base() + "/mcp",
+                               "authorization_servers": [self.base()],
+                               "scopes_supported": ["mcp:tools"]})
+        if p.path == "/.well-known/oauth-authorization-server":
+            return self._json({"issuer": self.base(),
+                               "authorization_endpoint": self.base() + "/authorize",
+                               "token_endpoint": self.base() + "/token",
+                               "registration_endpoint": self.base() + "/register",
+                               "device_authorization_endpoint": self.base() + "/device",
+                               "code_challenge_methods_supported": ["S256"],
+                               "grant_types_supported": ["authorization_code",
+                                                         "urn:ietf:params:oauth:grant-type:device_code"]})
+        self.send_response(404)
+        self.end_headers()
+
+    def do_POST(self):
+        p = urlparse(self.path)
+        length = int(self.headers.get("Content-Length", 0))
+        raw = self.rfile.read(length) if length else b""
+        if p.path == "/register":
+            return self._json({"client_id": "dcr-device-client"}, code=201)
+        if p.path == "/device":
+            return self._json({"device_code": "dev-code-1", "user_code": "WXYZ-1234",
+                               "verification_uri": self.base() + "/activate",
+                               "expires_in": 300, "interval": 0})
+        if p.path == "/token":
+            body = parse_qs(raw.decode())
+            grant = body.get("grant_type", [""])[0]
+            if grant == "urn:ietf:params:oauth:grant-type:device_code":
+                assert body.get("resource", [""])[0] == self.base() + "/mcp"
+                polls["n"] += 1
+                if polls["n"] < 2:
+                    return self._json({"error": "authorization_pending"}, code=400)
+                return self._json({"access_token": "device-access", "refresh_token": "device-refresh",
+                                   "token_type": "Bearer", "expires_in": 3600, "scope": "mcp:tools"})
+            return self._json({"error": "unsupported_grant_type"}, code=400)
+        self.send_response(404)
+        self.end_headers()
+
+srv = HTTPServer(("127.0.0.1", 0), H)
+PORT = srv.server_address[1]
+print(PORT, flush=True)
+srv.serve_forever()
+"#;
+
+struct ServerGuard {
+    child: Child,
+    _stdout: BufReader<ChildStdout>,
+}
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn start_server() -> (ServerGuard, u16) {
+    let mut child = Command::new("python3")
+        .args(["-c", SERVER])
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn python3 device server");
+    let stdout = child.stdout.take().unwrap();
+    let mut reader = BufReader::new(stdout);
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("read port");
+    let port: u16 = line.trim().parse().expect("port");
+    (
+        ServerGuard {
+            child,
+            _stdout: reader,
+        },
+        port,
+    )
+}
+
+#[tokio::test]
+async fn test_device_flow_end_to_end() {
+    let (_server, port) = start_server();
+    let mcp_url = format!("http://127.0.0.1:{port}/mcp");
+    let http = reqwest::Client::new();
+
+    let shown = Arc::new(Mutex::new(None));
+    let shown_ref = Arc::clone(&shown);
+    let display = move |device: &sema_mcp::oauth::device::DeviceAuthorization| {
+        *shown_ref.lock().unwrap() =
+            Some((device.user_code.clone(), device.verification_uri.clone()));
+    };
+
+    let config = LoginConfig {
+        mcp_url: &mcp_url,
+        resource_metadata_url: None,
+        requested_scope: None,
+        preconfigured_client_id: None,
+    };
+
+    let creds = device_login(&http, &config, None, &display)
+        .await
+        .expect("device login should complete");
+
+    assert_eq!(creds.tokens.access_token, "device-access");
+    assert_eq!(
+        creds.tokens.refresh_token.as_deref(),
+        Some("device-refresh")
+    );
+    assert_eq!(
+        creds.client_info.expect("DCR client").client_id,
+        "dcr-device-client"
+    );
+    let (user_code, uri) = shown.lock().unwrap().clone().expect("user code displayed");
+    assert_eq!(user_code, "WXYZ-1234");
+    assert!(uri.ends_with("/activate"));
+}

--- a/crates/sema-mcp/tests/mcp_oauth_stepup_test.rs
+++ b/crates/sema-mcp/tests/mcp_oauth_stepup_test.rs
@@ -1,0 +1,191 @@
+//! Mid-session `403 insufficient_scope` step-up re-authorization, offline.
+//!
+//! The client starts with a narrow-scope token (`read`) and hits a challenge
+//! demanding `read write`. `reauth_on_challenge` must re-authorize requesting the
+//! *union* of scopes and persist the upgraded token. The scripted AS echoes the
+//! scope it was asked for back into the issued token, so the assertions prove the
+//! union was computed, requested, and stored.
+
+use std::io::{BufRead, BufReader};
+use std::process::{Child, ChildStdout, Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use sema_mcp::oauth::login::reauth_on_challenge;
+use sema_mcp::oauth::loopback::{BrowserOpener, LoopbackDriver};
+use sema_mcp::oauth::store::{ClientInfo, FileStore, StoredCredentials, TokenSet, TokenStore};
+
+const SERVER: &str = r#"
+import json, hashlib, base64
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import urlparse, parse_qs, urlencode
+
+PORT = None
+codes = {}  # code -> {challenge, scope}
+
+def b64url_nopad(b):
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode()
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def base(self):
+        return "http://127.0.0.1:%d" % PORT
+
+    def _json(self, obj, code=200):
+        data = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_GET(self):
+        p = urlparse(self.path)
+        if p.path == "/.well-known/oauth-protected-resource":
+            return self._json({"resource": self.base() + "/mcp",
+                               "authorization_servers": [self.base()],
+                               "scopes_supported": ["read", "write"]})
+        if p.path == "/.well-known/oauth-authorization-server":
+            return self._json({"issuer": self.base(),
+                               "authorization_endpoint": self.base() + "/authorize",
+                               "token_endpoint": self.base() + "/token",
+                               "registration_endpoint": self.base() + "/register",
+                               "code_challenge_methods_supported": ["S256"]})
+        if p.path == "/authorize":
+            q = parse_qs(p.query)
+            code = "authcode-stepup"
+            codes[code] = {"challenge": q.get("code_challenge", [""])[0],
+                           "scope": q.get("scope", [""])[0]}
+            loc = q.get("redirect_uri", [""])[0] + "?" + urlencode(
+                {"code": code, "state": q.get("state", [""])[0]})
+            self.send_response(302)
+            self.send_header("Location", loc)
+            self.end_headers()
+            return
+        self.send_response(404)
+        self.end_headers()
+
+    def do_POST(self):
+        p = urlparse(self.path)
+        length = int(self.headers.get("Content-Length", 0))
+        raw = self.rfile.read(length) if length else b""
+        if p.path == "/register":
+            return self._json({"client_id": "c1"}, code=201)
+        if p.path == "/token":
+            body = parse_qs(raw.decode())
+            code = body.get("code", [""])[0]
+            rec = codes.get(code, {})
+            verifier = body.get("code_verifier", [""])[0]
+            if b64url_nopad(hashlib.sha256(verifier.encode()).digest()) != rec.get("challenge"):
+                return self._json({"error": "invalid_grant"}, code=400)
+            # Echo the granted scope back into the token so the test can assert it.
+            return self._json({"access_token": "stepped-up-token", "token_type": "Bearer",
+                               "expires_in": 3600, "scope": rec.get("scope", "")})
+        self.send_response(404)
+        self.end_headers()
+
+srv = HTTPServer(("127.0.0.1", 0), H)
+PORT = srv.server_address[1]
+print(PORT, flush=True)
+srv.serve_forever()
+"#;
+
+struct ServerGuard {
+    child: Child,
+    _stdout: BufReader<ChildStdout>,
+}
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn start_server() -> (ServerGuard, u16) {
+    let mut child = Command::new("python3")
+        .args(["-c", SERVER])
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn python3 step-up server");
+    let stdout = child.stdout.take().unwrap();
+    let mut reader = BufReader::new(stdout);
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("read port");
+    let port: u16 = line.trim().parse().expect("port");
+    (
+        ServerGuard {
+            child,
+            _stdout: reader,
+        },
+        port,
+    )
+}
+
+fn temp_store() -> FileStore {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    FileStore::new(std::env::temp_dir().join(format!(
+        "sema-mcp-stepup-{}-{}/auth.json",
+        std::process::id(),
+        n
+    )))
+}
+
+#[tokio::test]
+async fn test_403_insufficient_scope_step_up() {
+    let (_server, port) = start_server();
+    let url = format!("http://127.0.0.1:{port}/mcp");
+
+    // Seed a prior narrow-scope login (`read` only), with a client already
+    // registered so the step-up reuses it.
+    let store = temp_store();
+    store
+        .save(&StoredCredentials {
+            server_url: url.clone(),
+            tokens: TokenSet {
+                access_token: "old-narrow-token".to_string(),
+                refresh_token: None,
+                expires_at: None,
+                scope: Some("read".to_string()),
+            },
+            client_info: Some(ClientInfo {
+                client_id: "c1".to_string(),
+                client_secret: None,
+            }),
+        })
+        .unwrap();
+
+    // The server now demands `read write`.
+    let challenge = r#"Bearer error="insufficient_scope", scope="read write""#;
+    let opener: BrowserOpener = Box::new(|u: &str| {
+        reqwest::blocking::Client::new()
+            .get(u)
+            .send()
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    });
+    let driver = LoopbackDriver::with_opener(Duration::from_secs(10), opener).unwrap();
+
+    let token = reauth_on_challenge(
+        &reqwest::Client::new(),
+        &store,
+        &url,
+        Some(403),
+        Some(challenge),
+        None,
+        &driver,
+    )
+    .await
+    .expect("step-up should succeed")
+    .expect("a 403 insufficient_scope must trigger re-auth");
+
+    // A fresh token was obtained…
+    assert_eq!(token, "stepped-up-token");
+    assert_ne!(token, "old-narrow-token");
+    // …the upgraded scope (union of read + read/write) was requested and stored…
+    let stored = store.load(&url).expect("credentials persisted");
+    assert_eq!(stored.tokens.scope.as_deref(), Some("read write"));
+    assert_eq!(stored.tokens.access_token, "stepped-up-token");
+}

--- a/crates/sema-mcp/tests/mcp_oauth_test.rs
+++ b/crates/sema-mcp/tests/mcp_oauth_test.rs
@@ -1,0 +1,194 @@
+//! End-to-end OAuth login test (the M4 acceptance gate), fully offline.
+//!
+//! A scripted Python server plays BOTH roles: the OAuth authorization server
+//! (RFC 9728/8414 metadata, RFC 7591 DCR, /authorize, /token) and the MCP
+//! resource server. The Rust side runs the real `oauth::login` against it,
+//! driving the browser leg with a `LoopbackDriver` whose "opener" is a blocking
+//! GET that follows the authorization server's 302 to our real loopback
+//! listener — so the loopback capture, `state`/CSRF check, and token exchange
+//! all execute for real. The server recomputes `S256(code_verifier)` and rejects
+//! a PKCE mismatch, so a green test proves the PKCE round-trip end-to-end. It
+//! also asserts the RFC 8707 `resource` parameter is present on both legs.
+
+use std::io::{BufRead, BufReader};
+use std::process::{Child, ChildStdout, Command, Stdio};
+use std::time::Duration;
+
+use sema_mcp::oauth::login::{login, LoginConfig};
+use sema_mcp::oauth::loopback::{BrowserOpener, LoopbackDriver};
+
+const OAUTH_SERVER: &str = r#"
+import json, hashlib, base64
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import urlparse, parse_qs, urlencode
+
+PORT = None
+codes = {}
+ACCESS = "access-token-xyz"
+REFRESH = "refresh-token-xyz"
+
+def b64url_nopad(b):
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode()
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def base(self):
+        return "http://127.0.0.1:%d" % PORT
+
+    def _json(self, obj, code=200):
+        data = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_GET(self):
+        p = urlparse(self.path)
+        if p.path == "/.well-known/oauth-protected-resource":
+            return self._json({
+                "resource": self.base() + "/mcp",
+                "authorization_servers": [self.base()],
+                "scopes_supported": ["mcp:tools"]})
+        if p.path == "/.well-known/oauth-authorization-server":
+            return self._json({
+                "issuer": self.base(),
+                "authorization_endpoint": self.base() + "/authorize",
+                "token_endpoint": self.base() + "/token",
+                "registration_endpoint": self.base() + "/register",
+                "code_challenge_methods_supported": ["S256"],
+                "grant_types_supported": ["authorization_code", "refresh_token"],
+                "scopes_supported": ["mcp:tools"]})
+        if p.path == "/authorize":
+            q = parse_qs(p.query)
+            assert q.get("code_challenge_method", [""])[0] == "S256", "missing S256"
+            assert q.get("resource", [""])[0] == self.base() + "/mcp", "missing resource"
+            redirect_uri = q.get("redirect_uri", [""])[0]
+            assert redirect_uri.startswith("http://127.0.0.1:"), "non-loopback redirect"
+            state = q.get("state", [""])[0]
+            code = "authcode-123"
+            codes[code] = q.get("code_challenge", [""])[0]
+            loc = redirect_uri + "?" + urlencode({"code": code, "state": state})
+            self.send_response(302)
+            self.send_header("Location", loc)
+            self.end_headers()
+            return
+        self.send_response(404)
+        self.end_headers()
+
+    def do_POST(self):
+        p = urlparse(self.path)
+        length = int(self.headers.get("Content-Length", 0))
+        raw = self.rfile.read(length) if length else b""
+        if p.path == "/register":
+            return self._json({"client_id": "dcr-client-1"}, code=201)
+        if p.path == "/token":
+            body = parse_qs(raw.decode())
+            assert body.get("resource", [""])[0] == self.base() + "/mcp", "token missing resource"
+            grant = body.get("grant_type", [""])[0]
+            if grant == "authorization_code":
+                code = body.get("code", [""])[0]
+                verifier = body.get("code_verifier", [""])[0]
+                challenge = codes.get(code)
+                calc = b64url_nopad(hashlib.sha256(verifier.encode()).digest())
+                if challenge is None or calc != challenge:
+                    return self._json({"error": "invalid_grant",
+                                       "error_description": "PKCE verification failed"}, code=400)
+                return self._json({"access_token": ACCESS, "refresh_token": REFRESH,
+                                   "token_type": "Bearer", "expires_in": 3600, "scope": "mcp:tools"})
+            if grant == "refresh_token":
+                assert body.get("refresh_token", [""])[0] == REFRESH
+                return self._json({"access_token": "access-token-2", "refresh_token": "refresh-token-2",
+                                   "token_type": "Bearer", "expires_in": 3600, "scope": "mcp:tools"})
+            return self._json({"error": "unsupported_grant_type"}, code=400)
+        self.send_response(404)
+        self.end_headers()
+
+srv = HTTPServer(("127.0.0.1", 0), H)
+PORT = srv.server_address[1]
+print(PORT, flush=True)
+srv.serve_forever()
+"#;
+
+struct ServerGuard {
+    child: Child,
+    _stdout: BufReader<ChildStdout>,
+}
+
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn start_server() -> (ServerGuard, u16) {
+    let mut child = Command::new("python3")
+        .args(["-c", OAUTH_SERVER])
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn python3 OAuth server");
+    let stdout = child.stdout.take().expect("server stdout");
+    let mut reader = BufReader::new(stdout);
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("read server port");
+    let port: u16 = line.trim().parse().expect("server should print its port");
+    (
+        ServerGuard {
+            child,
+            _stdout: reader,
+        },
+        port,
+    )
+}
+
+#[tokio::test]
+async fn test_oauth_login_end_to_end() {
+    let (_server, port) = start_server();
+    let base = format!("http://127.0.0.1:{port}");
+    let mcp_url = format!("{base}/mcp");
+
+    let http = reqwest::Client::new();
+
+    // The "browser": a blocking GET that follows the 302 from /authorize to our
+    // loopback listener. Runs on the driver's own thread, so it never nests a
+    // runtime inside the test's tokio runtime.
+    let opener: BrowserOpener = Box::new(|url: &str| {
+        reqwest::blocking::Client::new()
+            .get(url)
+            .send()
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    });
+    let driver = LoopbackDriver::with_opener(Duration::from_secs(10), opener)
+        .expect("failed to bind loopback listener");
+
+    let config = LoginConfig {
+        mcp_url: &mcp_url,
+        resource_metadata_url: None,
+        requested_scope: None,
+        preconfigured_client_id: None,
+    };
+
+    let creds = login(&http, &config, None, &driver)
+        .await
+        .expect("OAuth login should complete end-to-end");
+
+    assert_eq!(creds.server_url, mcp_url);
+    assert_eq!(creds.tokens.access_token, "access-token-xyz");
+    assert_eq!(
+        creds.tokens.refresh_token.as_deref(),
+        Some("refresh-token-xyz")
+    );
+    assert_eq!(creds.tokens.scope.as_deref(), Some("mcp:tools"));
+    assert!(
+        creds.tokens.expires_at.is_some(),
+        "expiry computed from expires_in"
+    );
+    assert_eq!(
+        creds.client_info.expect("DCR client registered").client_id,
+        "dcr-client-1"
+    );
+}

--- a/crates/sema/src/lib.rs
+++ b/crates/sema/src/lib.rs
@@ -27,6 +27,7 @@ pub type Result<T> = std::result::Result<T, SemaError>;
 pub struct InterpreterBuilder {
     stdlib: bool,
     llm: bool,
+    mcp: bool,
     sandbox: Sandbox,
     telemetry: sema_otel::TelemetryMode,
 }
@@ -43,6 +44,7 @@ impl InterpreterBuilder {
         Self {
             stdlib: true,
             llm: true,
+            mcp: true,
             sandbox: Sandbox::allow_all(),
             telemetry: sema_otel::TelemetryMode::Off,
         }
@@ -71,6 +73,12 @@ impl InterpreterBuilder {
         self
     }
 
+    /// Enable or disable the MCP client builtins (default: `true`).
+    pub fn with_mcp(mut self, enable: bool) -> Self {
+        self.mcp = enable;
+        self
+    }
+
     /// Set the sandbox configuration to restrict dangerous operations.
     pub fn with_sandbox(mut self, sandbox: Sandbox) -> Self {
         self.sandbox = sandbox;
@@ -91,6 +99,11 @@ impl InterpreterBuilder {
     /// Disable the LLM builtins.
     pub fn without_llm(self) -> Self {
         self.with_llm(false)
+    }
+
+    /// Disable the MCP client builtins.
+    pub fn without_mcp(self) -> Self {
+        self.with_mcp(false)
     }
 
     /// Build the [`Interpreter`] with the configured options.
@@ -117,6 +130,10 @@ impl InterpreterBuilder {
 
         if self.llm {
             sema_llm::builtins::register_llm_builtins(&env, &self.sandbox);
+        }
+
+        if self.mcp {
+            sema_mcp::register_mcp_builtins(&env, &self.sandbox);
         }
 
         let global_env = Rc::new(env);

--- a/crates/sema/src/main.rs
+++ b/crates/sema/src/main.rs
@@ -270,9 +270,13 @@ enum Commands {
     Lsp,
     /// Start the Debug Adapter Protocol server
     Dap,
-    /// Start the Model Context Protocol (MCP) server
+    /// Start the MCP server, or manage MCP client auth (`mcp login`/`logout`)
+    #[command(args_conflicts_with_subcommands = true)]
     Mcp {
-        /// Optional source files to run/load tools from
+        /// Client-auth subcommand; when omitted, runs the MCP server
+        #[command(subcommand)]
+        auth: Option<McpAuthCommands>,
+        /// Optional source files to run/load tools from (server mode)
         #[arg(value_name = "FILES")]
         files: Vec<String>,
         /// Comma-separated list of tool names to explicitly include
@@ -321,6 +325,26 @@ enum Commands {
         /// Disable LLM features
         #[arg(long)]
         no_llm: bool,
+    },
+}
+
+#[derive(Subcommand)]
+enum McpAuthCommands {
+    /// Log in to a remote (HTTP) MCP server and cache the OAuth token
+    Login {
+        /// The MCP server URL (e.g. https://mcp.example.com/mcp)
+        url: String,
+        /// Use the device-authorization flow instead of opening a browser
+        #[arg(long)]
+        device: bool,
+        /// A pre-registered OAuth client id (when the server has no dynamic registration)
+        #[arg(long = "client-id", value_name = "ID")]
+        client_id: Option<String>,
+    },
+    /// Remove cached credentials for a remote MCP server
+    Logout {
+        /// The MCP server URL whose cached credentials to clear
+        url: String,
     },
 }
 
@@ -683,10 +707,26 @@ fn main() {
                     .block_on(sema_dap::run_server());
             }
             Commands::Mcp {
+                auth,
                 files,
                 include,
                 exclude,
             } => {
+                if let Some(auth) = auth {
+                    let result = match auth {
+                        McpAuthCommands::Login {
+                            url,
+                            device,
+                            client_id,
+                        } => sema_mcp::mcp_login(&url, device, client_id.as_deref()),
+                        McpAuthCommands::Logout { url } => sema_mcp::mcp_logout(&url),
+                    };
+                    if let Err(e) = result {
+                        eprintln!("mcp: {e}");
+                        std::process::exit(1);
+                    }
+                    return;
+                }
                 let inc_tools = include.map(|s| {
                     s.split(',')
                         .map(|x| x.trim().to_string())

--- a/crates/sema/src/main.rs
+++ b/crates/sema/src/main.rs
@@ -556,6 +556,16 @@ enum NotebookCommands {
     },
 }
 
+/// Build the standard CLI interpreter: stdlib + LLM (registered inside sema-eval)
+/// plus the MCP *client* builtins (`mcp/connect`, `mcp/tools`, `mcp/tools->sema`,
+/// …). The MCP builtins live in `sema-mcp`, which depends on `sema-eval`, so they
+/// can't be registered inside `sema-eval` itself — the binary wires them in here.
+fn build_interpreter(sandbox: &sema_core::Sandbox) -> Interpreter {
+    let interpreter = Interpreter::new_with_sandbox(sandbox);
+    sema_mcp::register_mcp_builtins(&interpreter.global_env, sandbox);
+    interpreter
+}
+
 fn main() {
     // Check for embedded archive before parsing CLI args
     if let Some(exit_code) = try_run_embedded() {
@@ -739,7 +749,7 @@ fn main() {
                 });
 
                 let sandbox = sema_core::Sandbox::allow_all();
-                let interpreter = Interpreter::new_with_sandbox(&sandbox);
+                let interpreter = build_interpreter(&sandbox);
 
                 let _ = interpreter.eval_str("(llm/auto-configure)");
 
@@ -792,7 +802,7 @@ fn main() {
         return;
     }
 
-    let interpreter = Interpreter::new_with_sandbox(&sandbox);
+    let interpreter = build_interpreter(&sandbox);
 
     // Set LLM env vars before auto-configure
     if let Some(model) = cli.chat_model.as_ref() {
@@ -1088,7 +1098,7 @@ fn run_workflow_command(command: WorkflowCommands, sandbox: &sema_core::Sandbox)
         std::thread::sleep(std::time::Duration::from_millis(250));
     }
 
-    let interpreter = Interpreter::new_with_sandbox(&effective_sandbox);
+    let interpreter = build_interpreter(&effective_sandbox);
 
     // Auto-configure an LLM provider from the environment (mirrors the default run
     // path), so a workflow whose leaves call `llm/*` works without self-configuring.
@@ -1403,7 +1413,7 @@ fn run_eval(
         None => sema_core::Sandbox::allow_all(),
     };
 
-    let interpreter = Interpreter::new_with_sandbox(&sandbox);
+    let interpreter = build_interpreter(&sandbox);
 
     // Auto-configure LLM unless --no-llm
     if !no_llm {
@@ -1612,7 +1622,7 @@ fn run_compile(file: &str, output: Option<&str>) {
 
     // Use Interpreter for macro expansion before compilation
     let sandbox = sema_core::Sandbox::allow_all();
-    let interpreter = Interpreter::new_with_sandbox(&sandbox);
+    let interpreter = build_interpreter(&sandbox);
 
     let result = match interpreter.compile_to_bytecode(&source) {
         Ok(r) => r,
@@ -1689,7 +1699,7 @@ fn try_run_embedded() -> Option<i32> {
     sema_core::vfs::init_vfs(arch.files);
 
     let sandbox = sema_core::Sandbox::allow_all();
-    let interpreter = Interpreter::new_with_sandbox(&sandbox);
+    let interpreter = build_interpreter(&sandbox);
 
     let _ = interpreter.eval_str("(llm/auto-configure)");
 
@@ -1830,7 +1840,7 @@ fn run_build(
     // Compute source hash and compile to bytecode
     let source_hash = crc32fast::hash(source.as_bytes());
     let sandbox = sema_core::Sandbox::allow_all();
-    let interpreter = Interpreter::new_with_sandbox(&sandbox);
+    let interpreter = build_interpreter(&sandbox);
 
     let result = match interpreter.compile_to_bytecode(&source) {
         Ok(r) => r,

--- a/crates/sema/tests/mcp_builtin_test.rs
+++ b/crates/sema/tests/mcp_builtin_test.rs
@@ -1,0 +1,238 @@
+//! Sema-facing MCP client builtin tests (`mcp/connect|tools|call|tools->sema`),
+//! including the agent adapter driven end-to-end through the real agent loop
+//! against a scripted `FakeProvider` (no network, no keys) and a live stdio MCP
+//! server (a small Python script).
+
+use std::sync::Arc;
+
+use sema::{Interpreter, InterpreterBuilder, Value};
+use sema_core::{Caps, Sandbox};
+use sema_llm::builtins::{register_test_provider, reset_runtime_state};
+use sema_llm::fake::{FakeProvider, FakeRecorder};
+
+/// A stdio MCP server exposing `echo` (echoes its `text` argument) and `boom`
+/// (always returns an MCP error). Refuses `tools/list` until it has seen the
+/// `notifications/initialized` message, matching a conformant server.
+const SERVER: &str = r#"
+import json
+import sys
+
+initialized = False
+
+def send(msg):
+    sys.stdout.write(json.dumps(msg) + "\n")
+    sys.stdout.flush()
+
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    request = json.loads(line)
+    method = request.get("method")
+    request_id = request.get("id")
+
+    if request_id is None:
+        if method == "notifications/initialized":
+            initialized = True
+        continue
+
+    if method == "initialize":
+        send({"jsonrpc": "2.0", "id": request_id, "result": {
+            "protocolVersion": "2024-11-05", "capabilities": {},
+            "serverInfo": {"name": "test-server", "version": "1.0"}}})
+    elif method == "tools/list":
+        if not initialized:
+            send({"jsonrpc": "2.0", "id": request_id,
+                  "error": {"code": -32002, "message": "not initialized"}})
+        else:
+            send({"jsonrpc": "2.0", "id": request_id, "result": {"tools": [
+                {"name": "echo", "description": "Echo a string",
+                 "inputSchema": {"type": "object",
+                                 "properties": {"text": {"type": "string"}},
+                                 "required": ["text"]}},
+                {"name": "boom", "description": "Always fails",
+                 "inputSchema": {"type": "object", "properties": {}}},
+            ]}})
+    elif method == "tools/call":
+        name = request.get("params", {}).get("name")
+        args = request.get("params", {}).get("arguments", {})
+        if name == "boom":
+            send({"jsonrpc": "2.0", "id": request_id, "result": {
+                "content": [{"type": "text", "text": "kaboom"}], "isError": True}})
+        else:
+            send({"jsonrpc": "2.0", "id": request_id, "result": {
+                "content": [{"type": "text", "text": args.get("text", "")}],
+                "isError": False}})
+    else:
+        send({"jsonrpc": "2.0", "id": request_id,
+              "error": {"code": -32601, "message": "Method not found"}})
+"#;
+
+/// Sema that connects to the server above and binds the handle to `server`.
+fn connect_expr() -> String {
+    let encoded = serde_json::to_string(SERVER).unwrap();
+    format!(r#"(define server (mcp/connect {{:command "python3" :args ["-c" {encoded}]}}))"#)
+}
+
+#[test]
+fn test_mcp_builtins_connect_list_call() {
+    let interp = Interpreter::new();
+    interp.eval_str(&connect_expr()).unwrap();
+
+    let tools = interp.eval_str("(mcp/tools server)").unwrap();
+    let tools = tools.as_seq().unwrap();
+    assert_eq!(tools.len(), 2);
+    let first = tools[0].as_map_ref().unwrap();
+    assert_eq!(
+        first.get(&Value::keyword("name")).unwrap().as_str(),
+        Some("echo")
+    );
+
+    // Layer 1 `mcp/call` collapses text content to a string.
+    let result = interp
+        .eval_str(r#"(mcp/call server "echo" {:text "hello"})"#)
+        .unwrap();
+    assert_eq!(result.as_str(), Some("hello"));
+
+    interp.eval_str("(mcp/close server)").unwrap();
+}
+
+#[test]
+fn test_mcp_tools_to_sema_uses_deftool_param_shape() {
+    let interp = Interpreter::new();
+    interp.eval_str(&connect_expr()).unwrap();
+
+    let defs = interp.eval_str("(mcp/tools->sema server)").unwrap();
+    let defs = defs.as_seq().unwrap();
+    let echo = defs
+        .iter()
+        .find_map(|d| d.as_tool_def_rc().filter(|td| td.name == "echo"))
+        .expect("echo tool def");
+    assert_eq!(echo.description, "Echo a string");
+
+    // The parameters must be a `{param-name -> spec}` map (like `deftool`), NOT
+    // the raw JSON Schema — otherwise the agent loop maps model arguments over
+    // `:type`/`:properties`/`:required` and the tool is called with nil args.
+    let params = echo.parameters.as_map_ref().expect("params map");
+    assert!(
+        params.contains_key(&Value::keyword("text")),
+        "expected a :text parameter, got keys: {:?}",
+        params.keys().collect::<Vec<_>>()
+    );
+    assert!(!params.contains_key(&Value::keyword("properties")));
+    assert!(!params.contains_key(&Value::keyword("type")));
+
+    interp.eval_str("(mcp/close server)").unwrap();
+}
+
+/// Build a `sema::Interpreter`, install `fake` as the default provider, eval `src`.
+fn eval_with_fake(
+    interp: &Interpreter,
+    src: &str,
+    fake: FakeProvider,
+) -> (Result<Value, sema_core::SemaError>, Arc<FakeRecorder>) {
+    reset_runtime_state();
+    let recorder = fake.recorder();
+    register_test_provider(Box::new(fake));
+    (interp.eval_str(src), recorder)
+}
+
+#[test]
+fn test_mcp_agent_tool_call_round_trips_arguments() {
+    // The model calls `echo` with {text: "ping"}; the server echoes it back; the
+    // model then produces a final answer. Proves the whole adapter -> agent loop
+    // -> mcp/call -> server path passes the argument through correctly.
+    let interp = Interpreter::new();
+    interp.eval_str(&connect_expr()).unwrap();
+    interp
+        .eval_str(
+            r#"(defagent mcp-agent
+                 {:system "Use the echo tool." :model "fake-model"
+                  :tools (mcp/tools->sema server) :max-turns 5})"#,
+        )
+        .unwrap();
+
+    let fake = FakeProvider::builder("fake")
+        .model("fake-model")
+        .tool_call("call_1", "echo", serde_json::json!({ "text": "ping" }))
+        .reply("all done")
+        .build();
+
+    let (result, recorder) = eval_with_fake(&interp, r#"(agent/run mcp-agent "echo ping")"#, fake);
+    assert_eq!(result.unwrap().as_str(), Some("all done"));
+    assert_eq!(
+        recorder.call_count(),
+        2,
+        "expected a tool round then a reply"
+    );
+
+    // The round-2 request must carry the tool result the server produced — proof
+    // the "ping" argument actually reached the server (a nil-arg bug echoes "").
+    let round2 = &recorder.requests()[1];
+    let tool_msg = round2
+        .messages
+        .iter()
+        .find(|m| m.role == "tool")
+        .expect("round 2 must include the correlated tool result");
+    assert_eq!(tool_msg.content.as_text(), Some("ping"));
+
+    interp.eval_str("(mcp/close server)").unwrap();
+}
+
+#[test]
+fn test_mcp_tool_error_surfaces_to_agent() {
+    // A tool that returns `isError: true` must surface as an error the loop feeds
+    // back to the model, not a silent success.
+    let interp = Interpreter::new();
+    interp.eval_str(&connect_expr()).unwrap();
+    interp
+        .eval_str(
+            r#"(defagent boom-agent
+                 {:system "Try the tool." :model "fake-model"
+                  :tools (mcp/tools->sema server) :max-turns 5})"#,
+        )
+        .unwrap();
+
+    let fake = FakeProvider::builder("fake")
+        .model("fake-model")
+        .tool_call("call_1", "boom", serde_json::json!({}))
+        .reply("recovered")
+        .build();
+
+    let (result, recorder) = eval_with_fake(&interp, r#"(agent/run boom-agent "go")"#, fake);
+    assert_eq!(result.unwrap().as_str(), Some("recovered"));
+
+    let round2 = &recorder.requests()[1];
+    let tool_msg = round2
+        .messages
+        .iter()
+        .find(|m| m.role == "tool")
+        .expect("round 2 must include the tool result");
+    assert!(
+        tool_msg
+            .content
+            .as_text()
+            .unwrap_or_default()
+            .contains("kaboom"),
+        "the tool error detail should reach the model, got: {:?}",
+        tool_msg.content.as_text()
+    );
+
+    interp.eval_str("(mcp/close server)").unwrap();
+}
+
+#[test]
+fn test_mcp_connect_denied_without_process_capability() {
+    // Connecting spawns a process, so a sandbox that denies PROCESS must refuse.
+    let interp = InterpreterBuilder::new()
+        .with_sandbox(Sandbox::deny(Caps::PROCESS))
+        .build();
+    let err = interp
+        .eval_str(r#"(mcp/connect {:command "python3" :args ["-c" "pass"]})"#)
+        .expect_err("mcp/connect must be denied without the process capability");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("process") || msg.contains("capability") || msg.contains("mcp/connect"),
+        "unexpected error: {msg}"
+    );
+}

--- a/crates/sema/tests/mcp_cassette_test.rs
+++ b/crates/sema/tests/mcp_cassette_test.rs
@@ -1,0 +1,102 @@
+//! Acceptance gate for MCP-call cassette record/replay (M5). A stdio server
+//! whose `count` tool returns an ever-incrementing `call-N` is the oracle: after
+//! recording one call (`call-1`), a **replay** must return `call-1` again — if it
+//! had actually hit the server the counter would have advanced to `call-2`. A
+//! final cassette-free call proves the server *would* have returned `call-2`, so
+//! the replayed value provably came from the tape, not the network.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use sema::Interpreter;
+use sema_llm::builtins::{install_cassette, take_cassette};
+use sema_llm::cassette::{Cassette, CassetteMode};
+
+const SERVER: &str = r#"
+import json, sys
+initialized = False
+counter = 0
+def send(m):
+    sys.stdout.write(json.dumps(m) + "\n"); sys.stdout.flush()
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    r = json.loads(line); method = r.get("method"); rid = r.get("id")
+    if rid is None:
+        if method == "notifications/initialized":
+            initialized = True
+        continue
+    if method == "initialize":
+        send({"jsonrpc": "2.0", "id": rid, "result": {
+            "protocolVersion": "2025-11-25", "capabilities": {},
+            "serverInfo": {"name": "counter", "version": "1"}}})
+    elif method == "tools/list":
+        send({"jsonrpc": "2.0", "id": rid, "result": {"tools": [
+            {"name": "count", "description": "increment",
+             "inputSchema": {"type": "object", "properties": {}}}]}})
+    elif method == "tools/call":
+        counter += 1
+        send({"jsonrpc": "2.0", "id": rid, "result": {
+            "content": [{"type": "text", "text": "call-%d" % counter}], "isError": False}})
+    else:
+        send({"jsonrpc": "2.0", "id": rid, "error": {"code": -32601, "message": "no"}})
+"#;
+
+fn connect_expr() -> String {
+    let encoded = serde_json::to_string(SERVER).unwrap();
+    format!(r#"(define server (mcp/connect {{:command "python3" :args ["-c" {encoded}]}}))"#)
+}
+
+fn tape_path() -> PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    std::env::temp_dir().join(format!(
+        "sema-mcp-cassette-{}-{}/tape.ndjson",
+        std::process::id(),
+        n
+    ))
+}
+
+#[test]
+fn mcp_call_records_then_replays_without_hitting_the_server() {
+    let tape = tape_path();
+
+    // `Interpreter::new()` registers the MCP builtins + the cassette hook and
+    // resets runtime state — so install the cassette AFTER building it.
+    let interp = Interpreter::new();
+    interp.eval_str(&connect_expr()).expect("connect");
+
+    // --- Record: the real call runs and is taped. ---
+    install_cassette(Cassette::load(tape.clone(), CassetteMode::Record));
+    let r1 = interp
+        .eval_str(r#"(mcp/call server "count" {})"#)
+        .expect("record call");
+    assert_eq!(r1.as_str(), Some("call-1"));
+    take_cassette()
+        .expect("cassette installed")
+        .save()
+        .expect("save tape");
+
+    // --- Replay: the server is still alive, but the call must be served from
+    //     the tape (so the counter stays at 1). ---
+    install_cassette(Cassette::load(tape, CassetteMode::Replay));
+    let r2 = interp
+        .eval_str(r#"(mcp/call server "count" {})"#)
+        .expect("replay call");
+    assert_eq!(
+        r2.as_str(),
+        Some("call-1"),
+        "replay must return the recorded value, not re-hit the server"
+    );
+
+    // --- Proof: drop the cassette and call for real → the server advances to
+    //     call-2, confirming the replay above did NOT touch it. ---
+    take_cassette();
+    let r3 = interp
+        .eval_str(r#"(mcp/call server "count" {})"#)
+        .expect("live call");
+    assert_eq!(r3.as_str(), Some("call-2"));
+
+    interp.eval_str("(mcp/close server)").ok();
+}

--- a/docs/plans/2026-06-21-mcp-client-spike.md
+++ b/docs/plans/2026-06-21-mcp-client-spike.md
@@ -10,7 +10,7 @@ RFC 8252 loopback browser flow with `resource=` (RFC 8707), keychain/`0600`-file
 token storage, auto-refresh, RFC 8628 device flow, and a `sema mcp login/logout`
 CLI. Each layer is covered by offline scripted-server tests. **Remaining:** a
 live end-to-end run against a real OAuth-gated provider (needs a human + browser),
-and M5 (MCP-call cassette recording). See the milestones section for detail.
+(the browser flow is exercised end-to-end offline in tests). See the milestones section for detail.
 
 ## Decisions locked (2026-07-01)
 
@@ -456,7 +456,16 @@ agent tests that use MCP tools stay deterministic and offline in CI.
   URL and detect a first `endpoint` SSE event → drive the deprecated two-endpoint
   `2024-11-05` transport. *Acceptance:* headless login works via device flow against
   the test IdP; a `2024-11-05` server connects via the SSE fallback.
-- **M5 — MCP-call cassette recording** (shared format with LLM cassettes).
+- **M5 — MCP-call cassette recording [SHIPPED 2026-07-01].** `tools/call` records
+  and replays through the shared LLM cassette (kind `"mcp-call"`): a crate-neutral
+  hook in `sema-core` (`mcp_cassette_decide`/`record`) bridges `sema-mcp`'s call
+  seam to the `sema-llm` tape without a dependency edge; keyed by
+  `sha256(server-identity + tool + canonical args)`. A replay hit returns the
+  recorded result with no network. *Acceptance met:* record a call, then replay
+  returns it without re-hitting the server (proven by a server-side counter);
+  verified via the Rust gate and the Sema `llm/cassette-load`/`save` builtins.
+  Follow-up: recording `tools/list` + skipping `connect` on replay for a
+  fully-offline agent session (not needed for deterministic call replay).
 - **Convenience features (deferred — riff on after the first PR lands):**
   - **Named/aliased servers** — declare a server once (e.g. a name → `:url`/`:command`
     config, in a script or a config file) and refer to it by name in `mcp/connect`

--- a/docs/plans/2026-06-21-mcp-client-spike.md
+++ b/docs/plans/2026-06-21-mcp-client-spike.md
@@ -457,6 +457,14 @@ agent tests that use MCP tools stay deterministic and offline in CI.
   `2024-11-05` transport. *Acceptance:* headless login works via device flow against
   the test IdP; a `2024-11-05` server connects via the SSE fallback.
 - **M5 — MCP-call cassette recording** (shared format with LLM cassettes).
+- **Convenience features (deferred — riff on after the first PR lands):**
+  - **Named/aliased servers** — declare a server once (e.g. a name → `:url`/`:command`
+    config, in a script or a config file) and refer to it by name in `mcp/connect`
+    and the CLI, instead of repeating the URL.
+  - **`sema mcp list`** — show authenticated/known servers (and, if feasible, which
+    script or config declared each) alongside token status.
+  - Mid-session **`403 insufficient_scope`** step-up re-scope (initial-login scope
+    handling is done; mid-call step-up is not yet wired into `mcp/call`).
 
 ## Open questions
 

--- a/docs/plans/2026-06-21-mcp-client-spike.md
+++ b/docs/plans/2026-06-21-mcp-client-spike.md
@@ -463,8 +463,11 @@ agent tests that use MCP tools stay deterministic and offline in CI.
     and the CLI, instead of repeating the URL.
   - **`sema mcp list`** — show authenticated/known servers (and, if feasible, which
     script or config declared each) alongside token status.
-  - Mid-session **`403 insufficient_scope`** step-up re-scope (initial-login scope
-    handling is done; mid-call step-up is not yet wired into `mcp/call`).
+
+Mid-session auth recovery is **done** (2026-07-01): a `mcp/call` that gets a `401`
+(expired) refreshes/re-logs-in and retries; a `403 insufficient_scope` re-authorizes
+requesting the union of prior + challenged scopes and retries
+(`oauth::login::reauth_on_challenge`, wired into `call_tool_via_connection`).
 
 ## Open questions
 

--- a/docs/plans/2026-06-21-mcp-client-spike.md
+++ b/docs/plans/2026-06-21-mcp-client-spike.md
@@ -10,6 +10,42 @@ and **where** does it live (agent-only vs whole-language)? — and now also: how
 we reach **authenticated remote servers** (Asana, Linear, hosted GitHub, …) and
 what is the login/token journey.
 
+## Decisions locked (2026-07-01)
+
+Target spec revision: **`2025-11-25`** for BOTH transport and authorization (verified
+live against modelcontextprotocol.io). The `2026-07-28` revision is a release
+candidate — do NOT implement its additions (RFC 9207 `iss` validation, OIDC
+`application_type`, `Mcp-Method`/`Mcp-Name` routing headers) yet. This supersedes the
+older `2025-03-26` / `2025-06-18` version references elsewhere in this doc.
+
+1. **Build vs reuse → hand-roll + `oauth2` crate (Option B); M0 gate RESOLVED.**
+   Matches the shipped hand-rolled stdio client (M1/M2) and Sema's single-threaded
+   `block_on` model. `oauth2 = "5"` for PKCE-S256 + auth-code/refresh exchange (RFC
+   8707 `resource` via `.add_extra_param`); hand-roll RFC 9728/8414 discovery (~2
+   `GET`s + serde) and RFC 7591 DCR (one JSON `POST`). `rmcp` stays a documented
+   fallback + reference only. Early de-risk: confirm `oauth2 5` drives our reqwest
+   client via its `AsyncHttpClient` impl.
+2. **Token storage → OS keychain primary, `0600` JSON-file fallback.** `keyring` for
+   macOS Keychain / Windows Credential Manager / Linux Secret Service; fall back to a
+   `0600`-perm JSON file under the config dir on headless Linux/CI (no *automatic*
+   fallback exists — we implement it, with a visible plaintext warning). Keychain
+   calls block → wrap in `spawn_blocking`. Store per-server keyed by canonical URL:
+   tokens (access/refresh/expiry/scope) + DCR `client_info`.
+3. **First-PR scope = maximal completeness (all of the below must land + work before
+   the PR opens):** Streamable HTTP transport; bring-your-own-token (`:headers`);
+   full browser OAuth (discovery → DCR/pre-registered/CIMD → PKCE-S256 → loopback
+   capture → token exchange → refresh → `403 insufficient_scope` re-scope) with
+   keychain/file storage; **RFC 8628 device-authorization grant** for headless boxes
+   (capability-gated on AS support); print-URL-and-paste fallback as the always-
+   available floor; and **legacy 2024-11-05 HTTP+SSE back-compat** (POST→4xx→GET-for-
+   `endpoint`-event detection). `sema mcp login`/`logout` CLI. Crates: `oauth2`,
+   `webbrowser` (browser open, `hardened` feature), `tiny_http` (loopback listener),
+   `keyring`.
+
+Remaining genuine unknowns are per-server (e.g. whether Asana's AS accepts loopback
+redirect URIs) — resolved empirically during M4 against a live server, not blockers
+for starting M3.
+
 ## Context: today Sema is an MCP *server* only
 
 `crates/sema-mcp/` exposes Sema **to** external agents (protocol.rs, server.rs,
@@ -378,12 +414,10 @@ agent tests that use MCP tools stay deterministic and offline in CI.
 
 ## Milestones
 
-- **M0 — build-vs-reuse decision (gate before M3).** Resolve Option A (`rmcp`) vs
-  Option B (hand-roll + `oauth2`). Cheap spikes: (1) confirm `oauth2 = "5"` drives
-  our reqwest-0.13 client via `AsyncHttpClient` (the one Option-B risk); (2) sketch
-  bridging `rmcp`'s async `RunningService` behind a `block_on` Rc handle (the one
-  Option-A risk). Pick, then proceed. *Acceptance:* a one-page decision recorded
-  here with the spike result.
+- **M0 — build-vs-reuse decision [RESOLVED 2026-07-01 → Option B].** Hand-roll +
+  `oauth2` crate; see "Decisions locked" above. First implementation step of M3 is
+  the de-risk spike: confirm `oauth2 = "5"` drives our reqwest client via its
+  `AsyncHttpClient` impl.
 - **M1 — stdio client primitive [SHIPPED 2026-07-01]:** `mcp/connect` (stdio) +
   `initialize` (with the mandatory `notifications/initialized`) + `mcp/tools` +
   `mcp/call` + `mcp/close`; capability-gated (`PROCESS`); response-id correlation
@@ -411,6 +445,15 @@ agent tests that use MCP tools stay deterministic and offline in CI.
   OAuth-gated server (Asana/Linear). *Acceptance:* `mcp/connect` to a real
   OAuth-gated server completes the browser flow once, then reconnects silently from
   cached tokens; CI exercises the full flow against the local test IdP.
+- **M4b — device-authorization grant (RFC 8628) + legacy HTTP+SSE back-compat.** In
+  scope for the first PR (Decision #3). Device flow: check AS metadata for
+  `device_authorization_endpoint`; `POST /device/code` → display `user_code` +
+  `verification_uri` → poll `/token` honoring `interval`/`slow_down`/
+  `authorization_pending`; request `offline_access` for a refresh token (device flow
+  uses no PKCE). Legacy transport: on `initialize` POST failure (`4xx`), `GET` the
+  URL and detect a first `endpoint` SSE event → drive the deprecated two-endpoint
+  `2024-11-05` transport. *Acceptance:* headless login works via device flow against
+  the test IdP; a `2024-11-05` server connects via the SSE fallback.
 - **M5 — MCP-call cassette recording** (shared format with LLM cassettes).
 
 ## Open questions

--- a/docs/plans/2026-06-21-mcp-client-spike.md
+++ b/docs/plans/2026-06-21-mcp-client-spike.md
@@ -1,14 +1,16 @@
 # MCP Client — spike & scoping (Sema as an MCP *client*)
 
-**Status:** Scoping / design sketch (2026-06-21; auth + HTTP transport added
-2026-06-23). **M1 + M2 shipped** (stdio transport, 2026-07-01): the Layer-1
-`mcp/connect|tools|call|close` primitives and the Layer-2 `mcp/tools->sema` agent
-adapter now exist for the **stdio** transport (`crates/sema-mcp/src/client.rs` +
-`builtins.rs`), capability-gated on `PROCESS`. M3 (Streamable HTTP) and M4 (OAuth
-login) remain future work. Answers the two questions raised: **how** would it work
-and **where** does it live (agent-only vs whole-language)? — and now also: how do
-we reach **authenticated remote servers** (Asana, Linear, hosted GitHub, …) and
-what is the login/token journey.
+**Status:** **M1–M4 + M4b shipped (2026-07-01)** on branch `feature/mcp-client`.
+The Layer-1 `mcp/connect|tools|call|close` primitives and the Layer-2
+`mcp/tools->sema` adapter work over **all** transports: stdio (`PROCESS`-gated),
+Streamable HTTP (`NETWORK`-gated, spec `2025-11-25`), and the deprecated
+2024-11-05 HTTP+SSE (auto-fallback). Remote OAuth 2.1 is native and complete —
+discovery (RFC 9728/8414), DCR (RFC 7591), Authorization-Code + PKCE-S256 over an
+RFC 8252 loopback browser flow with `resource=` (RFC 8707), keychain/`0600`-file
+token storage, auto-refresh, RFC 8628 device flow, and a `sema mcp login/logout`
+CLI. Each layer is covered by offline scripted-server tests. **Remaining:** a
+live end-to-end run against a real OAuth-gated provider (needs a human + browser),
+and M5 (MCP-call cassette recording). See the milestones section for detail.
 
 ## Decisions locked (2026-07-01)
 
@@ -431,12 +433,12 @@ agent tests that use MCP tools stay deterministic and offline in CI.
   network/keys) in `crates/sema/tests/mcp_builtin_test.rs`. *Acceptance met:* an
   agent completes a tool call deterministically in CI. (Cassette recording — the
   shared LLM/MCP tape format — is still M5.)
-- **M3 — native Streamable HTTP transport** (the wire contract above:
+- **M3 — native Streamable HTTP transport [SHIPPED 2026-07-01]** (the wire contract above:
   `Mcp-Session-Id`, JSON-or-SSE branching, `MCP-Protocol-Version`) **+
   `:headers`/bring-your-own-token + `:mcp-servers` sugar on `defagent`.**
   Capability-gated (`NETWORK`). *Acceptance:* connect to a remote server with a
   static bearer token (no OAuth yet) against a real Streamable-HTTP server.
-- **M4 — native OAuth 2.1 login flow** (the auth architecture above): the auth-store
+- **M4 — native OAuth 2.1 login flow [SHIPPED 2026-07-01]** (the auth architecture above): the auth-store
   trait + engine; config dir + token store (keychain w/ `0600`-file fallback);
   PRM/AS discovery; DCR/CIMD/pre-registered client; PKCE; browser open + loopback
   callback (deterministic→ephemeral port); refresh + `403` re-scope + self-heal;
@@ -445,7 +447,7 @@ agent tests that use MCP tools stay deterministic and offline in CI.
   OAuth-gated server (Asana/Linear). *Acceptance:* `mcp/connect` to a real
   OAuth-gated server completes the browser flow once, then reconnects silently from
   cached tokens; CI exercises the full flow against the local test IdP.
-- **M4b — device-authorization grant (RFC 8628) + legacy HTTP+SSE back-compat.** In
+- **M4b — device-authorization grant (RFC 8628) + legacy HTTP+SSE back-compat [SHIPPED 2026-07-01].** In
   scope for the first PR (Decision #3). Device flow: check AS metadata for
   `device_authorization_endpoint`; `POST /device/code` → display `user_code` +
   `verification_uri` → poll `/token` honoring `interval`/`slow_down`/

--- a/docs/plans/2026-06-21-mcp-client-spike.md
+++ b/docs/plans/2026-06-21-mcp-client-spike.md
@@ -1,7 +1,11 @@
 # MCP Client — spike & scoping (Sema as an MCP *client*)
 
 **Status:** Scoping / design sketch (2026-06-21; auth + HTTP transport added
-2026-06-23). Not started. Answers the two questions raised: **how** would it work
+2026-06-23). **M1 + M2 shipped** (stdio transport, 2026-07-01): the Layer-1
+`mcp/connect|tools|call|close` primitives and the Layer-2 `mcp/tools->sema` agent
+adapter now exist for the **stdio** transport (`crates/sema-mcp/src/client.rs` +
+`builtins.rs`), capability-gated on `PROCESS`. M3 (Streamable HTTP) and M4 (OAuth
+login) remain future work. Answers the two questions raised: **how** would it work
 and **where** does it live (agent-only vs whole-language)? — and now also: how do
 we reach **authenticated remote servers** (Asana, Linear, hosted GitHub, …) and
 what is the login/token journey.
@@ -380,13 +384,19 @@ agent tests that use MCP tools stay deterministic and offline in CI.
   bridging `rmcp`'s async `RunningService` behind a `block_on` Rc handle (the one
   Option-A risk). Pick, then proceed. *Acceptance:* a one-page decision recorded
   here with the spike result.
-- **M1 — stdio client primitive:** `mcp/connect` (stdio) + `initialize` +
-  `mcp/tools` + `mcp/call` + `mcp/close`; capability-gated (`PROCESS`); a test
-  against the reference filesystem MCP server. *Acceptance:* list + call a real
-  MCP tool from Sema.
-- **M2 — agent adapter:** `mcp/tools->sema`; a `defagent` that uses an MCP tool
-  end-to-end (replayed via cassette in CI). *Acceptance:* an agent completes a
-  task using an external MCP tool, deterministically in CI.
+- **M1 — stdio client primitive [SHIPPED 2026-07-01]:** `mcp/connect` (stdio) +
+  `initialize` (with the mandatory `notifications/initialized`) + `mcp/tools` +
+  `mcp/call` + `mcp/close`; capability-gated (`PROCESS`); response-id correlation
+  (skips interleaved notifications) + a per-request timeout. Tested against a
+  scripted stdio server in `crates/sema-mcp/tests/mcp_client_test.rs`.
+  *Acceptance met:* list + call a tool from Sema.
+- **M2 — agent adapter [SHIPPED 2026-07-01]:** `mcp/tools->sema` inverts the MCP
+  `inputSchema` into the `deftool` params shape and wraps each tool in a handler
+  that rebuilds the arguments object and surfaces `isError` as a `SemaError`. A
+  `defagent` drives an external MCP tool end-to-end against a `FakeProvider` (no
+  network/keys) in `crates/sema/tests/mcp_builtin_test.rs`. *Acceptance met:* an
+  agent completes a tool call deterministically in CI. (Cassette recording — the
+  shared LLM/MCP tape format — is still M5.)
 - **M3 — native Streamable HTTP transport** (the wire contract above:
   `Mcp-Session-Id`, JSON-or-SSE branching, `MCP-Protocol-Version`) **+
   `:headers`/bring-your-own-token + `:mcp-servers` sugar on `defagent`.**

--- a/examples/mcp/asana-tasks.sema
+++ b/examples/mcp/asana-tasks.sema
@@ -9,17 +9,18 @@
 ;; in; the token is then cached (OS keychain, or a 0600 file) so later runs are
 ;; silent. You can also pre-authenticate from the shell:
 ;;
-;;     sema mcp login https://mcp.asana.com/sse
+;;     sema mcp login https://mcp.asana.com/mcp
 ;;
 ;; Requirements:
 ;;   - ANTHROPIC_API_KEY set in your environment (for the agent's model).
 ;;   - Network access (this reaches Asana). Run unsandboxed (the default).
 ;;
-;; NOTE: confirm Asana's current MCP endpoint from their docs and update
-;; `asana-url` below if it differs. Sema auto-detects Streamable-HTTP vs the
-;; legacy SSE transport, so either shape works.
+;; Asana exposes two endpoints (per https://developers.asana.com/docs/using-asanas-mcp-server):
+;;   - https://mcp.asana.com/mcp — modern Streamable HTTP (recommended)
+;;   - https://mcp.asana.com/sse — deprecated HTTP+SSE (also works; Sema
+;;     auto-detects and falls back to it)
 
-(define asana-url "https://mcp.asana.com/sse")
+(define asana-url "https://mcp.asana.com/mcp")
 
 ;; The model the agent uses. Any tool-use-capable Claude model works; bump this
 ;; to a stronger model if the agent struggles to pick the right Asana tool.

--- a/examples/mcp/asana-tasks.sema
+++ b/examples/mcp/asana-tasks.sema
@@ -1,0 +1,61 @@
+;; ---------------------------------------------------------------------------
+;; MCP client demo: an agent that fetches YOUR Asana tasks via Asana's MCP server
+;; ---------------------------------------------------------------------------
+;;
+;; This connects Sema (as an MCP *client*) to Asana's hosted MCP server, exposes
+;; its tools to an agent, and asks the agent to list the tasks assigned to you.
+;;
+;; FIRST RUN: Asana requires OAuth. `mcp/connect` will open your browser to log
+;; in; the token is then cached (OS keychain, or a 0600 file) so later runs are
+;; silent. You can also pre-authenticate from the shell:
+;;
+;;     sema mcp login https://mcp.asana.com/sse
+;;
+;; Requirements:
+;;   - ANTHROPIC_API_KEY set in your environment (for the agent's model).
+;;   - Network access (this reaches Asana). Run unsandboxed (the default).
+;;
+;; NOTE: confirm Asana's current MCP endpoint from their docs and update
+;; `asana-url` below if it differs. Sema auto-detects Streamable-HTTP vs the
+;; legacy SSE transport, so either shape works.
+
+(define asana-url "https://mcp.asana.com/sse")
+
+;; The model the agent uses. Any tool-use-capable Claude model works; bump this
+;; to a stronger model if the agent struggles to pick the right Asana tool.
+(define agent-model "claude-sonnet-5")
+
+;; --- 1. Connect (this triggers the OAuth browser login on the first run) ------
+(println "Connecting to Asana MCP server…")
+(define asana (mcp/connect {:url asana-url}))
+(println "Connected.\n")
+
+;; --- 2. Sanity check: what tools does the server expose? ----------------------
+(println "Available Asana tools:")
+(for-each
+  (fn (tool) (println "  - " (:name tool) " — " (:description tool)))
+  (mcp/tools asana))
+(println "")
+
+;; --- 3. Define an agent whose tools ARE the Asana MCP tools -------------------
+(defagent asana-agent
+  {:system (str "You are an Asana assistant. Use the available Asana tools to "
+                "answer the user. When asked about tasks assigned to the user, "
+                "resolve the current user (the Asana 'me' user) and list their "
+                "assigned, incomplete tasks with due dates. Be concise.")
+   :model agent-model
+   :tools (mcp/tools->sema asana)
+   :max-turns 8})
+
+;; --- 4. Run it ----------------------------------------------------------------
+(println "Asking the agent to fetch your assigned tasks…\n")
+(define answer
+  (agent/run asana-agent
+             "List the tasks currently assigned to me in Asana. Include the task name and due date if there is one."))
+
+(println "=== Result ===")
+(println answer)
+
+;; --- 5. Clean up --------------------------------------------------------------
+(mcp/close asana)
+(println "\n(token usage: " (llm/session-usage) ")")

--- a/website/docs/cli.md
+++ b/website/docs/cli.md
@@ -405,6 +405,25 @@ sema lsp
 
 Provides diagnostics, completion, hover, go-to-definition, and code lenses. See the [LSP documentation](/docs/lsp) for full feature details and editor setup instructions.
 
+### `sema mcp`
+
+Start the [Model Context Protocol](/docs/mcp) server (exposes Sema's tools to LLM clients), or manage **MCP client** authentication.
+
+```
+sema mcp [FILES]...                 # run the MCP server (optionally loading tool files)
+sema mcp login  <url> [--device] [--client-id ID]
+sema mcp logout <url>
+```
+
+- `sema mcp` (no subcommand) starts the stdio MCP **server** — see the [MCP documentation](/docs/mcp).
+- `sema mcp login <url>` authenticates to a remote MCP **server** you want to *consume* and caches the OAuth token so later `mcp/connect` calls are silent. `--device` uses the headless device-code flow; `--client-id` supplies a pre-registered OAuth client.
+- `sema mcp logout <url>` clears the cached credentials for a server.
+
+```bash
+sema mcp login https://mcp.asana.com/mcp
+sema mcp logout https://mcp.asana.com/mcp
+```
+
 ## Examples
 
 ```bash
@@ -548,6 +567,7 @@ sema --sandbox=no-shell,no-network --allowed-paths=./data script.sema
 | `SEMA_EMBEDDING_PROVIDER` | Preferred embedding provider                    |
 | `SEMA_REGISTRY_URL`  | Override default package registry URL                 |
 | `SEMA_RUNTIME_BASE_URL` | Override base URL for cross-compilation runtime downloads |
+| `SEMA_MCP_TOKEN_STORE` | MCP client token backend: `file` (0600 file) or `keychain` (OS keychain). Default: keychain when available, else file. |
 | `NO_COLOR`           | Disable colored output when set                       |
 
 

--- a/website/docs/mcp.md
+++ b/website/docs/mcp.md
@@ -16,59 +16,6 @@ Sema is also an MCP **client** — it can *consume* external MCP servers' tools 
 
 ---
 
-## Sema as an MCP client
-
-`mcp/connect` connects to an external MCP server and returns an opaque handle; the transport is chosen from the config map. `mcp/tools` lists its tools, `mcp/call` invokes one, and `mcp/close` disconnects.
-
-```scheme
-;; stdio: spawn a local server (needs the `process` capability). Credentials for
-;; a server that wants them go through :env.
-(define fs (mcp/connect {:command "npx"
-                         :args ["-y" "@modelcontextprotocol/server-filesystem" "/tmp"]}))
-
-(mcp/tools fs)
-; => [{:name "read_file" :description "…" :input-schema {…}} …]
-
-(mcp/call fs "read_file" {:path "/tmp/notes.txt"})
-(mcp/close fs)
-
-;; remote over Streamable HTTP (needs the `network` capability):
-(define gh (mcp/connect {:url "https://mcp.example.com/mcp"
-                         :headers {"Authorization" "Bearer …"}}))   ; bring-your-own-token
-```
-
-### Using external tools from an agent
-
-`mcp/tools->sema` converts a server's tools into the same value shape `deftool` produces, so `defagent` uses them exactly like local tools — no agent-loop changes:
-
-```scheme
-(defagent librarian
-  {:model "claude-…"
-   :system "You manage files."
-   :tools (mcp/tools->sema fs)})     ; MCP tools become first-class agent tools
-```
-
-### Authenticated remote servers (OAuth)
-
-For a remote server that requires authorization, `mcp/connect` runs the standards-compliant OAuth 2.1 flow automatically on the first `401`: it discovers the authorization server (RFC 9728 → RFC 8414/OIDC), registers or reuses a client (RFC 7591 dynamic registration, or a pre-registered `:auth {:client-id "…"}`), and completes the Authorization-Code + PKCE flow by **opening your browser** (RFC 8252 loopback capture). Tokens are cached in your OS keychain (with a `0600`-file fallback) and refreshed automatically, so later connects are silent.
-
-```scheme
-;; Browser opens on first use; subsequent runs reuse the cached token.
-(define asana (mcp/connect {:url "https://mcp.asana.com/mcp"}))
-```
-
-You can also authenticate ahead of time (or on a headless box) from the CLI:
-
-```bash
-sema mcp login https://mcp.example.com/mcp            # opens a browser
-sema mcp login https://mcp.example.com/mcp --device   # headless device-code flow
-sema mcp logout https://mcp.example.com/mcp           # clear cached credentials
-```
-
-Connecting to an MCP server runs its tools with the *server's* authority, not Sema's sandbox — treat connecting to an untrusted server like running untrusted code.
-
----
-
 ## Default MCP Tools
 
 When started, the MCP server exposes a set of core developer tools:
@@ -205,22 +152,25 @@ When a cell is evaluated, the cached engine runs the code, updates the cell outp
 
 ## Sema as an MCP Client
 
-The sections above cover Sema acting as an MCP **server**. Sema can also be an MCP **client** — connecting to an external MCP server and consuming its tools from Sema code, so you can use the wider MCP ecosystem (filesystem, GitHub, databases, …) without hand-writing a `deftool` for each.
+The sections above cover Sema acting as an MCP **server**. Sema can also be an MCP **client** — connecting to an external MCP server and consuming its tools from Sema code, so you can use the wider MCP ecosystem (filesystem, GitHub, Slack, databases, hosted vendors like Asana/Linear, …) without hand-writing a `deftool` for each.
 
-The client currently speaks the **stdio** transport: it launches the server as a child process and exchanges JSON-RPC 2.0 over its stdin/stdout. (Remote `Streamable HTTP` servers and the OAuth login flow for authenticated providers are a separate, future milestone.)
-
-### Client Builtins
+### Client builtins
 
 | Function | Description |
 |---|---|
-| `mcp/connect` | Launch a stdio MCP server, perform the `initialize` handshake, and return an opaque handle |
+| `mcp/connect` | Connect to a server (stdio or HTTP), run the `initialize` handshake, and return an opaque handle |
 | `mcp/tools` | List the server's tools as descriptor maps (`{:name :description :input-schema}`) |
 | `mcp/call` | Call a tool by name with an arguments map; returns the result (text collapses to a string) |
 | `mcp/tools->sema` | Convert the server's tools into `deftool`-shaped values ready to hand to `defagent` |
-| `mcp/close` | Terminate the server process and drop the handle |
+| `mcp/close` | Disconnect (terminate the stdio child / end the HTTP session) and drop the handle |
+
+`mcp/connect` chooses its transport from the config map: `:command` for a local **stdio** server, `:url` for a **remote** one.
+
+### Transports
+
+**stdio** — launch the server as a child process and exchange JSON-RPC 2.0 over its stdin/stdout. `:command` is required; `:args`, `:env`, and `:cwd` are optional. A server that needs a credential reads it from the environment Sema hands the child, so pass tokens through `:env`:
 
 ```scheme
-;; Connect to a stdio MCP server. :command is required; :args, :env and :cwd are optional.
 (define fs (mcp/connect {:command "npx"
                          :args ["-y" "@modelcontextprotocol/server-filesystem" "/tmp"]}))
 
@@ -231,33 +181,83 @@ The client currently speaks the **stdio** transport: it launches the server as a
 ; => "…file contents…"
 
 (mcp/close fs)
-```
 
-A server that needs a credential reads it from the environment Sema hands the child process, so pass tokens through the `:env` map:
-
-```scheme
+;; A server that reads a token from its environment:
 (define gh (mcp/connect {:command "github-mcp-server"
                          :env {"GITHUB_TOKEN" (env "GITHUB_TOKEN")}}))
 ```
 
-### Using MCP Tools in an Agent
+**HTTP** — connect to a remote server by `:url`. Sema speaks the modern **Streamable HTTP** transport (MCP spec `2025-11-25`: a single endpoint, `Mcp-Session-Id` continuity, JSON-or-SSE responses) and **auto-detects and falls back** to the deprecated 2024-11-05 HTTP+SSE two-endpoint transport when a server only speaks that — so you use the same call either way:
+
+```scheme
+;; Open server, or a static bearer token you already have:
+(define gh (mcp/connect {:url "https://mcp.example.com/mcp"
+                         :headers {"Authorization" "Bearer ghp_…"}}))
+```
+
+### Authenticated remote servers (OAuth)
+
+For a remote server that requires authorization, `mcp/connect` runs the standards-compliant **OAuth 2.1** flow automatically on the first `401` — no bespoke steps:
+
+1. **Discover** the authorization server from the `WWW-Authenticate` challenge → Protected Resource Metadata (RFC 9728) → Authorization Server Metadata (RFC 8414 / OpenID Connect Discovery).
+2. **Obtain a client id** — a pre-registered one you pass as `:auth {:client-id "…"}`, a cached one, or Dynamic Client Registration (RFC 7591).
+3. **Authorize** with the Authorization-Code + **PKCE-S256** flow, binding the token to the server with `resource=` (RFC 8707), by **opening your browser** and capturing the redirect on a loopback listener (RFC 8252).
+4. **Cache & refresh** — tokens are stored (OS keychain, or a `0600` file) and refreshed automatically, so later connects are silent.
+
+```scheme
+;; Browser opens on first use; subsequent runs reuse the cached token.
+(define asana (mcp/connect {:url "https://mcp.asana.com/mcp"}))
+
+;; Pin a pre-registered client when the server has no dynamic registration:
+(define linear (mcp/connect {:url "https://mcp.linear.app/mcp"
+                             :auth {:client-id "your-client-id"}}))
+```
+
+Prefer to authenticate ahead of time (recommended, and required on a headless box)? Use the CLI:
+
+```bash
+sema mcp login  https://mcp.example.com/mcp             # opens a browser
+sema mcp login  https://mcp.example.com/mcp --device    # RFC 8628 device-code flow (headless)
+sema mcp login  https://mcp.example.com/mcp --client-id ID   # pre-registered client
+sema mcp logout https://mcp.example.com/mcp             # clear cached credentials
+```
+
+**Token storage.** Credentials are kept per server URL in the OS keychain by default, falling back to a `0600`-permission file (`~/.config/sema/mcp-auth.json`, XDG-aware) on headless boxes. Override the backend with an environment variable:
+
+```bash
+export SEMA_MCP_TOKEN_STORE=file      # force the 0600 file store (no keychain prompts)
+export SEMA_MCP_TOKEN_STORE=keychain  # force the OS keychain
+```
+
+> **Tip (dev):** a locally-built (ad-hoc-signed) `sema` binary gets a new code identity every time you rebuild, so macOS Keychain re-prompts after each `cargo build`. Set `SEMA_MCP_TOKEN_STORE=file` while iterating to avoid the prompts.
+
+### Using MCP tools in an agent
 
 `mcp/tools->sema` produces values structurally identical to what `deftool` yields, so an agent uses them exactly like local tools — no new agent concepts:
 
 ```scheme
-(define fs (mcp/connect {:command "npx"
-                         :args ["-y" "@modelcontextprotocol/server-filesystem" "/tmp"]}))
+(define asana (mcp/connect {:url "https://mcp.asana.com/mcp"}))
 
-(defagent librarian
-  {:model "claude-haiku-4-5-20251001"
-   :system "You manage files in /tmp."
-   :tools (mcp/tools->sema fs)})
+(defagent assistant
+  {:model "claude-sonnet-5"
+   :system "You are an Asana assistant. Use the tools to answer."
+   :tools (mcp/tools->sema asana)
+   :max-turns 8})
 
-(agent/run librarian "Summarize the newest note in /tmp.")
+(agent/run assistant "List the tasks assigned to me, with due dates.")
 ```
 
-A tool that reports `isError` surfaces as an error the agent loop feeds back to the model, so the agent can react to failures instead of treating them as success.
+A tool that reports `isError` surfaces as an error the agent loop feeds back to the model, so the agent can react to failures instead of treating them as success. A full runnable example lives at `examples/mcp/asana-tasks.sema`.
 
 ### Security
 
-Connecting to an MCP server **spawns a process**, so `mcp/connect` requires the `process` capability (see the [`--sandbox`](/docs/cli) CLI flag) — a sandbox that denies process spawning cannot open MCP connections. Note that the tools a server exposes run with the **server's** authority, not Sema's sandbox: connecting to an untrusted MCP server is equivalent to running untrusted code.
+- **Capabilities.** A stdio connection **spawns a process** (`process` capability); an HTTP connection is **network I/O** (`network` capability). A sandbox that denies the relevant capability cannot open that kind of connection (see the [`--sandbox`](/docs/cli) flag).
+- **Server authority.** The tools a server exposes run with the **server's** authority, not Sema's sandbox — connecting to an untrusted MCP server is equivalent to running untrusted code.
+- **Untrusted output.** Tool descriptions and results are **data, not instructions**. They come from the server and can contain prompt-injection (e.g. "tell the user to reconnect to server X"). Treat them as untrusted input; never act on instructions embedded in tool output.
+
+### Troubleshooting
+
+- **`OAuth login failed` / no browser opens** — on a headless machine, use `sema mcp login <url> --device` (device-code flow) or pass a token directly via `:headers {"Authorization" "Bearer …"}`.
+- **Repeated macOS Keychain prompts while developing** — expected for a frequently-rebuilt dev binary; set `SEMA_MCP_TOKEN_STORE=file`.
+- **`mcp/connect requires a :command or :url entry`** — the config map needs one of `:command` (stdio) or `:url` (http).
+- Errors surface as `SemaError` values, so wrap `mcp/connect`/`mcp/call` in your usual error handling.

--- a/website/docs/mcp.md
+++ b/website/docs/mcp.md
@@ -255,6 +255,23 @@ A tool that reports `isError` surfaces as an error the agent loop feeds back to 
 - **Server authority.** The tools a server exposes run with the **server's** authority, not Sema's sandbox — connecting to an untrusted MCP server is equivalent to running untrusted code.
 - **Untrusted output.** Tool descriptions and results are **data, not instructions**. They come from the server and can contain prompt-injection (e.g. "tell the user to reconnect to server X"). Treat them as untrusted input; never act on instructions embedded in tool output.
 
+### Deterministic testing (cassettes)
+
+MCP `tools/call` results record and replay through the same **cassette** tape as LLM calls, so an agent-over-MCP flow can be captured once and replayed offline (no network, no live server) in CI. Record a session, then replay it:
+
+```scheme
+;; Record: real calls run and their results are taped.
+(llm/cassette-load "tape.ndjson" {:mode :record})
+(define s (mcp/connect {:url "https://mcp.example.com/mcp"}))
+(mcp/call s "search" {:q "hello"})
+(llm/cassette-save)
+
+;; Replay: the same call is served from the tape without touching the network.
+(llm/cassette-load "tape.ndjson" {:mode :replay})
+```
+
+A call is keyed by a hash of the server identity + tool name + arguments; a replay with no matching entry is a hard "miss" so drift is caught. (`SEMA_LLM_CASSETTE=tape.ndjson SEMA_LLM_CASSETTE_MODE=replay` installs a tape process-wide for a test suite.)
+
 ### Troubleshooting
 
 - **`OAuth login failed` / no browser opens** — on a headless machine, use `sema mcp login <url> --device` (device-code flow) or pass a token directly via `:headers {"Authorization" "Bearer …"}`.

--- a/website/docs/mcp.md
+++ b/website/docs/mcp.md
@@ -12,6 +12,61 @@ The server communicates over standard input/output (stdio) using JSON-RPC 2.0.
 sema mcp
 ```
 
+Sema is also an MCP **client** — it can *consume* external MCP servers' tools (see [Sema as an MCP client](#sema-as-an-mcp-client) below).
+
+---
+
+## Sema as an MCP client
+
+`mcp/connect` connects to an external MCP server and returns an opaque handle; the transport is chosen from the config map. `mcp/tools` lists its tools, `mcp/call` invokes one, and `mcp/close` disconnects.
+
+```scheme
+;; stdio: spawn a local server (needs the `process` capability). Credentials for
+;; a server that wants them go through :env.
+(define fs (mcp/connect {:command "npx"
+                         :args ["-y" "@modelcontextprotocol/server-filesystem" "/tmp"]}))
+
+(mcp/tools fs)
+; => [{:name "read_file" :description "…" :input-schema {…}} …]
+
+(mcp/call fs "read_file" {:path "/tmp/notes.txt"})
+(mcp/close fs)
+
+;; remote over Streamable HTTP (needs the `network` capability):
+(define gh (mcp/connect {:url "https://mcp.example.com/mcp"
+                         :headers {"Authorization" "Bearer …"}}))   ; bring-your-own-token
+```
+
+### Using external tools from an agent
+
+`mcp/tools->sema` converts a server's tools into the same value shape `deftool` produces, so `defagent` uses them exactly like local tools — no agent-loop changes:
+
+```scheme
+(defagent librarian
+  {:model "claude-…"
+   :system "You manage files."
+   :tools (mcp/tools->sema fs)})     ; MCP tools become first-class agent tools
+```
+
+### Authenticated remote servers (OAuth)
+
+For a remote server that requires authorization, `mcp/connect` runs the standards-compliant OAuth 2.1 flow automatically on the first `401`: it discovers the authorization server (RFC 9728 → RFC 8414/OIDC), registers or reuses a client (RFC 7591 dynamic registration, or a pre-registered `:auth {:client-id "…"}`), and completes the Authorization-Code + PKCE flow by **opening your browser** (RFC 8252 loopback capture). Tokens are cached in your OS keychain (with a `0600`-file fallback) and refreshed automatically, so later connects are silent.
+
+```scheme
+;; Browser opens on first use; subsequent runs reuse the cached token.
+(define asana (mcp/connect {:url "https://mcp.asana.com/mcp"}))
+```
+
+You can also authenticate ahead of time (or on a headless box) from the CLI:
+
+```bash
+sema mcp login https://mcp.example.com/mcp            # opens a browser
+sema mcp login https://mcp.example.com/mcp --device   # headless device-code flow
+sema mcp logout https://mcp.example.com/mcp           # clear cached credentials
+```
+
+Connecting to an MCP server runs its tools with the *server's* authority, not Sema's sandbox — treat connecting to an untrusted server like running untrusted code.
+
 ---
 
 ## Default MCP Tools

--- a/website/docs/mcp.md
+++ b/website/docs/mcp.md
@@ -145,3 +145,64 @@ The MCP server exposes a set of stateful notebook management and evaluation tool
 To support interactive cell execution (where Cell 2 relies on variables or functions defined in Cell 1), the MCP server maintains an in-memory cache of notebook evaluation engines mapped by their canonical file paths.
 
 When a cell is evaluated, the cached engine runs the code, updates the cell output, saves the updated JSON representation back to disk, and returns the result, ensuring state is preserved across consecutive tool calls.
+
+---
+
+## Sema as an MCP Client
+
+The sections above cover Sema acting as an MCP **server**. Sema can also be an MCP **client** — connecting to an external MCP server and consuming its tools from Sema code, so you can use the wider MCP ecosystem (filesystem, GitHub, databases, …) without hand-writing a `deftool` for each.
+
+The client currently speaks the **stdio** transport: it launches the server as a child process and exchanges JSON-RPC 2.0 over its stdin/stdout. (Remote `Streamable HTTP` servers and the OAuth login flow for authenticated providers are a separate, future milestone.)
+
+### Client Builtins
+
+| Function | Description |
+|---|---|
+| `mcp/connect` | Launch a stdio MCP server, perform the `initialize` handshake, and return an opaque handle |
+| `mcp/tools` | List the server's tools as descriptor maps (`{:name :description :input-schema}`) |
+| `mcp/call` | Call a tool by name with an arguments map; returns the result (text collapses to a string) |
+| `mcp/tools->sema` | Convert the server's tools into `deftool`-shaped values ready to hand to `defagent` |
+| `mcp/close` | Terminate the server process and drop the handle |
+
+```scheme
+;; Connect to a stdio MCP server. :command is required; :args, :env and :cwd are optional.
+(define fs (mcp/connect {:command "npx"
+                         :args ["-y" "@modelcontextprotocol/server-filesystem" "/tmp"]}))
+
+(mcp/tools fs)
+; => ({:name "read_file" :description "…" :input-schema {…}} …)
+
+(mcp/call fs "read_file" {:path "/tmp/notes.txt"})
+; => "…file contents…"
+
+(mcp/close fs)
+```
+
+A server that needs a credential reads it from the environment Sema hands the child process, so pass tokens through the `:env` map:
+
+```scheme
+(define gh (mcp/connect {:command "github-mcp-server"
+                         :env {"GITHUB_TOKEN" (env "GITHUB_TOKEN")}}))
+```
+
+### Using MCP Tools in an Agent
+
+`mcp/tools->sema` produces values structurally identical to what `deftool` yields, so an agent uses them exactly like local tools — no new agent concepts:
+
+```scheme
+(define fs (mcp/connect {:command "npx"
+                         :args ["-y" "@modelcontextprotocol/server-filesystem" "/tmp"]}))
+
+(defagent librarian
+  {:model "claude-haiku-4-5-20251001"
+   :system "You manage files in /tmp."
+   :tools (mcp/tools->sema fs)})
+
+(agent/run librarian "Summarize the newest note in /tmp.")
+```
+
+A tool that reports `isError` surfaces as an error the agent loop feeds back to the model, so the agent can react to failures instead of treating them as success.
+
+### Security
+
+Connecting to an MCP server **spawns a process**, so `mcp/connect` requires the `process` capability (see the [`--sandbox`](/docs/cli) CLI flag) — a sandbox that denies process spawning cannot open MCP connections. Note that the tools a server exposes run with the **server's** authority, not Sema's sandbox: connecting to an untrusted MCP server is equivalent to running untrusted code.

--- a/website/docs/mcp.md
+++ b/website/docs/mcp.md
@@ -222,7 +222,7 @@ sema mcp login  https://mcp.example.com/mcp --client-id ID   # pre-registered cl
 sema mcp logout https://mcp.example.com/mcp             # clear cached credentials
 ```
 
-**Token storage.** Credentials are kept per server URL in the OS keychain by default, falling back to a `0600`-permission file (`~/.config/sema/mcp-auth.json`, XDG-aware) on headless boxes. Override the backend with an environment variable:
+**Token storage.** Credentials are kept per server URL in the OS keychain by default, falling back to a `0600`-permission `mcp-auth.json` in the platform config directory on headless boxes (Linux: `$XDG_CONFIG_HOME` or `~/.config/sema/`; macOS: `~/Library/Application Support/sema/`; Windows: `%APPDATA%\sema\`). Override the backend with an environment variable:
 
 ```bash
 export SEMA_MCP_TOKEN_STORE=file      # force the 0600 file store (no keychain prompts)


### PR DESCRIPTION
Makes Sema an MCP **client**, not just a server: it can connect to external MCP servers and consume their tools from Sema code (and from `defagent`). Supersedes the closed #57.

## What's included

**Transports (`mcp/connect` picks by config):**
- **stdio** (`:command`) — spawn a local server, JSON-RPC over stdio; `process`-gated; creds via `:env`.
- **Streamable HTTP** (`:url`) — remote servers, MCP spec `2025-11-25` (`Mcp-Session-Id`, JSON-or-SSE, `MCP-Protocol-Version`); `network`-gated; `:headers` for a bring-your-own token.
- **Legacy 2024-11-05 HTTP+SSE** — auto-detected fallback (POST→404/405→GET-`endpoint`).

**Agent adapter:** `mcp/tools->sema` yields `deftool`-shaped values so `defagent` uses MCP tools with zero agent-loop changes (`isError` → error).

**Native OAuth 2.1** for authenticated remote servers (no bespoke steps): RFC 9728/8414 discovery → RFC 7591 DCR / pre-registered / cached client → Authorization-Code + PKCE-S256 over an RFC 8252 loopback browser flow with `resource=` (RFC 8707) → keychain / `0600`-file token storage with auto-refresh. Headless **RFC 8628 device-code** flow too. `sema mcp login`/`logout` CLI; `SEMA_MCP_TOKEN_STORE=file|keychain`.

## Verified against real Asana
End-to-end: browser OAuth → connect (both `/mcp` Streamable HTTP and `/sse` legacy) → 47 tools → agent returned the user's assigned tasks. Live testing caught three real bugs the scripted tests missed (legacy-fallback-after-auth, `params:null`→400, CLI not registering `mcp/*`) — all fixed + regression-tested.

## Testing
Offline scripted-server acceptance gates for each layer (stdio, Streamable HTTP + SSE, full OAuth login with server-side PKCE verification, OAuth-gated connect + cached reconnect, device flow, legacy HTTP+SSE) + unit tests. `make lint` / `make docs-check` green; no regressions (527 integration + 1034 eval).

## Docs
`crates/sema-docs/entries/stdlib/mcp/*` for all five builtins; rewritten `website/docs/mcp.md` client guide; `cli.md` updated.

## Deferred (tracked in the plan doc; per discussion, riff on after this lands)
Named/aliased servers, `sema mcp list`, mid-session `403 insufficient_scope` step-up re-scope, and M5 MCP-call cassette recording.

Plan: `docs/plans/2026-06-21-mcp-client-spike.md`.