### PR TITLE
spike: modular Jakefile to replace the Makefile (jake migration)

### DIFF
--- a/Jakefile
+++ b/Jakefile
@@ -1,0 +1,60 @@
+# Jakefile — build automation for Sema (Lisp with LLM primitives, in Rust)
+#
+# A spike replacing the 393-line Makefile with modular Jake recipes.
+# Run `jake -l` for the grouped recipe list, `jake -s <recipe>` for details.
+#
+# Module layout (each file owns one area; imported below, some namespaced):
+#   jake/rust.jake     — cargo build/test/lint/install/pgo  (UNnamespaced: the daily drivers)
+#   jake/docs.jake     — builtin-doc index, pricing, link check
+#   jake/examples.jake — headless example + notebook + bytecode smoke runners
+#   jake/wasm.jake     — WASM VM build + browser-runtime vendoring (file recipes = incremental)
+#   jake/ui.jake       — @sema/ui component library build + vendoring into notebook/playground
+#   jake/web.jake      — VitePress docs site (build/preview/deploy/OG cards)
+#   jake/playground.jake — sema.run WASM playground (build/dev/deploy)
+#   jake/bench.jake    — hyperfine benchmarks + samply profiling
+#   jake/fuzz.jake     — cargo-fuzz + in-Sema grammar fuzzer
+#   jake/editors.jake  — tree-sitter grammar, LSP e2e
+#   jake/release.jake  — coverage, mutation testing, publish-list guard
+
+@import "jake/rust.jake"
+@import "jake/docs.jake"
+@import "jake/examples.jake"
+@import "jake/wasm.jake" as wasm
+@import "jake/ui.jake" as ui
+@import "jake/web.jake" as site
+@import "jake/playground.jake" as pg
+@import "jake/bench.jake" as bench
+@import "jake/fuzz.jake" as fuzz
+@import "jake/editors.jake" as ed
+@import "jake/release.jake" as release
+
+# ── Aggregate pipelines ──────────────────────────────────────────────
+
+@group ci
+@desc "Lint + test + build (the `make all` equivalent)"
+task all: [lint, test, build]
+    echo "all: lint + test + build complete"
+
+# Full CI-equivalent gate (mirrors AGENTS.md release step 1). Runs the checks
+# plain `cargo test` skips: example + bytecode smoke suites. Dependencies run
+# in listed order (run serial, i.e. without -j, so the gate reads top-to-bottom).
+@group ci
+@desc "Full local CI gate: workspace tests + examples + bytecode smoke + lint + docs"
+task ci: [test-workspace, examples, smoke-bytecode, lint, docs-check]
+    echo "CI gate green"
+
+# One-shot "ship the web": build playground, gate on E2E, deploy site + playground.
+@group deploy
+@desc "Build + E2E-gate + deploy both docs site and playground to production"
+task deploy-all: [pg.build]
+    @confirm "Deploy site AND playground to production?"
+    cd playground && npx playwright test
+    jake ed.test-notebook-e2e
+    jake site.deploy
+    jake pg.deploy
+    echo "site + playground deployed"
+
+@group deploy
+@desc "Quick deploy (site + playground, skips the E2E gate)"
+task deploy: [site.deploy, pg.deploy]
+    echo "deployed site + playground"

--- a/Jakefile
+++ b/Jakefile
@@ -28,6 +28,10 @@
 @import "jake/editors.jake" as ed
 @import "jake/release.jake" as release
 
+# Load .env so LLM/provider tasks pick up API keys (ANTHROPIC_API_KEY, …)
+# without polluting the shell. No-op when there's no .env.
+@dotenv
+
 # ── Aggregate pipelines ──────────────────────────────────────────────
 
 @group ci
@@ -42,6 +46,23 @@ task all: [lint, test, build]
 @desc "Full local CI gate: workspace tests + examples + bytecode smoke + lint + docs"
 task ci: [test-workspace, examples, smoke-bytecode, lint, docs-check]
     echo "CI gate green"
+
+# Runs the full CI gate, then prints the manual release steps from AGENTS.md.
+# The version-bump sed across Cargo.toml stays manual by design (too risky to
+# automate); this just gets you to a verified-green tree and reminds the steps.
+@group ci
+@desc "Run the CI gate, then print the manual release checklist"
+task release-preflight: [ci]
+    @echo ""
+    @echo "CI gate is green. To cut a release (see AGENTS.md 'Release Procedure'):"
+    @echo "  1. Bump workspace version + every inter-crate =X.Y.Z pin in Cargo.toml"
+    @echo "     sed -i '' -e 's/^version = \"OLD\"/version = \"NEW\"/' \\"
+    @echo "               -e 's/version = \"=OLD\"/version = \"=NEW\"/g' Cargo.toml"
+    @echo "     grep -c 'OLD' Cargo.toml   # must be 0"
+    @echo "  2. Add a ## X.Y.Z section at the top of CHANGELOG.md"
+    @echo "  3. cargo build --release && ./target/release/sema --version"
+    @echo "  4. git commit -m 'release: X.Y.Z' && git tag vX.Y.Z"
+    @echo "  5. git push origin main --tags   # then confirm 'gh run list' is green"
 
 # One-shot "ship the web": build playground, gate on E2E, deploy site + playground.
 @group deploy

--- a/docs/plans/2026-07-03-jake-migration.md
+++ b/docs/plans/2026-07-03-jake-migration.md
@@ -1,0 +1,109 @@
+# Jake migration spike — replacing the Makefile with jakefile.dev
+
+**Date:** 2026-07-03 · **Status:** spike complete, adoption gated on jake#17 · **Branch:** `worktree-jake-spike`
+
+Spike to evaluate replacing the 393-line `Makefile` with [Jake](https://jakefile.dev)
+(`helgesverre/jake`, dogfooding our own tool). Everything below was built and verified in an
+isolated worktree; **the repo Makefile is untouched.**
+
+## What was built
+
+A modular `Jakefile` + `jake/*.jake` set porting the whole Makefile (96 recipes, 23 groups):
+
+| File | Namespace | Covers |
+| --- | --- | --- |
+| `Jakefile` | — | imports + aggregate pipelines (`all`, `ci`, `deploy`, `deploy-all`) |
+| `jake/rust.jake` | *(bare)* | build/release/pgo, install, test*, lint/clippy/fmt |
+| `jake/docs.jake` | *(bare)* | doc index, pricing, link check, docs-search-gate |
+| `jake/examples.jake` | *(bare)* | examples, examples-build, smoke-bytecode, notebooks, llm/provider smokes |
+| `jake/wasm.jake` | `wasm` | WASM VM build + **shared** browser-runtime vendoring |
+| `jake/ui.jake` | `ui` | `@sema/ui` build + **vendoring into notebook/playground** |
+| `jake/web.jake` | `site` | VitePress docs site build/preview/deploy/og |
+| `jake/playground.jake` | `pg` | sema.run WASM playground build/dev/deploy |
+| `jake/bench.jake` | `bench` | hyperfine suites, 1BRC ladder, samply profile |
+| `jake/fuzz.jake` | `fuzz` | cargo-fuzz + in-Sema grammar fuzzer |
+| `jake/editors.jake` | `ed` | tree-sitter grammar + browser E2E suites |
+| `jake/release.jake` | `release` | coverage, mutation testing, publish-list guard |
+
+The daily drivers (`build`, `test`, `lint`, `fmt`, `run`) are imported **un-namespaced** so muscle
+memory carries over (`jake build` == `make build`). Everything else is namespaced to keep `jake -l`
+navigable.
+
+## Why Jake is a real improvement here (verified)
+
+1. **Discoverability.** `jake -l` groups 96 recipes under 23 `@group`s with a `@desc` each; `jake -s <r>`
+   shows deps/params/commands; typo suggestions. The Makefile is a flat 50-target `.PHONY` wall.
+2. **`@needs` pre-flight.** Recipes declare their external tools (`wasm-pack`, `vercel`/`npx`, `uv`,
+   `docker`, `jq`, `lychee`, `samply`, `hyperfine`, `cargo-llvm-cov`, `cargo-mutants`) with install
+   hints. Verified: a missing tool fails **before** any command runs, with the custom hint. The
+   Makefile just explodes mid-recipe with a cryptic `command not found`.
+3. **`@cd` kills the `cd X && …` noise** across website/playground/ui/tree-sitter recipes.
+4. **`@confirm` on deploys.** `site.deploy` / `pg.deploy` / `deploy-all` now prompt before
+   `vercel --prod`; the Makefile fired `--prod --yes` immediately.
+5. **DRY vendoring.** The web-runtime copy-list (~8 files) was duplicated between `web-runtime` and
+   `sema-web-example-build` in the Makefile; here it's one private `wasm._vendor-runtime <dir>`
+   parameterized recipe.
+6. **Parallelism.** `jake -j` runs independent recipes concurrently (site + wasm + ui builds), with
+   dependency ordering respected. No `make -j` foot-guns.
+7. **Params instead of `$(if $(N),…)` soup.** `bench`, `profile`, `fuzz.grammar` take clean
+   `name=value` params (`jake fuzz.grammar n=20000 seed=123`) with `@if`/`@else` for optional flags.
+
+Verified end-to-end: `jake -l` (parse), dependency + cross-namespace resolution (`ci`,
+`ed.test-web-e2e -> wasm.web-runtime`, bare `[build]` from a namespaced import), param/conditional
+expansion, and a **real** `jake fmt-check` run against the repo (`cargo fmt --check`, exit 0).
+
+## The monorepo vendoring story (the main motivation)
+
+`@sema/ui` (Lit components) is **not npm-published**; it's built once (`ui/dist/sema-ui.js`) and
+**copied** into each consumer — currently the notebook crate (`crates/sema-notebook/src/ui/vendor/`,
+embedded via `include_str!`), with the playground to follow (notebook-ui-refactor branch). The same
+pattern already exists for the sema-web browser runtime.
+
+Modeled as a two-stage `file`-recipe chain:
+
+```
+file ui/dist/sema-ui.js: ui/src/**/* …        # stage 1: build the bundle
+file crates/sema-notebook/.../sema-ui.js: ui/dist/sema-ui.js   # stage 2: re-copy
+task ui.vendor: [vendor-notebook, vendor-playground]
+```
+
+This is the ideal shape: re-vendor only when `ui/src` actually changed, one `jake ui.vendor` for all
+consumers. **However — see the blocker.**
+
+## ⚠️ Blocker: incremental `file` recipes are currently a no-op (jake#17)
+
+Jake 0.8.1's incremental caching does not work in the CLI path: **`file` recipes and `@cache` always
+re-run**, and `.jake/cache` stays 0 bytes. Root-caused to `Executor.initWithIndexAndContext` copying
+`runtime.cache` **by value** (`src/executor.zig:123`) — the executor mutates its copy, but
+`RuntimeContext.deinit` saves the un-updated original. Filed as
+[jake#17](https://github.com/HelgeSverre/jake/issues/17) with the source analysis and a suggested fix
+(share the cache by pointer, like `environment`/`hook_runner`).
+
+**Consequence for adoption:** with the bug present, our `file` recipes behave exactly like the
+Makefile's always-copy targets — i.e. **no regression**, just no incremental win yet. Once jake#17
+lands, `ui.vendor` / wasm vendoring become genuinely incremental with zero Jakefile changes.
+
+Also filed while spiking:
+- [jake#18](https://github.com/HelgeSverre/jake/issues/18) — import error doesn't name the missing file.
+- [jake#19](https://github.com/HelgeSverre/jake/issues/19) — `--fmt` hoists/merges leading comments across
+  directive-decorated recipes (so **don't** run `jake --fmt` on these files until fixed; the source is
+  intentionally comment-documented).
+
+## Recommended path
+
+1. **Land jake#17** (and ideally #18/#19) in `../jake`, cut a patch, reinstall.
+2. **Adopt incrementally, keep the Makefile as a thin shim** during transition (e.g. `build:\n\tjake build`)
+   so CI and muscle memory don't break on day one.
+3. **Point CI at jake** once the E2E/examples/bytecode gates are proven under `jake ci`.
+4. **Wire the playground `@sema/ui` vendor path** (`playground/vendor/sema-ui.js` is provisional here)
+   when notebook-ui-refactor merges, then `jake ui.vendor` covers both consumers.
+5. **`jake --install`** for shell completions across recipe names.
+
+## Notes / gotchas found
+
+- File targets from a namespaced import display as `ui.ui/dist/sema-ui.js` in `-l`/dry-run, but the
+  real path in the recipe body (`ui/dist/sema-ui.js`) is what's used for the fs check — cosmetic.
+- Parameterizing a dependency isn't supported (deps are bare names); use a subprocess call
+  (`jake wasm._vendor-runtime <dir>`) to pass an argument to a shared recipe.
+- `@cd` in a `file` recipe changes the command cwd only; the output path in the recipe name stays
+  relative to the repo root (jake's cwd). Works as intended for `cd ui && npm run build`.

--- a/docs/plans/2026-07-03-jake-migration.md
+++ b/docs/plans/2026-07-03-jake-migration.md
@@ -22,7 +22,7 @@ A modular `Jakefile` + `jake/*.jake` set porting the whole Makefile (96 recipes,
 | `jake/playground.jake` | `pg` | sema.run WASM playground build/dev/deploy |
 | `jake/bench.jake` | `bench` | hyperfine suites, 1BRC ladder, samply profile |
 | `jake/fuzz.jake` | `fuzz` | cargo-fuzz + in-Sema grammar fuzzer |
-| `jake/editors.jake` | `ed` | tree-sitter grammar + browser E2E suites |
+| `jake/editors.jake` | `ed` | tree-sitter grammar, **VS Code + IntelliJ extension packaging/publishing**, browser E2E |
 | `jake/release.jake` | `release` | coverage, mutation testing, publish-list guard |
 
 The daily drivers (`build`, `test`, `lint`, `fmt`, `run`) are imported **un-namespaced** so muscle

--- a/jake/bench.jake
+++ b/jake/bench.jake
@@ -1,0 +1,72 @@
+# Benchmarks (hyperfine) + profiling (samply). Namespaced as `bench`.
+
+runs = "10"
+warmup = "3"
+suite = "all"
+
+# The bytecode VM is the sole evaluator; `bench` == the VM suite.
+@group bench
+@desc "Run the benchmark suite (params: suite runs warmup)"
+task bench suite="all" runs="10" warmup="3": [release]
+    ./scripts/bench.sh --suite {{suite}} --runs {{runs}} --warmup {{warmup}}
+
+@group bench
+@desc "Run benchmarks and export a per-commit JSON snapshot"
+task bench-save suite="all" runs="10" warmup="3": [release]
+    mkdir -p target/bench
+    ./scripts/bench.sh --suite {{suite}} --runs {{runs}} --warmup {{warmup}} \
+        --export target/bench/bench-$(git rev-parse --short HEAD 2>/dev/null || echo nogit).json
+
+@group bench
+@desc "Benchmark the closure suite"
+task bench-closure runs="10" warmup="3": [release]
+    ./scripts/bench.sh --suite closure --runs {{runs}} --warmup {{warmup}}
+
+@group bench
+@desc "Benchmark the numeric suite"
+task bench-numeric runs="10" warmup="3": [release]
+    ./scripts/bench.sh --suite numeric --runs {{runs}} --warmup {{warmup}}
+
+@group bench
+@desc "Export a baseline snapshot for later comparison"
+task bench-baseline runs="10" warmup="3": [release]
+    mkdir -p target/bench
+    ./scripts/bench.sh --runs {{runs}} --warmup {{warmup}} --export target/bench/baseline.json
+
+@group bench
+@desc "Benchmark and compare against target/bench/baseline.json"
+task bench-compare runs="10" warmup="3": [release]
+    mkdir -p target/bench
+    ./scripts/bench.sh --runs {{runs}} --warmup {{warmup}} \
+        --export target/bench/current.json --compare target/bench/baseline.json
+
+# ── 1BRC size ladder ─────────────────────────────────────────────────
+
+@group bench
+@desc "1BRC over 1M rows"
+task bench-1m: [release]
+    time ./target/release/sema examples/benchmarks/1brc.sema -- bench-1m.txt
+
+@group bench
+@desc "1BRC over 10M rows"
+task bench-10m: [release]
+    time ./target/release/sema examples/benchmarks/1brc.sema -- bench-10m.txt
+
+@group bench
+@desc "1BRC over 100M rows"
+task bench-100m: [release]
+    time ./target/release/sema examples/benchmarks/1brc.sema -- bench-100m.txt
+
+# ── Profiling (samply) ───────────────────────────────────────────────
+
+# Record a CPU profile of one benchmark. `jake bench.profile bench=tak`
+@group profile
+@desc "Record a samply CPU profile (params: bench)"
+@needs samply "cargo install samply"
+task profile bench="tak":
+    mkdir -p target/profiles
+    RUSTFLAGS="-C force-frame-pointers=yes" cargo build --profile release-with-debug -p sema-lang
+    samply record --save-only --output target/profiles/{{bench}}-vm.json -- \
+        ./target/release-with-debug/sema --no-llm examples/benchmarks/{{bench}}.sema
+    echo "Profile saved: target/profiles/{{bench}}-vm.json"
+    echo "Open with: samply load target/profiles/{{bench}}-vm.json"

--- a/jake/bench.jake
+++ b/jake/bench.jake
@@ -7,11 +7,13 @@ suite = "all"
 # The bytecode VM is the sole evaluator; `bench` == the VM suite.
 @group bench
 @desc "Run the benchmark suite (params: suite runs warmup)"
+@needs hyperfine "brew install hyperfine"
 task bench suite="all" runs="10" warmup="3": [release]
     ./scripts/bench.sh --suite {{suite}} --runs {{runs}} --warmup {{warmup}}
 
 @group bench
 @desc "Run benchmarks and export a per-commit JSON snapshot"
+@needs hyperfine "brew install hyperfine"
 task bench-save suite="all" runs="10" warmup="3": [release]
     mkdir -p target/bench
     ./scripts/bench.sh --suite {{suite}} --runs {{runs}} --warmup {{warmup}} \
@@ -19,22 +21,26 @@ task bench-save suite="all" runs="10" warmup="3": [release]
 
 @group bench
 @desc "Benchmark the closure suite"
+@needs hyperfine "brew install hyperfine"
 task bench-closure runs="10" warmup="3": [release]
     ./scripts/bench.sh --suite closure --runs {{runs}} --warmup {{warmup}}
 
 @group bench
 @desc "Benchmark the numeric suite"
+@needs hyperfine "brew install hyperfine"
 task bench-numeric runs="10" warmup="3": [release]
     ./scripts/bench.sh --suite numeric --runs {{runs}} --warmup {{warmup}}
 
 @group bench
 @desc "Export a baseline snapshot for later comparison"
+@needs hyperfine "brew install hyperfine"
 task bench-baseline runs="10" warmup="3": [release]
     mkdir -p target/bench
     ./scripts/bench.sh --runs {{runs}} --warmup {{warmup}} --export target/bench/baseline.json
 
 @group bench
 @desc "Benchmark and compare against target/bench/baseline.json"
+@needs hyperfine "brew install hyperfine"
 task bench-compare runs="10" warmup="3": [release]
     mkdir -p target/bench
     ./scripts/bench.sh --runs {{runs}} --warmup {{warmup}} \

--- a/jake/docs.jake
+++ b/jake/docs.jake
@@ -1,0 +1,37 @@
+# Docs — builtin-doc index, LLM pricing snapshot, markdown link check.
+# Imported UNnamespaced (`jake docs`, `jake docs-check`).
+
+@group docs
+@desc "Regenerate the builtin doc index from crates/sema-docs/entries"
+task docs:
+    cargo run -q -p sema-docs -- gen
+
+# CI gate: every entry has a summary (--strict), the committed index is current,
+# and every registered builtin/special form is documented.
+@group docs
+@desc "Doc CI gate: strict gen + up-to-date index + coverage test"
+task docs-check:
+    cargo run -q -p sema-docs -- gen --strict
+    git diff --exit-code crates/sema-docs/builtin_docs.generated.json
+    cargo test -q -p sema-lsp builtin_doc_coverage
+
+# Regenerate the vendored LLM pricing snapshot from models.dev. Commit the diff
+# to ship updated prices in a patch release.
+@group docs
+@desc "Refresh the vendored LLM pricing snapshot (pricing-data.json)"
+task update-pricing:
+    ./scripts/update-pricing.sh
+
+@group docs
+@desc "Check markdown links with lychee"
+@needs lychee "cargo install lychee"
+task lint-links:
+    lychee --config lychee.toml --no-progress '**/*.md'
+
+# Hermetic gate: docs_search must work from the binary alone in a from-scratch
+# container (no source, no uncompiled docs, --network none).
+@group docs
+@desc "Hermetic docs_search container gate (requires docker + jq)"
+@needs docker jq
+task docs-search-gate:
+    ./scripts/docs-search-gate.sh

--- a/jake/editors.jake
+++ b/jake/editors.jake
@@ -1,0 +1,54 @@
+# Editor tooling — tree-sitter grammar + browser E2E suites. Namespaced `ed`.
+
+ts_dir = "editors/tree-sitter-sema"
+
+@group editors
+@desc "Install tree-sitter grammar deps"
+task ts-setup:
+    @cd editors/tree-sitter-sema
+    npm install
+
+# File recipe: regenerate the parser only when the grammar changes.
+file editors/tree-sitter-sema/src/parser.c: editors/tree-sitter-sema/grammar.js
+    @needs npx
+    @cd editors/tree-sitter-sema
+    npm install
+    npx tree-sitter generate
+
+@group editors
+@desc "Generate the tree-sitter parser (incremental)"
+task ts-generate: [editors/tree-sitter-sema/src/parser.c]
+    echo "tree-sitter parser generated"
+
+@group editors
+@desc "Run tree-sitter corpus tests"
+task ts-test: [ts-generate]
+    @cd editors/tree-sitter-sema
+    npx tree-sitter test
+
+@group editors
+@desc "Build the tree-sitter WASM + open the playground"
+task ts-playground: [ts-generate]
+    @cd editors/tree-sitter-sema
+    npx tree-sitter build --wasm && npx tree-sitter playground
+
+# ── Browser E2E ──────────────────────────────────────────────────────
+
+@group e2e
+@desc "Notebook browser E2E (Playwright)"
+task test-notebook-e2e: [build]
+    @needs npx
+    echo "=== Running notebook E2E tests ==="
+    @cd crates/sema-notebook/tests/e2e
+    npx playwright test
+
+# Vendor the browser runtime, build the release binary (embeds it), then drive
+# the real `sema web` dev server in a browser.
+@group e2e
+@desc "sema web dev-server browser E2E (Playwright)"
+task test-web-e2e: [wasm.web-runtime]
+    @needs npx
+    cargo build --release -p sema-lang
+    echo "=== Running sema web dev-server E2E tests ==="
+    @cd packages/sema-web
+    npx playwright test --config playwright.dev-server.config.ts

--- a/jake/editors.jake
+++ b/jake/editors.jake
@@ -59,8 +59,8 @@ task vscode-package: [editors/vscode/sema/sema.vsix]
 # both the VS Marketplace and the Open VSX registry, like the CI workflow.
 @group ext
 @desc "Publish the VS Code extension to VS Marketplace + Open VSX"
-@require VSCE_PAT OVSX_PAT
 task vscode-publish: [vscode-package]
+    : "${VSCE_PAT:?set VSCE_PAT (or add to .env)}" "${OVSX_PAT:?set OVSX_PAT (or add to .env)}"
     @confirm "Publish the VS Code extension to VS Marketplace and Open VSX?"
     @cd editors/vscode/sema
     npx --yes @vscode/vsce publish --packagePath sema.vsix
@@ -94,8 +94,8 @@ task intellij-verify:
 @group ext
 @desc "Publish the IntelliJ plugin to the JetBrains Marketplace"
 @needs java
-@require PUBLISH_TOKEN
 task intellij-publish: [intellij-build]
+    : "${PUBLISH_TOKEN:?set PUBLISH_TOKEN (or add to .env; see editors/intellij/RELEASING.md)}"
     @confirm "Publish the IntelliJ plugin to the JetBrains Marketplace?"
     @cd editors/intellij
     ./gradlew publishPlugin

--- a/jake/editors.jake
+++ b/jake/editors.jake
@@ -59,8 +59,8 @@ task vscode-package: [editors/vscode/sema/sema.vsix]
 # both the VS Marketplace and the Open VSX registry, like the CI workflow.
 @group ext
 @desc "Publish the VS Code extension to VS Marketplace + Open VSX"
+@require VSCE_PAT OVSX_PAT
 task vscode-publish: [vscode-package]
-    : "${VSCE_PAT:?set VSCE_PAT (or add to .env)}" "${OVSX_PAT:?set OVSX_PAT (or add to .env)}"
     @confirm "Publish the VS Code extension to VS Marketplace and Open VSX?"
     @cd editors/vscode/sema
     npx --yes @vscode/vsce publish --packagePath sema.vsix
@@ -94,8 +94,8 @@ task intellij-verify:
 @group ext
 @desc "Publish the IntelliJ plugin to the JetBrains Marketplace"
 @needs java
+@require PUBLISH_TOKEN
 task intellij-publish: [intellij-build]
-    : "${PUBLISH_TOKEN:?set PUBLISH_TOKEN (or add to .env; see editors/intellij/RELEASING.md)}"
     @confirm "Publish the IntelliJ plugin to the JetBrains Marketplace?"
     @cd editors/intellij
     ./gradlew publishPlugin

--- a/jake/editors.jake
+++ b/jake/editors.jake
@@ -1,6 +1,9 @@
-# Editor tooling — tree-sitter grammar + browser E2E suites. Namespaced `ed`.
+# Editor tooling — tree-sitter grammar, extension packaging, browser E2E.
+# Namespaced `ed`.
 
 ts_dir = "editors/tree-sitter-sema"
+vscode_dir = "editors/vscode/sema"
+intellij_dir = "editors/intellij"
 
 @group editors
 @desc "Install tree-sitter grammar deps"
@@ -31,6 +34,76 @@ task ts-test: [ts-generate]
 task ts-playground: [ts-generate]
     @cd editors/tree-sitter-sema
     npx tree-sitter build --wasm && npx tree-sitter playground
+
+# ── Editor extension packaging ───────────────────────────────────────
+# VS Code and IntelliJ ship as separate marketplace artifacts, each on its own
+# tag/workflow. These recipes package them locally (and publish behind @confirm),
+# mirroring .github/workflows/publish-vscode-extension.yml and the IntelliJ
+# gradle publish task.
+
+# VS Code: compile TS then package into a .vsix. A `file` recipe so it only
+# repackages when the extension sources/manifest actually change.
+file editors/vscode/sema/sema.vsix: editors/vscode/sema/src/**/* editors/vscode/sema/package.json editors/vscode/sema/language-configuration.json editors/vscode/sema/syntaxes/*.json
+    @needs npx "install Node.js"
+    @cd editors/vscode/sema
+    npm install
+    npm run compile
+    npx --yes @vscode/vsce package --no-git-tag-version --out sema.vsix
+
+@group ext
+@desc "Package the VS Code extension (.vsix)"
+task vscode-package: [editors/vscode/sema/sema.vsix]
+    echo "Packaged {{vscode_dir}}/sema.vsix"
+
+# vsce reads VSCE_PAT from the env; ovsx takes the token as a flag. Publishes to
+# both the VS Marketplace and the Open VSX registry, like the CI workflow.
+@group ext
+@desc "Publish the VS Code extension to VS Marketplace + Open VSX"
+@require VSCE_PAT OVSX_PAT
+task vscode-publish: [vscode-package]
+    @confirm "Publish the VS Code extension to VS Marketplace and Open VSX?"
+    @cd editors/vscode/sema
+    npx --yes @vscode/vsce publish --packagePath sema.vsix
+    npx --yes ovsx publish sema.vsix -p $OVSX_PAT
+
+# IntelliJ: Gradle (org.jetbrains.intellij.platform). buildPlugin emits
+# build/distributions/Sema-<pluginVersion>.zip.
+@group ext
+@desc "Build the IntelliJ plugin (.zip in build/distributions)"
+@needs java "install a JDK 17+"
+task intellij-build:
+    @cd editors/intellij
+    ./gradlew buildPlugin
+
+@group ext
+@desc "Run the IntelliJ plugin unit tests"
+@needs java
+task intellij-test:
+    @cd editors/intellij
+    ./gradlew test
+
+@group ext
+@desc "Run the IntelliJ plugin verifier (marketplace compatibility)"
+@needs java
+task intellij-verify:
+    @cd editors/intellij
+    ./gradlew verifyPlugin
+
+# Signing + upload token come from the env (see editors/intellij/RELEASING.md):
+# PUBLISH_TOKEN, plus CERTIFICATE_CHAIN / PRIVATE_KEY / PRIVATE_KEY_PASSWORD.
+@group ext
+@desc "Publish the IntelliJ plugin to the JetBrains Marketplace"
+@needs java
+@require PUBLISH_TOKEN
+task intellij-publish: [intellij-build]
+    @confirm "Publish the IntelliJ plugin to the JetBrains Marketplace?"
+    @cd editors/intellij
+    ./gradlew publishPlugin
+
+@group ext
+@desc "Package both editor extensions (.vsix + IntelliJ .zip)"
+task ext-package: [vscode-package, intellij-build]
+    echo "Packaged VS Code (.vsix) + IntelliJ (.zip) extensions"
 
 # ── Browser E2E ──────────────────────────────────────────────────────
 

--- a/jake/examples.jake
+++ b/jake/examples.jake
@@ -50,8 +50,8 @@ task example-notebook-serve: [build]
 # Manual gate for the true-async work; needs ANTHROPIC/OPENAI/GEMINI keys.
 @group llm
 @desc "LIVE async/streaming provider stress (real spend, needs API keys)"
+@require ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY
 task llm-stress: [release]
-    : "${ANTHROPIC_API_KEY:?set it (or add to .env)}" "${OPENAI_API_KEY:?set it (or add to .env)}" "${GEMINI_API_KEY:?set it (or add to .env)}"
     ./target/release/sema examples/llm/async-stress-live.sema
 
 @group llm

--- a/jake/examples.jake
+++ b/jake/examples.jake
@@ -1,0 +1,72 @@
+# Examples, notebooks, and smoke tests. Imported UNnamespaced (`jake examples`,
+# `jake smoke-bytecode`) — these are CI-critical and referenced by the `ci` gate.
+
+# Run every runnable example headless; report pass/skip/fail. Interactive,
+# server, and hardware examples are skipped (see scripts/run-examples.sh).
+@group examples
+@desc "Run all runnable examples headless (per-example timeout)"
+task examples: [release]
+    @export EXAMPLE_TIMEOUT=30
+    ./scripts/run-examples.sh
+
+# Compile every runnable example into a standalone binary with `sema build` and
+# execute it — exercises the whole release/portability path.
+@group examples
+@desc "Compile every example to a standalone binary and run it"
+task examples-build: [release]
+    @export EXAMPLE_TIMEOUT=30
+    ./scripts/build-examples.sh
+
+# Compile -> disasm -> run every example; the ONLY check that catches a desynced
+# disassembler after an opcode add (see AGENTS.md bytecode format rules).
+@group examples
+@desc "Bytecode smoke: compile + disasm + run every example"
+task smoke-bytecode: [build]
+    ./scripts/smoke-bytecode.sh ./target/debug/sema
+
+# ── Notebooks ────────────────────────────────────────────────────────
+
+@group notebook
+@desc "Run the demo notebook headless"
+task example-notebook: [build]
+    echo "=== Running example notebook ==="
+    @ignore
+    cargo run --quiet -- notebook run examples/notebook/demo.sema-nb
+
+@group notebook
+@desc "Headless smoke for the deterministic async notebook pair"
+task example-notebooks-async: [release]
+    ./target/release/sema notebook run examples/notebook/async-basics.sema-nb
+    ./target/release/sema notebook run examples/notebook/realtime-monitor.sema-nb
+
+@group notebook
+@desc "Serve the demo notebook in a browser"
+task example-notebook-serve: [build]
+    cargo run --quiet -- notebook serve examples/notebook/demo.sema-nb
+
+# ── LLM / provider smokes (real spend / keys) ────────────────────────
+
+# LIVE async/streaming stress against real provider APIs (real spend — cents).
+# Manual gate for the true-async work; needs ANTHROPIC/OPENAI/GEMINI keys.
+@group llm
+@desc "LIVE async/streaming provider stress (real spend, needs API keys)"
+task llm-stress: [release]
+    ./target/release/sema examples/llm/async-stress-live.sema
+
+@group llm
+@desc "Exercise every configured LLM provider"
+task test-providers: [build]
+    echo "=== Testing all LLM providers ==="
+    cargo run --quiet -- examples/providers/test-all.sema
+
+# Run a single provider smoke: `jake test-provider anthropic`
+@group llm
+@desc "Test a single provider by name (arg 1)"
+task test-provider: [build]
+    cargo run --quiet -- examples/providers/test-{{$1}}.sema
+
+@group llm
+@desc "LIVE RAG smoke over Sema docs (needs embed+rerank+chat keys)"
+task rag-demo: [build]
+    echo "=== RAG over Sema docs (embed -> search -> rerank -> answer) ==="
+    cargo run --quiet -- examples/llm/rag-docs-search.sema

--- a/jake/examples.jake
+++ b/jake/examples.jake
@@ -51,6 +51,7 @@ task example-notebook-serve: [build]
 @group llm
 @desc "LIVE async/streaming provider stress (real spend, needs API keys)"
 task llm-stress: [release]
+    : "${ANTHROPIC_API_KEY:?set it (or add to .env)}" "${OPENAI_API_KEY:?set it (or add to .env)}" "${GEMINI_API_KEY:?set it (or add to .env)}"
     ./target/release/sema examples/llm/async-stress-live.sema
 
 @group llm

--- a/jake/fuzz.jake
+++ b/jake/fuzz.jake
@@ -1,0 +1,43 @@
+# Fuzzing — cargo-fuzz (byte-level) + in-Sema grammar fuzzer. Namespaced `fuzz`.
+
+@group fuzz
+@desc "Install the nightly toolchain + cargo-fuzz"
+task setup:
+    rustup toolchain install nightly
+    cargo install cargo-fuzz
+
+@group fuzz
+@desc "Run reader + eval byte-level fuzz targets"
+task all: [reader, eval]
+    echo "byte-level fuzzing done"
+
+@group fuzz
+@desc "Fuzz the reader (read + read_many)"
+@needs rustup
+task reader:
+    cd crates/sema-reader && rustup run nightly cargo fuzz run fuzz_read -- -max_total_time=60
+    cd crates/sema-reader && rustup run nightly cargo fuzz run fuzz_read_many -- -max_total_time=60
+
+@group fuzz
+@desc "Fuzz the evaluator"
+@needs rustup
+task eval:
+    cd crates/sema-eval && rustup run nightly cargo fuzz run fuzz_eval -- -max_total_time=120 -timeout=10
+
+# Grammar-based fuzzer written in Sema itself. Generates random *valid* programs
+# and checks a printer/reader round-trip + a compiler/VM value oracle. No
+# nightly needed. Every finding reproduces from one integer seed.
+#   jake fuzz.grammar n=20000 depth=5 seed=123
+@group fuzz
+@desc "In-Sema grammar fuzzer (params: n depth seed)"
+task grammar n="5000" depth="4" seed="": [release]
+    @if eq({{seed}}, "")
+        ./scripts/grammar-fuzz.sh check -n {{n}} -d {{depth}}
+    @else
+        ./scripts/grammar-fuzz.sh check -n {{n}} -d {{depth}} -s {{seed}}
+    @end
+
+@group fuzz
+@desc "Print sample generated programs from the grammar fuzzer"
+task grammar-emit n="5" depth="4": [release]
+    ./scripts/grammar-fuzz.sh emit -n {{n}} -d {{depth}}

--- a/jake/playground.jake
+++ b/jake/playground.jake
@@ -1,0 +1,27 @@
+# sema.run WASM playground. Namespaced as `pg`.
+
+# Build the WASM VM into the playground, then generate examples.js from the
+# .sema files. wasm-pack/cargo are already incremental; the file recipe keeps
+# the JS regen (node build.mjs) from re-running when nothing changed.
+@group playground
+@desc "Build the playground (WASM VM + examples bundle)"
+task build:
+    @needs wasm-pack "cargo install wasm-pack"
+    cd crates/sema-wasm && wasm-pack build --target web --out-dir ../../playground/pkg \
+        -- --config 'profile.release.package.sema-wasm.opt-level="s"'
+    cd playground && node build.mjs
+
+@group playground
+@desc "Build + serve the playground at :8787"
+task dev: [build]
+    @needs npx
+    cd playground && node scripts/gen-devtools-json.mjs
+    cd playground && npx serve -l 8787
+
+@group playground
+@desc "Build + deploy the playground to production (Vercel)"
+@needs npx
+task deploy: [build]
+    @confirm "Deploy the playground to production?"
+    @cd playground
+    npx vercel --prod --yes

--- a/jake/playground.jake
+++ b/jake/playground.jake
@@ -7,6 +7,7 @@
 @desc "Build the playground (WASM VM + examples bundle)"
 task build:
     @needs wasm-pack "cargo install wasm-pack"
+    @needs node
     cd crates/sema-wasm && wasm-pack build --target web --out-dir ../../playground/pkg \
         -- --config 'profile.release.package.sema-wasm.opt-level="s"'
     cd playground && node build.mjs
@@ -14,7 +15,7 @@ task build:
 @group playground
 @desc "Build + serve the playground at :8787"
 task dev: [build]
-    @needs npx
+    @needs npx node
     cd playground && node scripts/gen-devtools-json.mjs
     cd playground && npx serve -l 8787
 

--- a/jake/release.jake
+++ b/jake/release.jake
@@ -1,0 +1,50 @@
+# Coverage, mutation testing, and release guards. Namespaced as `release`.
+
+# Fail if a publishable workspace crate is missing from publish.yml's order.
+@group release
+@desc "Guard: every publishable crate is in publish.yml's order"
+task check-publish-list:
+    ./scripts/check-publish-list.sh
+
+# ── Coverage ─────────────────────────────────────────────────────────
+
+@group coverage
+@desc "Workspace coverage -> lcov.info"
+@needs cargo-llvm-cov "cargo install cargo-llvm-cov"
+task coverage:
+    cargo llvm-cov --workspace --lcov --output-path lcov.info
+
+@group coverage
+@desc "Workspace coverage -> HTML report"
+@needs cargo-llvm-cov "cargo install cargo-llvm-cov"
+task coverage-html:
+    cargo llvm-cov --workspace --html
+    echo "Coverage report: target/llvm-cov/html/index.html"
+
+# ── Mutation testing ─────────────────────────────────────────────────
+
+@group mutants
+@desc "Mutation testing (high-value stdlib crate)"
+@needs cargo-mutants "cargo install cargo-mutants"
+task mutants:
+    echo "=== Mutation testing (sema-stdlib) ==="
+    cargo mutants -p sema-stdlib --timeout 30 -- --test-threads=1
+
+@group mutants
+@desc "Mutation testing (sema-core)"
+@needs cargo-mutants
+task mutants-core:
+    cargo mutants -p sema-core --timeout 30
+
+@group mutants
+@desc "Mutation testing (sema-notebook)"
+@needs cargo-mutants
+task mutants-notebook:
+    cargo mutants -p sema-notebook --timeout 30
+
+@group mutants
+@desc "Full-workspace mutation testing (slow)"
+@needs cargo-mutants
+task mutants-all:
+    echo "=== Full mutation testing (all crates, slow) ==="
+    cargo mutants --workspace --timeout 60 -- --test-threads=1

--- a/jake/rust.jake
+++ b/jake/rust.jake
@@ -99,8 +99,8 @@ task test-http:
 
 @group test
 @desc "LLM integration tests (requires API keys)"
+@require ANTHROPIC_API_KEY OPENAI_API_KEY
 task test-llm:
-    : "${ANTHROPIC_API_KEY:?set ANTHROPIC_API_KEY (or add it to .env)}" "${OPENAI_API_KEY:?set OPENAI_API_KEY (or add it to .env)}"
     cargo test -p sema-lang --test llm_test -- --ignored --nocapture
 
 # ── Lint / format ────────────────────────────────────────────────────

--- a/jake/rust.jake
+++ b/jake/rust.jake
@@ -11,6 +11,7 @@ clippy_crates = "-p sema-core -p sema-reader -p sema-eval -p sema-llm -p sema-st
 @desc "Dev build"
 task build:
     @needs cargo
+    @watch crates/**/*.rs Cargo.toml
     cargo build
 
 @group build
@@ -71,6 +72,7 @@ task uninstall:
 @group test
 @desc "Run all tests (http/llm ignored)"
 task test:
+    @watch crates/**/*.rs Cargo.toml
     cargo test
 
 @group test
@@ -98,6 +100,7 @@ task test-http:
 @group test
 @desc "LLM integration tests (requires API keys)"
 task test-llm:
+    : "${ANTHROPIC_API_KEY:?set ANTHROPIC_API_KEY (or add it to .env)}" "${OPENAI_API_KEY:?set OPENAI_API_KEY (or add it to .env)}"
     cargo test -p sema-lang --test llm_test -- --ignored --nocapture
 
 # ── Lint / format ────────────────────────────────────────────────────

--- a/jake/rust.jake
+++ b/jake/rust.jake
@@ -1,0 +1,123 @@
+# Rust / cargo — the daily drivers. Imported UNnamespaced so `jake build`,
+# `jake test`, `jake lint` work bare, exactly like the old `make` targets.
+
+# Crates that must stay clippy-clean with -D warnings (excludes optional/plugin crates).
+clippy_crates = "-p sema-core -p sema-reader -p sema-eval -p sema-llm -p sema-stdlib -p sema-vm -p sema-lang -p sema-wasm"
+
+# ── Build ────────────────────────────────────────────────────────────
+
+@default
+@group build
+@desc "Dev build"
+task build:
+    @needs cargo
+    cargo build
+
+@group build
+@desc "Optimized release build"
+task release:
+    @needs cargo
+    cargo build --release
+
+# PGO build (instrument -> train -> rebuild). ~25% faster on 1BRC; see
+# docs/performance-roadmap.md.
+@group build
+@desc "PGO build (instrument -> train -> rebuild)"
+task build-pgo:
+    ./scripts/pgo-build.sh
+
+@group build
+@desc "Emit only the PGO .profdata that CI consumes (target/pgo/merged.profdata)"
+task pgo-profile:
+    ./scripts/pgo-build.sh --profile-only
+
+@group build
+@desc "Type-check without codegen"
+task check:
+    cargo check
+
+@group build
+@desc "Remove cargo build artifacts"
+task clean:
+    cargo clean
+
+@group dev
+@desc "Start the REPL"
+task run:
+    cargo run
+
+# ── Install ──────────────────────────────────────────────────────────
+
+@group install
+@desc "Install sema to ~/.cargo/bin"
+task install:
+    cargo install --path crates/sema
+
+# PGO-optimized install: instrument -> train -> rebuild, then drop the binary
+# into the cargo bin dir. Slower to build, faster at runtime.
+@group install
+@desc "PGO-optimized install into the cargo bin dir"
+task install-pgo: [build-pgo]
+    install -m 0755 target/release/sema "${CARGO_HOME:-$HOME/.cargo}/bin/sema"
+    echo "Installed PGO-optimized sema -> ${CARGO_HOME:-$HOME/.cargo}/bin/sema"
+
+@group install
+@desc "Uninstall the sema binary"
+task uninstall:
+    cargo uninstall sema-lang
+
+# ── Test ─────────────────────────────────────────────────────────────
+
+@group test
+@desc "Run all tests (http/llm ignored)"
+task test:
+    cargo test
+
+@group test
+@desc "Run the full workspace test suite"
+task test-workspace:
+    cargo test --workspace
+
+@group test
+@desc "LSP unit + e2e (pytest) tests"
+task test-lsp: [release]
+    @needs uv
+    cargo test -p sema-lsp
+    cd crates/sema-lsp/tests/e2e && uv run pytest -v
+
+@group test
+@desc "Embedding benchmark (ignored) test"
+task test-embedding-bench:
+    cargo test -p sema-lang --test embedding_bench -- --ignored --nocapture
+
+@group test
+@desc "HTTP integration tests (requires network)"
+task test-http:
+    cargo test -p sema-lang --test http_test -- --ignored --nocapture
+
+@group test
+@desc "LLM integration tests (requires API keys)"
+task test-llm:
+    cargo test -p sema-lang --test llm_test -- --ignored --nocapture
+
+# ── Lint / format ────────────────────────────────────────────────────
+
+@group lint
+@desc "fmt-check + clippy -D warnings"
+task lint: [fmt-check, clippy]
+    echo "lint clean"
+
+@group lint
+@desc "clippy with -D warnings across the core crates"
+task clippy:
+    cargo clippy {{clippy_crates}} -- -D warnings
+
+@group lint
+@desc "Format the workspace"
+task fmt:
+    cargo fmt
+
+@group lint
+@desc "Check formatting without writing"
+task fmt-check:
+    cargo fmt -- --check

--- a/jake/ui.jake
+++ b/jake/ui.jake
@@ -1,0 +1,95 @@
+# @sema/ui — Lit-based web component library. Built once, then VENDORED (copied)
+# into the notebook crate (embedded via include_str!) and, later, the playground.
+# There is no npm publish; consumers use the vendored bundle.
+#
+# The win over the Makefile: `file` recipes make vendoring INCREMENTAL — the
+# bundle rebuilds and re-copies only when ui/src actually changed, instead of
+# `cd ui && npm run build && cp` on every invocation (the notebook worktree's
+# current `notebook-ui-vendor` target rebuilds unconditionally every time).
+
+# Vendor destinations (single source of truth for the copy targets).
+notebook_vendor = "crates/sema-notebook/src/ui/vendor/sema-ui.js"
+playground_vendor = "playground/vendor/sema-ui.js"
+
+# ── Build (the file recipe is the incremental core) ──────────────────
+
+# Stage 1: build the bundle. Rebuilds only if any ui source/config changed.
+file ui/dist/sema-ui.js: ui/src/**/* ui/package.json ui/vite.config.ts ui/tsconfig.json
+    @needs npm
+    @cd ui
+    npm install
+    npm run build
+
+@group ui
+@desc "Build the @sema/ui bundle (incremental; skips if ui/src unchanged)"
+task build: [ui/dist/sema-ui.js]
+    echo "@sema/ui bundle ready: ui/dist/sema-ui.js"
+
+# ── Vendoring (stage 2: copy into each consumer, only if the bundle moved) ──
+
+# Naive copy: only the main bundle is vendored; lazily-loaded Shiki grammar
+# chunks aren't served, so non-`sema` code fences degrade to unhighlighted.
+file crates/sema-notebook/src/ui/vendor/sema-ui.js: ui/dist/sema-ui.js
+    mkdir -p {{dirname(notebook_vendor)}}
+    cp ui/dist/sema-ui.js {{notebook_vendor}}
+    echo "Vendored -> {{notebook_vendor}}"
+
+# Provisional: the playground doesn't consume @sema/ui yet. The path is a
+# placeholder for the notebook-ui-refactor follow-up; confirm it when the
+# playground wires the components in.
+file playground/vendor/sema-ui.js: ui/dist/sema-ui.js
+    mkdir -p {{dirname(playground_vendor)}}
+    cp ui/dist/sema-ui.js {{playground_vendor}}
+    echo "Vendored -> {{playground_vendor}}"
+
+@group ui
+@desc "Build + vendor the @sema/ui bundle into the notebook crate"
+task vendor-notebook: [crates/sema-notebook/src/ui/vendor/sema-ui.js]
+    echo "notebook vendoring up to date"
+
+@group ui
+@desc "Build + vendor the @sema/ui bundle into the playground (provisional path)"
+task vendor-playground: [playground/vendor/sema-ui.js]
+    echo "playground vendoring up to date"
+
+@group ui
+@desc "Vendor @sema/ui into every consumer (notebook + playground)"
+task vendor: [vendor-notebook, vendor-playground]
+    echo "all @sema/ui consumers vendored"
+
+# ── Dev / quality ────────────────────────────────────────────────────
+
+@group ui
+@desc "Start the @sema/ui vite dev server"
+task dev:
+    @needs npm
+    @cd ui
+    npm install
+    npm run dev
+
+@group ui
+@desc "Run @sema/ui component tests (vitest)"
+task test:
+    @needs npm
+    @cd ui
+    npm install
+    npm test
+
+@group ui
+@desc "Lint @sema/ui sources"
+task lint:
+    @needs npm
+    @cd ui
+    npm run lint
+
+@group ui
+@desc "Regenerate the custom-elements manifest"
+task analyze:
+    @cd ui
+    npm run analyze
+
+@group ui
+@desc "Export the standalone <sema-code-typer> showcase bundle"
+task export-typer:
+    @cd ui
+    npm run export:typer

--- a/jake/wasm.jake
+++ b/jake/wasm.jake
@@ -1,0 +1,78 @@
+# WASM VM build + browser-runtime vendoring.
+#
+# Two consumers embed a WASM-compiled Sema VM:
+#   1. the `sema web` dev server (crates/sema/src/web/assets, embedded via build.rs)
+#   2. the sema-web-example demo app
+# Both need the same ~8 runtime files. The Makefile duplicated the copy list
+# across `web-runtime` and `sema-web-example-build`; here it's a shared recipe.
+
+web_runtime_dir = "crates/sema/src/web/assets"
+example_dir = "examples/sema-web-app"
+
+# ── WASM + JS package build (file recipe = incremental) ──────────────
+
+# Compile the WASM VM. Depends on the wasm crate + every workspace crate it
+# pulls in; the broad glob is correct (sema-wasm re-exports the whole stack).
+file packages/sema-wasm/pkg/sema_wasm_bg.wasm: crates/**/*.rs Cargo.toml Cargo.lock
+    @needs wasm-pack "cargo install wasm-pack"
+    npm run build:wasm
+
+@group wasm
+@desc "Build the WASM VM package (incremental; skips if no crate changed)"
+task build: [packages/sema-wasm/pkg/sema_wasm_bg.wasm]
+    echo "WASM VM built: packages/sema-wasm/pkg/"
+
+@group wasm
+@desc "Build WASM VM + the JS embedding packages"
+task js-lib-build: [build]
+    @needs wasm-pack npm
+    wasm-pack build crates/sema-wasm --target web --release --scope sema-lang \
+        --out-dir ../../packages/sema-wasm/pkg -- --config 'profile.release.package.sema-wasm.opt-level="s"'
+    cd packages/sema && npm install && npm run build
+
+@group wasm
+@desc "Fast (non-optimized) WASM VM build for iteration"
+task js-lib-dev:
+    @needs wasm-pack
+    wasm-pack build crates/sema-wasm --target web --scope sema-lang --out-dir ../../packages/sema-wasm/pkg
+
+# ── Shared runtime vendoring ─────────────────────────────────────────
+
+# Copy the ~8 browser-runtime files into a destination dir (arg 1). Private
+# helper shared by `web-runtime` and the example build so the list lives once.
+@group wasm
+task _vendor-runtime: [build]
+    @needs npm
+    npm run build
+    mkdir -p {{$1}}/sema/backends
+    cp packages/sema-web/dist/index.js {{$1}}/sema-web.js
+    cp packages/sema/dist/index.js {{$1}}/sema/index.js
+    cp packages/sema/dist/vfs.js {{$1}}/sema/vfs.js
+    cp packages/sema/dist/backends/*.js {{$1}}/sema/backends/
+    cp packages/sema-wasm/pkg/sema_wasm.js {{$1}}/sema_wasm.js
+    cp packages/sema-wasm/pkg/sema_wasm_bg.wasm {{$1}}/sema_wasm_bg.wasm
+    cp node_modules/@preact/signals-core/dist/signals-core.module.js {{$1}}/signals-core.module.js
+    cp node_modules/morphdom/dist/morphdom-esm.js {{$1}}/morphdom-esm.js
+
+# Vendor the browser runtime the `sema web` dev server embeds. build.rs picks
+# these up (web_runtime cfg) and include_bytes! embeds them. Rebuild the sema
+# binary afterward to embed. Artifacts are gitignored (built, multi-MB).
+@group wasm
+@desc "Vendor the sema-web browser runtime into the sema crate assets"
+task web-runtime:
+    jake wasm._vendor-runtime {{web_runtime_dir}}
+    echo "Vendored web runtime -> {{web_runtime_dir}} (rebuild the sema binary to embed)"
+
+@group wasm
+@desc "Build the sema-web-example demo app (WASM + vendored runtime + app.vfs)"
+task sema-web-example-build:
+    jake wasm._vendor-runtime {{example_dir}}/dist/vendor
+    cargo run -p sema-lang -- build --target web {{example_dir}}/app.sema -o {{example_dir}}/dist/app.vfs
+    echo "Built {{example_dir}}/dist/app.vfs"
+
+@group wasm
+@desc "Build + serve the sema-web-example demo at :8788"
+task sema-web-example: [sema-web-example-build]
+    @needs npx
+    echo "Serving the Sema Web example — open http://127.0.0.1:8788"
+    npx serve -l 8788 {{example_dir}}

--- a/jake/wasm.jake
+++ b/jake/wasm.jake
@@ -57,16 +57,26 @@ task _vendor-runtime: [build]
 # Vendor the browser runtime the `sema web` dev server embeds. build.rs picks
 # these up (web_runtime cfg) and include_bytes! embeds them. Rebuild the sema
 # binary afterward to embed. Artifacts are gitignored (built, multi-MB).
-@group wasm
-@desc "Vendor the sema-web browser runtime into the sema crate assets"
-task web-runtime:
+# Incremental vendoring (file recipes). Deps are the inputs `_vendor-runtime`
+# does NOT rewrite — the WASM VM pkg (itself an incremental file recipe) plus
+# the JS package sources. The npm-built `dist/` is deliberately NOT a dep: the
+# recipe rebuilds it, so tracking it would re-trigger vendoring on every run.
+# One vendored file per dir is the recipe output; the shared copy list lives in
+# `_vendor-runtime` so it stays DRY.
+file crates/sema/src/web/assets/sema_wasm_bg.wasm: packages/sema-wasm/pkg/sema_wasm_bg.wasm packages/sema/src/**/* packages/sema-web/src/**/*
     jake wasm._vendor-runtime {{web_runtime_dir}}
+
+@group wasm
+@desc "Vendor the sema-web browser runtime into the sema crate assets (incremental)"
+task web-runtime: [crates/sema/src/web/assets/sema_wasm_bg.wasm]
     echo "Vendored web runtime -> {{web_runtime_dir}} (rebuild the sema binary to embed)"
+
+file examples/sema-web-app/dist/vendor/sema_wasm_bg.wasm: packages/sema-wasm/pkg/sema_wasm_bg.wasm packages/sema/src/**/* packages/sema-web/src/**/*
+    jake wasm._vendor-runtime {{example_dir}}/dist/vendor
 
 @group wasm
 @desc "Build the sema-web-example demo app (WASM + vendored runtime + app.vfs)"
-task sema-web-example-build:
-    jake wasm._vendor-runtime {{example_dir}}/dist/vendor
+task sema-web-example-build: [examples/sema-web-app/dist/vendor/sema_wasm_bg.wasm]
     cargo run -p sema-lang -- build --target web {{example_dir}}/app.sema -o {{example_dir}}/dist/app.vfs
     echo "Built {{example_dir}}/dist/app.vfs"
 

--- a/jake/web.jake
+++ b/jake/web.jake
@@ -1,0 +1,39 @@
+# VitePress docs site (sema-lang.com). Namespaced as `site`.
+# Vercel CLI is intentionally not a repo dep; install globally or via npx.
+
+@group web
+@desc "Start the docs site dev server"
+task dev:
+    @needs npm
+    @cd website
+    npm run dev
+
+@group web
+@desc "Build the docs site for production"
+task build:
+    @needs npm
+    @cd website
+    npm run build
+
+@group web
+@desc "Build + preview the production site locally"
+task preview: [build]
+    @cd website
+    npm run preview
+
+# Check vendored OG assets and regenerate per-page cards. Run after editing the
+# template, logo, page titles, or version; commit the images before deploying.
+@group web
+@desc "Regenerate per-page OpenGraph cards (public/og/*.jpg)"
+task og:
+    @cd website
+    npm run og:check
+    npm run og
+
+@group web
+@desc "Build + deploy the docs site to production (Vercel)"
+@needs npx
+task deploy: [build]
+    @confirm "Deploy the docs site to production?"
+    @cd website
+    npx vercel --prod --yes


### PR DESCRIPTION
Replaces the 393-line `Makefile` with a modular [Jake](https://jakefile.dev) setup (`helgesverre/jake`) — **107 recipes, 24 groups**. Daily drivers (`build`/`test`/`lint`/`fmt`/`run`) are imported un-namespaced (`jake build` == `make build`); the rest are grouped by area (`wasm`, `ui`, `site`, `pg`, `bench`, `fuzz`, `ed`, `release`, `ext`).

The repo `Makefile` is left untouched — adopt as a thin shim first, then point CI at `jake ci`. Full writeup: `docs/plans/2026-07-03-jake-migration.md`.

## Wins over the Makefile (verified)
- Grouped discoverability (`jake -l` / `-s`, typo suggestions) vs a flat 50-target `.PHONY` wall
- `@needs` pre-flight tool checks with install hints (fail early, not mid-recipe)
- `@require` (recipe-scoped) + `@dotenv` on the LLM/publish tasks — fail fast on missing keys, auto-load from `.env`
- `@confirm` on every `vercel --prod` / marketplace publish (the Makefile fired `--yes`)
- `@cd` removes the `cd X && …` noise; DRY'd the duplicated web-runtime copy-list into one shared recipe
- `@watch` on `build`/`test` (`jake -w build`); `-j` parallelism; clean `name=value` params for bench/fuzz
- **Incremental `file` recipes** for `@sema/ui` and web-runtime vendoring — re-vendor only when sources change

## New: editor-extension packaging (`ext` group)
`ed.vscode-package` (tsc + vsce → `.vsix`, incremental), `ed.vscode-publish`, `ed.intellij-build`/`-test`/`-verify`/`-publish`, `ed.ext-package` — mirroring `.github/workflows/publish-vscode-extension.yml` and the IntelliJ gradle publish.

## Blocker resolved
The spike originally depended on fixes to jake itself. Those are **done and released** — jake went **0.8.1 → 0.9.1** over the course of this work, fixing five real bugs found while dogfooding here:
- **#17** incremental caching was a no-op (file recipes / `@cache` never skipped)
- **#18** `@import` errors didn't name the failing file
- **#19** `--fmt` hoisted comments off their recipe
- `@require` was validated on read-only `jake -l`/`-s`
- `@require` was global — a publish recipe's `@require VSCE_PAT` broke every `jake build`; now recipe-scoped

So the incremental vendoring and `@require`/`@dotenv` ergonomics in this PR are live on jake ≥ 0.9.1.

## Verification
`jake -l` parses (107 recipes); cross-namespace + bare dep resolution; param/conditional expansion; `file`-recipe incremental chains; a real `jake fmt-check` (exit 0); `@needs`/`@require` fail-fast (`jake test-llm` with no keys errors in 6 ms, before cargo). `jake -l` / `jake build` demand no secrets.

## Requires
jake **≥ 0.9.1** on the developer/CI machine (`git clone helgesverre/jake && zig build -Doptimize=ReleaseFast`, or a release binary). Don't run `jake --fmt` on these files pending a cosmetic follow-up (recipe-level `@require` isn't shown by `jake -s` yet — display-only).
