### PR TITLE
e2e: prefer getByTestId over brittle CSS selectors (sema-web, web-demo, playground, notebook, workflow-view)

### DIFF
--- a/crates/sema-notebook/src/ui/index.html
+++ b/crates/sema-notebook/src/ui/index.html
@@ -199,7 +199,7 @@
                       <template x-if="!(output.output_type === 'value' && !output.content)">
                         <div class="cell-output" :class="{ error: output.output_type === 'error' }"
                              :data-testid="'cell-output-' + (output.output_type === 'error' ? 'error' : output.output_type === 'stdout' ? 'stdout' : 'value')">
-                          <div class="cell-output-header" @click="toggleOutput($el)">
+                          <div class="cell-output-header" data-testid="cell-output-header" @click="toggleOutput($el)">
                             <span class="output-chevron" data-testid="output-chevron">&#9660;</span>
                             <span class="output-meta" data-testid="output-meta" x-text="formatMeta(output)"></span>
                           </div>

--- a/crates/sema-notebook/tests/e2e/notebook.spec.ts
+++ b/crates/sema-notebook/tests/e2e/notebook.spec.ts
@@ -6,12 +6,12 @@ import { test, expect, Page } from '@playwright/test';
 async function waitForLoad(page: Page) {
   await page.goto('/', { waitUntil: 'networkidle' });
   // Cells are loaded via JS fetch after page load — wait for them
-  await page.waitForSelector('[data-testid="cell"]', { timeout: 15000 });
+  await page.getByTestId('cell').first().waitFor({ timeout: 15000 });
 }
 
 /** Get all cells on the page. */
 function cells(page: Page) {
-  return page.locator('[data-testid="cell"]');
+  return page.getByTestId('cell');
 }
 
 /** Get a cell by its 0-based index. */
@@ -21,19 +21,21 @@ function cellAt(page: Page, index: number) {
 
 /** Get cells of a specific type. */
 function cellsOfType(page: Page, type: 'code' | 'markdown') {
-  return page.locator(`[data-testid="cell"][data-cell-type="${type}"]`);
+  // data-cell-type is a real data attribute (not a testid) used to distinguish
+  // code/markdown cells; narrow the testid-selected set with it via `.and()`.
+  return page.getByTestId('cell').and(page.locator(`[data-cell-type="${type}"]`));
 }
 
 /** Wait for a cell's output to appear (stdout or value or error). */
 async function waitForOutput(page: Page, cellIndex: number) {
   const cell = cellAt(page, cellIndex);
-  await cell.locator('[data-testid^="cell-output-"]').first().waitFor({ timeout: 15000 });
+  await cell.getByTestId(/^cell-output-/).first().waitFor({ timeout: 15000 });
 }
 
 /** Get the text content of a cell's output. */
 async function getOutputText(page: Page, cellIndex: number) {
   const cell = cellAt(page, cellIndex);
-  const outputs = cell.locator('[data-testid="output-content"]');
+  const outputs = cell.getByTestId('output-content');
   const count = await outputs.count();
   const texts: string[] = [];
   for (let i = 0; i < count; i++) {
@@ -87,19 +89,19 @@ test.describe('Page structure', () => {
   });
 
   test('markdown cells are rendered by default', async ({ page }) => {
-    const rendered = page.locator('[data-testid="markdown-rendered"]');
+    const rendered = page.getByTestId('markdown-rendered');
     const count = await rendered.count();
     expect(count).toBeGreaterThan(0);
   });
 
   test('code cells have textareas', async ({ page }) => {
-    const textareas = page.locator('[data-testid="cell-textarea"]');
+    const textareas = page.getByTestId('cell-textarea');
     const count = await textareas.count();
     expect(count).toBeGreaterThan(0);
   });
 
   test('between-cell dividers exist', async ({ page }) => {
-    const dividers = page.locator('[data-testid="cell-divider"]');
+    const dividers = page.getByTestId('cell-divider');
     const count = await dividers.count();
     // There should be one more divider than cells (one before, one after each)
     const cellCount = await cells(page).count();
@@ -123,10 +125,10 @@ test.describe('Cell evaluation', () => {
     await codeCell.getByTestId('btn-cell-run').click();
 
     // Wait for output
-    await codeCell.locator('[data-testid="cell-output-stdout"]').waitFor({ timeout: 15000 });
+    await codeCell.getByTestId('cell-output-stdout').waitFor({ timeout: 15000 });
 
     // Check stdout content
-    const output = await codeCell.locator('[data-testid="output-content"]').first().textContent();
+    const output = await codeCell.getByTestId('output-content').first().textContent();
     expect(output).toContain('x = 42');
     expect(output).toContain('x + y = 50');
   });
@@ -141,10 +143,11 @@ test.describe('Cell evaluation', () => {
     const codeCell = cellsOfType(page, 'code').first();
     await codeCell.hover();
     await codeCell.getByTestId('btn-cell-run').click();
-    await codeCell.locator('[data-testid="cell-output-stdout"]').waitFor({ timeout: 15000 });
+    await codeCell.getByTestId('cell-output-stdout').waitFor({ timeout: 15000 });
 
     const rendered = await codeCell
-      .locator('[data-testid="cell-output-stdout"] .cell-output-content')
+      .getByTestId('cell-output-stdout')
+      .getByTestId('output-content')
       .first()
       .innerText();
     // First rendered character is real output, not leaked indentation.
@@ -160,8 +163,8 @@ test.describe('Cell evaluation', () => {
     await page.keyboard.press('Shift+Enter');
 
     // Wait for output
-    await codeCell.locator('[data-testid="cell-output-stdout"]').waitFor({ timeout: 15000 });
-    const output = await codeCell.locator('[data-testid="output-content"]').first().textContent();
+    await codeCell.getByTestId('cell-output-stdout').waitFor({ timeout: 15000 });
+    const output = await codeCell.getByTestId('output-content').first().textContent();
     expect(output).toContain('x = 42');
   });
 
@@ -173,9 +176,9 @@ test.describe('Cell evaluation', () => {
     await errorCell.getByTestId('btn-cell-run').click();
 
     // Wait for error output
-    await errorCell.locator('[data-testid="cell-output-error"]').waitFor({ timeout: 15000 });
+    await errorCell.getByTestId('cell-output-error').waitFor({ timeout: 15000 });
 
-    const output = await errorCell.locator('[data-testid="output-content"]').textContent();
+    const output = await errorCell.getByTestId('output-content').textContent();
     expect(output).toContain('division by zero');
   });
 
@@ -186,7 +189,7 @@ test.describe('Cell evaluation', () => {
     await page.waitForTimeout(3000);
 
     // Check that multiple cells have output
-    const outputs = page.locator('[data-testid^="cell-output-"]');
+    const outputs = page.getByTestId(/^cell-output-/);
     const count = await outputs.count();
     expect(count).toBeGreaterThan(3);
   });
@@ -211,20 +214,20 @@ test.describe('Output interaction', () => {
     const codeCell = cellsOfType(page, 'code').first();
     await codeCell.hover();
     await codeCell.getByTestId('btn-cell-run').click();
-    await codeCell.locator('[data-testid^="cell-output-"]').first().waitFor({ timeout: 15000 });
+    await codeCell.getByTestId(/^cell-output-/).first().waitFor({ timeout: 15000 });
 
     // Content should be visible
-    const content = codeCell.locator('[data-testid="output-content"]').first();
+    const content = codeCell.getByTestId('output-content').first();
     await expect(content).toBeVisible();
 
     // Click the chevron header to collapse
-    await codeCell.locator('.cell-output-header').first().click();
+    await codeCell.getByTestId('cell-output-header').first().click();
 
     // Content should be hidden
     await expect(content).toBeHidden();
 
     // Click again to expand
-    await codeCell.locator('.cell-output-header').first().click();
+    await codeCell.getByTestId('cell-output-header').first().click();
     await expect(content).toBeVisible();
   });
 });
@@ -290,7 +293,7 @@ test.describe('Markdown cells', () => {
   });
 
   test('markdown cells render as HTML by default', async ({ page }) => {
-    const rendered = page.locator('[data-testid="markdown-rendered"]').first();
+    const rendered = page.getByTestId('markdown-rendered').first();
     await expect(rendered).toBeVisible();
 
     // Should contain rendered HTML (h1, strong, etc.)
@@ -307,7 +310,7 @@ test.describe('Markdown cells', () => {
 
     // Should now show a textarea instead
     await expect(firstMarkdown.getByTestId('cell-textarea')).toBeVisible();
-    await expect(firstMarkdown.locator('[data-testid="markdown-rendered"]')).toHaveCount(0);
+    await expect(firstMarkdown.getByTestId('markdown-rendered')).toHaveCount(0);
   });
 
   test('Shift+Enter in markdown cell re-renders', async ({ page }) => {
@@ -449,12 +452,12 @@ test.describe('Reset', () => {
 
     // Load page and wait for outputs to render
     await page.goto('/', { waitUntil: 'networkidle' });
-    await page.waitForSelector('[data-testid="cell"]', { timeout: 15000 });
+    await page.getByTestId('cell').first().waitFor({ timeout: 15000 });
     // Give JS time to fetch and render
-    await page.waitForSelector('[data-testid^="cell-output-"]', { timeout: 10000 });
+    await page.getByTestId(/^cell-output-/).first().waitFor({ timeout: 10000 });
 
     // Confirm outputs exist
-    let outputs = page.locator('[data-testid^="cell-output-"]');
+    let outputs = page.getByTestId(/^cell-output-/);
     expect(await outputs.count()).toBeGreaterThan(0);
 
     // Reset via UI
@@ -463,7 +466,7 @@ test.describe('Reset', () => {
     await page.waitForTimeout(1000);
 
     // Outputs should be gone
-    outputs = page.locator('[data-testid^="cell-output-"]');
+    outputs = page.getByTestId(/^cell-output-/);
     expect(await outputs.count()).toBe(0);
   });
 });
@@ -492,8 +495,8 @@ test.describe('Undo', () => {
 
     // Load page and wait for outputs
     await page.goto('/', { waitUntil: 'networkidle' });
-    await page.waitForSelector('[data-testid="cell"]', { timeout: 15000 });
-    await page.waitForSelector('[data-testid^="cell-output-"]', { timeout: 10000 });
+    await page.getByTestId('cell').first().waitFor({ timeout: 15000 });
+    await page.getByTestId(/^cell-output-/).first().waitFor({ timeout: 10000 });
 
     // Click undo
     await page.getByTestId('btn-undo').click();
@@ -725,7 +728,7 @@ test.describe('Regression — notebook UI fixes', () => {
       if (/gstatic|googleapis|fonts\.google/.test(r.url())) external.push(r.url());
     });
     await page.goto('/', { waitUntil: 'networkidle' });
-    await page.waitForSelector('[data-testid="cell"]');
+    await page.getByTestId('cell').first().waitFor();
     expect(external, `unexpected CDN font requests: ${external.join(', ')}`).toHaveLength(0);
 
     const font = await request.get('/ui/fonts/jetbrains-mono-latin.woff2');

--- a/crates/sema/src/workflow_view/index.html
+++ b/crates/sema/src/workflow_view/index.html
@@ -238,26 +238,26 @@
         <span class="logo"><span class="paren">(</span>sema<span class="paren">)</span></span>
         <span class="lead">Workflow</span>
         <span class="dot-sep">—</span>
-        <span class="wf-name" id="wfname">audit-auth</span>
+        <span class="wf-name" id="wfname" data-testid="wfname">audit-auth</span>
       </div>
       <div class="run-status">
-        <span class="pill running" id="status-pill">running</span>
+        <span class="pill running" id="status-pill" data-testid="status-pill">running</span>
         <span class="elapsed tnum" id="elapsed">00:00</span>
       </div>
       <div class="rollup tnum">
-        <span><span class="num" id="r-phases">0</span> phases</span>
+        <span><span class="num" id="r-phases" data-testid="r-phases">0</span> phases</span>
         <span class="dot-sep">·</span>
-        <span><span class="num" id="r-agents">0</span> agents</span>
+        <span><span class="num" id="r-agents" data-testid="r-agents">0</span> agents</span>
         <span class="dot-sep">·</span>
-        <span><span class="num" id="r-tokens">0</span> tok</span>
+        <span><span class="num" id="r-tokens" data-testid="r-tokens">0</span> tok</span>
         <span class="dot-sep">·</span>
-        <span class="num" id="r-cost">—</span>
+        <span class="num" id="r-cost" data-testid="r-cost">—</span>
       </div>
     </div>
     <div class="meta-strip">
-      <div class="meta-cell"><span class="k">run id</span><span class="v ell tnum" id="m-runid"></span></div>
+      <div class="meta-cell"><span class="k">run id</span><span class="v ell tnum" id="m-runid" data-testid="m-runid"></span></div>
       <div class="meta-cell"><span class="k">workflow</span><span class="v ell" id="m-wf"></span></div>
-      <div class="meta-cell"><span class="k">code version</span><span class="v ell tnum" id="m-code"></span></div>
+      <div class="meta-cell"><span class="k">code version</span><span class="v ell tnum" id="m-code" data-testid="m-code"></span></div>
       <div class="meta-cell"><span class="k">started</span><span class="v ell tnum" id="m-started"></span></div>
       <div class="meta-cell">
         <span class="k">budget (tokens)</span>
@@ -277,7 +277,7 @@
     <div class="stream">
       <div class="stream-head">
         <span class="title">Event stream</span>
-        <span class="src ell">events.jsonl · seq &gt; <span id="stream-cursor">0</span></span>
+        <span class="src ell">events.jsonl · seq &gt; <span id="stream-cursor" data-testid="stream-cursor">0</span></span>
       </div>
       <div class="stream-body" id="stream-body"></div>
     </div>
@@ -450,11 +450,11 @@ const streamBody = document.getElementById("stream-body");
 function pGlyph(p){
   // Pending/skipped FIRST: their status is non-null, so without these branches they
   // would fall through to the ✓ "done" glyph — actively misleading.
-  if(p.status==="pending") return `<span class="pglyph g-pend">${G.pend}</span>`;
-  if(p.status==="skipped") return `<span class="pglyph g-skip">${G.skip}</span>`;
-  if(phaseOpen(p)) return `<span class="pglyph g-run pulse">${G.run}</span>`;
-  if(phaseHasFail(p)) return `<span class="pglyph g-fail">${G.fail}</span>`;
-  return `<span class="pglyph g-ok">${G.ok}</span>`;
+  if(p.status==="pending") return `<span class="pglyph g-pend" data-testid="phase-glyph">${G.pend}</span>`;
+  if(p.status==="skipped") return `<span class="pglyph g-skip" data-testid="phase-glyph">${G.skip}</span>`;
+  if(phaseOpen(p)) return `<span class="pglyph g-run pulse" data-testid="phase-glyph">${G.run}</span>`;
+  if(phaseHasFail(p)) return `<span class="pglyph g-fail" data-testid="phase-glyph">${G.fail}</span>`;
+  return `<span class="pglyph g-ok" data-testid="phase-glyph">${G.ok}</span>`;
 }
 
 function renderPhases(){
@@ -558,10 +558,10 @@ function renderDetail(){
     const dur = a.dur_ms!=null ? `<span class="c tnum">${fmtMs(a.dur_ms)}</span>`
                                : `<span class="c blank tnum">…</span>`;   // blank while running
     html +=
-      `<div class="${cls}" data-agent="${a.agent_id}" data-testid="agent-row" data-status="${st}">`+
+      `<div class="${cls}" data-agent="${a.agent_id}" data-testid="agent-row" data-status="${st}" data-selected="${sel}">`+
       aGlyph(st,"aglyph")+
       `<span class="albl"><span class="aname">${esc(a.agent_id)}</span>`+
-        `<span class="amodel">${esc(a.model)}</span></span>`+
+        `<span class="amodel" data-testid="agent-model">${esc(a.model)}</span></span>`+
       tok+
       `<span class="c tnum">${a.tools.length}</span>`+
       dur+
@@ -663,21 +663,21 @@ function wireDrill(){
    ========================================================================= */
 function evGlyph(e){
   switch(e.event){
-    case "run.started": return `<span class="eg g-pend">${G.cp}</span>`;
-    case "run.ended":   return `<span class="eg g-ok">${G.ok}</span>`;
-    case "phase.started": return `<span class="eg g-run">${G.run}</span>`;
-    case "phase.ended":   return `<span class="eg ${e.status==="failed"?"g-fail":"g-ok"}">${e.status==="failed"?G.fail:G.ok}</span>`;
+    case "run.started": return `<span class="eg g-pend" data-testid="ev-glyph">${G.cp}</span>`;
+    case "run.ended":   return `<span class="eg g-ok" data-testid="ev-glyph">${G.ok}</span>`;
+    case "phase.started": return `<span class="eg g-run" data-testid="ev-glyph">${G.run}</span>`;
+    case "phase.ended":   return `<span class="eg ${e.status==="failed"?"g-fail":"g-ok"}" data-testid="ev-glyph">${e.status==="failed"?G.fail:G.ok}</span>`;
     case "agent.started": {
       // Only pulse while the agent is genuinely still running; a finished run's
       // historical agent.started rows must not spin forever.
       const fin = M.agents.get(e.agent_id)?.status != null;
-      return `<span class="eg g-run${fin ? "" : " pulse"}">${G.run}</span>`;
+      return `<span class="eg g-run${fin ? "" : " pulse"}" data-testid="ev-glyph">${G.run}</span>`;
     }
-    case "agent.result":  return `<span class="eg ${e.status==="failed"?"g-fail":"g-ok"}">${e.status==="failed"?G.fail:G.ok}</span>`;
-    case "agent.tool_call": return `<span class="eg g-pend">${G.twig}</span>`;
-    case "checkpoint":    return `<span class="eg g-pend">${G.cp}</span>`;
-    case "budget":        return `<span class="eg g-pend">${G.bud}</span>`;
-    default: return `<span class="eg g-pend">${G.bud}</span>`;
+    case "agent.result":  return `<span class="eg ${e.status==="failed"?"g-fail":"g-ok"}" data-testid="ev-glyph">${e.status==="failed"?G.fail:G.ok}</span>`;
+    case "agent.tool_call": return `<span class="eg g-pend" data-testid="ev-glyph">${G.twig}</span>`;
+    case "checkpoint":    return `<span class="eg g-pend" data-testid="ev-glyph">${G.cp}</span>`;
+    case "budget":        return `<span class="eg g-pend" data-testid="ev-glyph">${G.bud}</span>`;
+    default: return `<span class="eg g-pend" data-testid="ev-glyph">${G.bud}</span>`;
   }
 }
 function evFields(e){

--- a/crates/sema/tests/e2e-workflow-view/workflow-view.spec.ts
+++ b/crates/sema/tests/e2e-workflow-view/workflow-view.spec.ts
@@ -6,54 +6,54 @@ import { test, expect, Page } from '@playwright/test';
 
 async function open(page: Page) {
   await page.goto('/?run=audit-auth', { waitUntil: 'networkidle' });
-  await page.waitForSelector('[data-testid="phase"]', { timeout: 15000 });
+  await page.getByTestId('phase').first().waitFor({ timeout: 15000 });
 }
 
 test('header + rollup: name, live status, phases/agents/tokens/cost', async ({ page }) => {
   await open(page);
-  await expect(page.locator('#wfname')).toHaveText('audit-auth');
-  await expect(page.locator('#status-pill')).toHaveText('running'); // no run.ended → live
-  await expect(page.locator('#r-phases')).toHaveText('4');
-  await expect(page.locator('#r-agents')).toHaveText('4');
-  await expect(page.locator('#r-tokens')).toHaveText('9.4k'); // 4000+3740+1660
-  await expect(page.locator('#r-cost')).toContainText('0.0058'); // 0.0041 + 0.0017 (auditor_2 unpriced)
+  await expect(page.getByTestId('wfname')).toHaveText('audit-auth');
+  await expect(page.getByTestId('status-pill')).toHaveText('running'); // no run.ended → live
+  await expect(page.getByTestId('r-phases')).toHaveText('4');
+  await expect(page.getByTestId('r-agents')).toHaveText('4');
+  await expect(page.getByTestId('r-tokens')).toHaveText('9.4k'); // 4000+3740+1660
+  await expect(page.getByTestId('r-cost')).toContainText('0.0058'); // 0.0041 + 0.0017 (auditor_2 unpriced)
   // meta strip is populated from run.started
-  await expect(page.locator('#m-runid')).toHaveText('wf_audit_auth_8f3a21');
-  await expect(page.locator('#m-code')).toHaveText('a3f1c09e');
+  await expect(page.getByTestId('m-runid')).toHaveText('wf_audit_auth_8f3a21');
+  await expect(page.getByTestId('m-code')).toHaveText('a3f1c09e');
 });
 
 test('left pane: the phase ledger renders all four phases in order', async ({ page }) => {
   await open(page);
-  const phases = page.locator('[data-testid="phase"]');
+  const phases = page.getByTestId('phase');
   await expect(phases).toHaveCount(4);
   for (const name of ['inventory', 'audit', 'verify', 'report']) {
-    await expect(page.locator(`[data-testid="phase"][data-phase-name="${name}"]`)).toHaveCount(1);
+    await expect(page.getByTestId('phase').and(page.locator(`[data-phase-name="${name}"]`))).toHaveCount(1);
   }
 });
 
 test('right pane: the raw event stream renders one row per journal event', async ({ page }) => {
   await open(page);
   // 24 events in the fixture → 24 stream rows; the cursor shows the last seq.
-  await expect(page.locator('[data-testid="ev-row"]')).toHaveCount(24);
-  await expect(page.locator('#stream-cursor')).toHaveText('23');
+  await expect(page.getByTestId('ev-row')).toHaveCount(24);
+  await expect(page.getByTestId('stream-cursor')).toHaveText('23');
 });
 
 test('center pane: selecting the audit phase shows its 3 agents with model + columns', async ({ page }) => {
   await open(page);
-  await page.locator('[data-testid="phase"][data-phase-name="audit"]').click();
-  const agents = page.locator('[data-testid="agent-row"]');
+  await page.getByTestId('phase').and(page.locator('[data-phase-name="audit"]')).click();
+  const agents = page.getByTestId('agent-row');
   await expect(agents).toHaveCount(3);
   // model column is rendered (full model id, per the prototype)
-  await expect(page.locator('.amodel').first()).toContainText('claude-haiku');
+  await expect(page.getByTestId('agent-model').first()).toContainText('claude-haiku');
   // one auditor failed → a failed status row exists
-  await expect(page.locator('[data-testid="agent-row"][data-status="failed"]')).toHaveCount(1);
+  await expect(page.getByTestId('agent-row').and(page.locator('[data-status="failed"]'))).toHaveCount(1);
 });
 
 test('drill-in details: Prompt / Tool calls / Output digest sections', async ({ page }) => {
   await open(page);
-  await page.locator('[data-testid="phase"][data-phase-name="audit"]').click();
-  await page.locator('[data-testid="agent-row"]').first().click();
-  const drill = page.locator('[data-testid="drill"]');
+  await page.getByTestId('phase').and(page.locator('[data-phase-name="audit"]')).click();
+  await page.getByTestId('agent-row').first().click();
+  const drill = page.getByTestId('drill');
   await expect(drill).toBeVisible();
   await expect(drill).toContainText('Prompt');
   await expect(drill).toContainText('Tool calls');
@@ -63,7 +63,7 @@ test('drill-in details: Prompt / Tool calls / Output digest sections', async ({ 
 test('status pill is on-brand (rounded, brand pill radius)', async ({ page }) => {
   await open(page);
   const radius = await page
-    .locator('#status-pill')
+    .getByTestId('status-pill')
     .evaluate((el) => getComputedStyle(el).borderRadius);
   expect(parseFloat(radius)).toBeGreaterThanOrEqual(12); // brand "pill" = 20px, not square
 });
@@ -71,31 +71,44 @@ test('status pill is on-brand (rounded, brand pill radius)', async ({ page }) =>
 test('event stream: finished agents do not pulse; only a live agent does', async ({ page }) => {
   await open(page);
   // auditor_1 finished (has agent.result) → its agent.started stream glyph must NOT pulse.
-  const finishedGlyph = page.locator('[data-testid="ev-row"][data-ev-agent="auditor_1"] .eg').first();
+  const finishedGlyph = page
+    .getByTestId('ev-row')
+    .and(page.locator('[data-ev-agent="auditor_1"]'))
+    .getByTestId('ev-glyph')
+    .first();
   await expect(finishedGlyph).not.toHaveClass(/pulse/);
   // reporter_1 is still running (no agent.result) → its glyph DOES pulse.
-  const liveGlyph = page.locator('[data-testid="ev-row"][data-ev-agent="reporter_1"] .eg').first();
+  const liveGlyph = page
+    .getByTestId('ev-row')
+    .and(page.locator('[data-ev-agent="reporter_1"]'))
+    .getByTestId('ev-glyph')
+    .first();
   await expect(liveGlyph).toHaveClass(/pulse/);
 });
 
 test('phase ledger: checkpoint-only phase shows ◇N, not a misleading 0/0', async ({ page }) => {
   await open(page);
   // verify is a pure-checkpoint phase (1 checkpoint, 0 agents) → "◇1", never "0/0".
-  const verifyCount = page.locator('[data-testid="phase"][data-phase-name="verify"] [data-testid="phase-count"]');
+  const verifyCount = page
+    .getByTestId('phase')
+    .and(page.locator('[data-phase-name="verify"]'))
+    .getByTestId('phase-count');
   await expect(verifyCount).toHaveText('◇1');
   await expect(verifyCount).not.toHaveText('0/0');
   // audit has agents → still the done/total form.
   await expect(
-    page.locator('[data-testid="phase"][data-phase-name="audit"] [data-testid="phase-count"]')
+    page.getByTestId('phase').and(page.locator('[data-phase-name="audit"]')).getByTestId('phase-count')
   ).toHaveText('3/3');
 });
 
 test('event stream → click jumps to the agent in the detail pane', async ({ page }) => {
   await open(page);
   // The agent.result for auditor_2 (an event-stream row) jumps to auditor_2.
-  const row = page.locator('[data-testid="ev-row"][data-ev-agent="auditor_2"]').first();
+  const row = page.getByTestId('ev-row').and(page.locator('[data-ev-agent="auditor_2"]')).first();
   await row.click();
-  await expect(page.locator('[data-testid="agent-row"][data-agent="auditor_2"].sel')).toHaveCount(1);
+  await expect(
+    page.getByTestId('agent-row').and(page.locator('[data-agent="auditor_2"][data-selected="true"]'))
+  ).toHaveCount(1);
 });
 
 // all-phases-upfront (S5): a run that declares 4 phases (run.started.phases) but has
@@ -103,9 +116,9 @@ test('event stream → click jumps to the agent in the detail pane', async ({ pa
 // pending (dimmed, NOT a misleading ✓). Order preserved.
 test('phase ledger shows ALL declared phases, un-started ones pending', async ({ page }) => {
   await page.goto('/?run=audit-pending', { waitUntil: 'networkidle' });
-  await page.waitForSelector('[data-testid="phase"]', { timeout: 15000 });
+  await page.getByTestId('phase').first().waitFor({ timeout: 15000 });
 
-  const phases = page.locator('[data-testid="phase"]');
+  const phases = page.getByTestId('phase');
   await expect(phases).toHaveCount(4); // all declared phases up front
   // order matches the declared plan
   await expect(phases.nth(0)).toHaveAttribute('data-phase-name', 'Inventory');
@@ -116,12 +129,12 @@ test('phase ledger shows ALL declared phases, un-started ones pending', async ({
   // status spread: done / running / pending / pending
   await expect(phases.nth(0)).toHaveAttribute('data-status', 'done');
   await expect(phases.nth(1)).toHaveAttribute('data-status', 'running');
-  await expect(page.locator('[data-testid="phase"][data-status="pending"]')).toHaveCount(2);
+  await expect(page.getByTestId('phase').and(page.locator('[data-status="pending"]'))).toHaveCount(2);
 
   // a pending row shows the pending glyph (○), never the done ✓
-  const verify = page.locator('[data-testid="phase"][data-phase-name="Verify"]');
-  await expect(verify.locator('.pglyph')).toHaveText('○');
+  const verify = page.getByTestId('phase').and(page.locator('[data-phase-name="Verify"]'));
+  await expect(verify.getByTestId('phase-glyph')).toHaveText('○');
 
   // header rollup counts only STARTED phases (2), while the ledger shows all 4
-  await expect(page.locator('#r-phases')).toHaveText('2');
+  await expect(page.getByTestId('r-phases')).toHaveText('2');
 });

--- a/examples/web-demo/chat.sema
+++ b/examples/web-demo/chat.sema
@@ -19,7 +19,8 @@
           (put! current-stream s))))))
 
 (define (format-message msg)
-  [:div {:class (string-append "message " (get msg :role))}
+  [:div {:class (string-append "message " (get msg :role))
+         :data-testid (string-append "msg-" (get msg :role))}
     [:strong (string-append (get msg :role) ": ")]
     [:span (get msg :content)]])
 
@@ -34,13 +35,13 @@
               (fn (msgs) (append msgs (list {:role "assistant" :content (get val :text)})))))
           (put! current-stream nil)
           [:span])
-        [:div {:class "message assistant streaming"}
+        [:div {:class "message assistant streaming" :data-testid "msg-assistant-streaming"}
           [:strong "assistant: "]
           [:span (get val :text)]]))
     [:span]))
 
 (define (chat-view)
-  [:div {:class "chat-container"}
+  [:div {:class "chat-container" :data-testid "chat-container"}
     [:h2 "Sema AI Chat"]
     [:div {:class "messages" :id "message-list"}
       (map format-message @messages)
@@ -51,7 +52,8 @@
                :placeholder "Ask something..."
                :value @input-text
                :on-input "update-input"
-               :autocomplete "off"}]
-      [:button {:type "submit"} "Send"]]])
+               :autocomplete "off"
+               :data-testid "chat-input"}]
+      [:button {:type "submit" :data-testid "send-btn"} "Send"]]])
 
 (mount! "#app" chat-view)

--- a/examples/web-demo/tests/board-demo.spec.ts
+++ b/examples/web-demo/tests/board-demo.spec.ts
@@ -19,24 +19,24 @@ test.describe("Project Board Demo", () => {
     await waitForSema(page);
 
     // Header should be visible
-    const header = page.locator('[data-testid="board-header"]');
+    const header = page.getByTestId("board-header");
     await expect(header).toBeVisible({ timeout: 10_000 });
 
     // All three columns should be visible
-    await expect(page.locator('[data-testid="column-todo"]')).toBeVisible();
-    await expect(page.locator('[data-testid="column-in-progress"]')).toBeVisible();
-    await expect(page.locator('[data-testid="column-done"]')).toBeVisible();
+    await expect(page.getByTestId("column-todo")).toBeVisible();
+    await expect(page.getByTestId("column-in-progress")).toBeVisible();
+    await expect(page.getByTestId("column-done")).toBeVisible();
 
     // Should have seed cards (at least 5)
-    const cards = page.locator('[data-testid="board-card"]');
+    const cards = page.getByTestId("board-card");
     await expect(cards.first()).toBeVisible({ timeout: 5_000 });
     const count = await cards.count();
     expect(count).toBeGreaterThanOrEqual(5);
 
     // Column counts should reflect the cards
-    await expect(page.locator('[data-testid="count-todo"]')).toBeVisible();
-    await expect(page.locator('[data-testid="count-in-progress"]')).toBeVisible();
-    await expect(page.locator('[data-testid="count-done"]')).toBeVisible();
+    await expect(page.getByTestId("count-todo")).toBeVisible();
+    await expect(page.getByTestId("count-in-progress")).toBeVisible();
+    await expect(page.getByTestId("count-done")).toBeVisible();
   });
 
   test("add a new card — click Add, type title, press Enter", async ({ page }) => {
@@ -50,19 +50,19 @@ test.describe("Project Board Demo", () => {
     await waitForSema(page);
 
     // Wait for board to render
-    await expect(page.locator('[data-testid="column-todo"]')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId("column-todo")).toBeVisible({ timeout: 10_000 });
 
     // Count initial cards in To Do
-    const initialCount = await page.locator('[data-testid="column-todo"] [data-testid="board-card"]').count();
+    const initialCount = await page.getByTestId("column-todo").getByTestId("board-card").count();
 
     // Click "Add a card" button in To Do column
-    await page.locator('[data-testid="add-card-todo"]').click();
+    await page.getByTestId("add-card-todo").click();
 
     // Form should appear
-    await expect(page.locator('[data-testid="add-card-input"]')).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByTestId("add-card-input")).toBeVisible({ timeout: 3_000 });
 
     // Type a card title and submit
-    const input = page.locator('[data-testid="add-card-input"]');
+    const input = page.getByTestId("add-card-input");
     await input.fill("My new test card");
 
     // Sync reactive state
@@ -70,15 +70,15 @@ test.describe("Project Board Demo", () => {
       (window as any).__semaWeb.eval('(put! adding-text "My new test card")');
     });
 
-    await page.locator('[data-testid="submit-add-card"]').click();
+    await page.getByTestId("submit-add-card").click();
 
     // New card should appear in To Do column
     await expect(
-      page.locator('[data-testid="column-todo"] [data-testid="card-title"]', { hasText: "My new test card" })
+      page.getByTestId("column-todo").getByTestId("card-title").filter({ hasText: "My new test card" })
     ).toBeVisible({ timeout: 5_000 });
 
     // Count should increase
-    const newCount = await page.locator('[data-testid="column-todo"] [data-testid="board-card"]').count();
+    const newCount = await page.getByTestId("column-todo").getByTestId("board-card").count();
     expect(newCount).toBe(initialCount + 1);
   });
 
@@ -91,14 +91,14 @@ test.describe("Project Board Demo", () => {
     await page.reload();
     await waitForSema(page);
 
-    await expect(page.locator('[data-testid="board-header"]')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId("board-header")).toBeVisible({ timeout: 10_000 });
 
     // Get total card count before search
-    const totalBefore = await page.locator('[data-testid="board-card"]').count();
+    const totalBefore = await page.getByTestId("board-card").count();
     expect(totalBefore).toBeGreaterThanOrEqual(5);
 
     // Type in search — "authentication" should match one seed card
-    const searchInput = page.locator('[data-testid="search-input"]');
+    const searchInput = page.getByTestId("search-input");
     await searchInput.fill("authentication");
 
     // Sync reactive state
@@ -110,13 +110,13 @@ test.describe("Project Board Demo", () => {
     await page.waitForTimeout(500);
 
     // Should show fewer cards
-    const totalAfter = await page.locator('[data-testid="board-card"]').count();
+    const totalAfter = await page.getByTestId("board-card").count();
     expect(totalAfter).toBeLessThan(totalBefore);
     expect(totalAfter).toBeGreaterThanOrEqual(1);
 
     // The matching card should still be visible
     await expect(
-      page.locator('[data-testid="card-title"]', { hasText: "authentication" })
+      page.getByTestId("card-title").filter({ hasText: "authentication" })
     ).toBeVisible();
 
     // Clear search
@@ -126,7 +126,7 @@ test.describe("Project Board Demo", () => {
     await page.waitForTimeout(500);
 
     // All cards should be visible again
-    const totalRestored = await page.locator('[data-testid="board-card"]').count();
+    const totalRestored = await page.getByTestId("board-card").count();
     expect(totalRestored).toBe(totalBefore);
   });
 
@@ -139,22 +139,22 @@ test.describe("Project Board Demo", () => {
     await page.reload();
     await waitForSema(page);
 
-    await expect(page.locator('[data-testid="column-todo"]')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId("column-todo")).toBeVisible({ timeout: 10_000 });
 
     // Get initial counts
-    const todoInitial = await page.locator('[data-testid="column-todo"] [data-testid="board-card"]').count();
-    const progressInitial = await page.locator('[data-testid="column-in-progress"] [data-testid="board-card"]').count();
+    const todoInitial = await page.getByTestId("column-todo").getByTestId("board-card").count();
+    const progressInitial = await page.getByTestId("column-in-progress").getByTestId("board-card").count();
 
     // Click the move-right button on the first todo card
-    const firstTodoCard = page.locator('[data-testid="column-todo"] [data-testid="board-card"]').first();
-    const moveRightBtn = firstTodoCard.locator('[data-testid="move-right-btn"]');
+    const firstTodoCard = page.getByTestId("column-todo").getByTestId("board-card").first();
+    const moveRightBtn = firstTodoCard.getByTestId("move-right-btn");
     await moveRightBtn.click();
 
     await page.waitForTimeout(500);
 
     // To Do should have one fewer card, In Progress should have one more
-    const todoAfter = await page.locator('[data-testid="column-todo"] [data-testid="board-card"]').count();
-    const progressAfter = await page.locator('[data-testid="column-in-progress"] [data-testid="board-card"]').count();
+    const todoAfter = await page.getByTestId("column-todo").getByTestId("board-card").count();
+    const progressAfter = await page.getByTestId("column-in-progress").getByTestId("board-card").count();
 
     expect(todoAfter).toBe(todoInitial - 1);
     expect(progressAfter).toBe(progressInitial + 1);
@@ -173,7 +173,7 @@ test.describe("Project Board Demo", () => {
     await page.reload();
     await waitForSema(page);
 
-    await expect(page.locator('[data-testid="board-card"]').first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId("board-card").first()).toBeVisible({ timeout: 10_000 });
 
     // Set selected card directly (click event delegation has timing issues)
     await page.evaluate(() => {
@@ -181,15 +181,15 @@ test.describe("Project Board Demo", () => {
     });
 
     // Modal should appear (now rendered inline in board-root)
-    await expect(page.locator('[data-testid="card-modal"]')).toBeVisible({ timeout: 5_000 });
-    await expect(page.locator('[data-testid="modal-title"]')).toBeVisible();
+    await expect(page.getByTestId("card-modal")).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId("modal-title")).toBeVisible();
 
     // Close modal
-    await page.locator('[data-testid="modal-close"]').click();
+    await page.getByTestId("modal-close").click();
     await page.waitForTimeout(500);
 
     // Modal should be gone (just a span)
-    await expect(page.locator('[data-testid="card-modal"]')).not.toBeVisible();
+    await expect(page.getByTestId("card-modal")).not.toBeVisible();
   });
 
   test("delete card removes it from the board", async ({ page }) => {
@@ -201,15 +201,15 @@ test.describe("Project Board Demo", () => {
     await page.reload();
     await waitForSema(page);
 
-    await expect(page.locator('[data-testid="board-card"]').first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId("board-card").first()).toBeVisible({ timeout: 10_000 });
 
-    const totalBefore = await page.locator('[data-testid="board-card"]').count();
+    const totalBefore = await page.getByTestId("board-card").count();
 
     // Click delete on the first card
-    await page.locator('[data-testid="delete-btn"]').first().click();
+    await page.getByTestId("delete-btn").first().click();
     await page.waitForTimeout(500);
 
-    const totalAfter = await page.locator('[data-testid="board-card"]').count();
+    const totalAfter = await page.getByTestId("board-card").count();
     expect(totalAfter).toBe(totalBefore - 1);
   });
 
@@ -222,7 +222,7 @@ test.describe("Project Board Demo", () => {
     await page.reload();
     await waitForSema(page);
 
-    await expect(page.locator('[data-testid="column-todo"]')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId("column-todo")).toBeVisible({ timeout: 10_000 });
 
     // Add a card via eval
     await page.evaluate(() => {
@@ -234,18 +234,18 @@ test.describe("Project Board Demo", () => {
 
     // Verify the card is there
     await expect(
-      page.locator('[data-testid="card-title"]', { hasText: "Persisted test card" })
+      page.getByTestId("card-title").filter({ hasText: "Persisted test card" })
     ).toBeVisible();
 
     // Reload the page
     await page.reload();
     await waitForSema(page);
 
-    await expect(page.locator('[data-testid="column-todo"]')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId("column-todo")).toBeVisible({ timeout: 10_000 });
 
     // Card should still be there after reload
     await expect(
-      page.locator('[data-testid="card-title"]', { hasText: "Persisted test card" })
+      page.getByTestId("card-title").filter({ hasText: "Persisted test card" })
     ).toBeVisible({ timeout: 5_000 });
   });
 
@@ -253,10 +253,10 @@ test.describe("Project Board Demo", () => {
     await page.goto("/board.html");
     await waitForSema(page);
 
-    await expect(page.locator('[data-testid="board-header"]')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId("board-header")).toBeVisible({ timeout: 10_000 });
 
     // AI generate button should be visible
-    const aiBtn = page.locator('[data-testid="ai-generate-btn"]');
+    const aiBtn = page.getByTestId("ai-generate-btn");
     await expect(aiBtn).toBeVisible();
     await expect(aiBtn).toContainText("AI Generate");
   });
@@ -270,10 +270,10 @@ test.describe("Project Board Demo", () => {
     await page.reload();
     await waitForSema(page);
 
-    await expect(page.locator('[data-testid="board-header"]')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId("board-header")).toBeVisible({ timeout: 10_000 });
 
     // Progress should show done/total (seed data has 1 done out of 6)
-    const progressText = page.locator('[data-testid="board-header"]').locator('text=/\\d+\\/\\d+/');
+    const progressText = page.getByTestId("board-header").locator('text=/\\d+\\/\\d+/');
     await expect(progressText).toBeVisible({ timeout: 3_000 });
   });
 });

--- a/examples/web-demo/tests/chat-demo.spec.ts
+++ b/examples/web-demo/tests/chat-demo.spec.ts
@@ -20,12 +20,12 @@ test.describe("AI Chat Demo", () => {
     await waitForSema(page);
 
     // Chat container should be visible
-    await expect(page.locator(".chat-container")).toBeVisible();
+    await expect(page.getByTestId("chat-container")).toBeVisible();
     await expect(page.locator("h2")).toHaveText("Sema AI Chat");
 
     // Input and send button should be present
-    await expect(page.locator("#chat-input")).toBeVisible();
-    await expect(page.locator('button[type="submit"]')).toHaveText("Send");
+    await expect(page.getByTestId("chat-input")).toBeVisible();
+    await expect(page.getByTestId("send-btn")).toHaveText("Send");
   });
 
   test("send message and receive streaming response", async ({ page }) => {
@@ -44,11 +44,11 @@ test.describe("AI Chat Demo", () => {
     });
 
     // User message should appear
-    await expect(page.locator(".message.user").first()).toBeVisible({ timeout: 5_000 });
-    await expect(page.locator(".message.user").first()).toContainText("Say hello");
+    await expect(page.getByTestId("msg-user").first()).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId("msg-user").first()).toContainText("Say hello");
 
     // Wait for assistant response (streaming or completed)
-    await expect(page.locator(".message.assistant")).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByTestId("msg-assistant").or(page.getByTestId("msg-assistant-streaming"))).toBeVisible({ timeout: 30_000 });
 
     // Wait for streaming to finish
     await page.waitForFunction(
@@ -73,7 +73,7 @@ test.describe("AI Chat Demo", () => {
     });
 
     // Wait for the assistant response to appear (streaming or completed)
-    await expect(page.locator(".message.assistant")).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByTestId("msg-assistant").or(page.getByTestId("msg-assistant-streaming"))).toBeVisible({ timeout: 30_000 });
 
     // Wait for streaming to finish — the message should have content
     await page.waitForFunction(
@@ -88,8 +88,8 @@ test.describe("AI Chat Demo", () => {
     );
 
     // Verify we have both user and assistant messages
-    await expect(page.locator(".message.user")).toHaveCount(1);
-    const assistantCount = await page.locator(".message.assistant, .message.assistant.streaming").count();
+    await expect(page.getByTestId("msg-user")).toHaveCount(1);
+    const assistantCount = await page.getByTestId("msg-assistant").or(page.getByTestId("msg-assistant-streaming")).count();
     expect(assistantCount).toBeGreaterThanOrEqual(1);
   });
 });

--- a/examples/web-demo/tests/full-verification.spec.ts
+++ b/examples/web-demo/tests/full-verification.spec.ts
@@ -23,39 +23,39 @@ test.describe("Full Verification: Board Demo", () => {
     await waitForSema(page);
 
     // 1. Board loaded — columns visible
-    await expect(page.locator('[data-testid="column-todo"]')).toBeVisible({ timeout: 10_000 });
-    await expect(page.locator('[data-testid="column-in-progress"]')).toBeVisible();
-    await expect(page.locator('[data-testid="column-done"]')).toBeVisible();
-    const seedCount = await page.locator('[data-testid="board-card"]').count();
+    await expect(page.getByTestId("column-todo")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId("column-in-progress")).toBeVisible();
+    await expect(page.getByTestId("column-done")).toBeVisible();
+    const seedCount = await page.getByTestId("board-card").count();
     expect(seedCount).toBeGreaterThanOrEqual(5);
     console.log(`PASS: Board loaded with ${seedCount} seed cards across 3 columns`);
 
     // 2. Add a card
-    await page.locator('[data-testid="add-card-todo"]').click();
-    const addInput = page.locator('[data-testid="add-card-input"]');
+    await page.getByTestId("add-card-todo").click();
+    const addInput = page.getByTestId("add-card-input");
     await expect(addInput).toBeVisible({ timeout: 3_000 });
     await addInput.fill("Verification card");
-    await page.locator('[data-testid="submit-add-card"]').click();
+    await page.getByTestId("submit-add-card").click();
     await page.waitForTimeout(500);
     await expect(page.locator('text=Verification card')).toBeVisible();
     console.log("PASS: Card added via UI");
 
     // 3. Search filters
-    await page.locator('[data-testid="search-input"]').fill("Verification");
+    await page.getByTestId("search-input").fill("Verification");
     await page.waitForTimeout(500);
-    const filtered = await page.locator('[data-testid="board-card"]').count();
+    const filtered = await page.getByTestId("board-card").count();
     expect(filtered).toBeLessThan(seedCount + 1); // fewer cards visible
-    await page.locator('[data-testid="search-input"]').fill("");
+    await page.getByTestId("search-input").fill("");
     await page.waitForTimeout(300);
     console.log("PASS: Search filtering works");
 
     // 4. Move card
-    const moveBtn = page.locator('[data-testid="column-todo"] [data-testid="move-right-btn"]').first();
+    const moveBtn = page.getByTestId("column-todo").getByTestId("move-right-btn").first();
     if (await moveBtn.isVisible()) {
-      const todoBefore = await page.locator('[data-testid="column-todo"] [data-testid="board-card"]').count();
+      const todoBefore = await page.getByTestId("column-todo").getByTestId("board-card").count();
       await moveBtn.click();
       await page.waitForTimeout(500);
-      const todoAfter = await page.locator('[data-testid="column-todo"] [data-testid="board-card"]').count();
+      const todoAfter = await page.getByTestId("column-todo").getByTestId("board-card").count();
       expect(todoAfter).toBe(todoBefore - 1);
       console.log("PASS: Card moved between columns");
     }
@@ -85,23 +85,23 @@ test.describe("Full Verification: Chat Widget", () => {
     await waitForSema(page);
 
     // 1. FAB visible
-    const fab = page.locator('[data-testid="chat-fab"]');
+    const fab = page.getByTestId("chat-fab");
     await expect(fab).toBeVisible({ timeout: 10_000 });
     console.log("PASS: Widget FAB visible");
 
     // 2. Open panel
     await fab.click();
-    const panel = page.locator('[data-testid="chat-panel"]');
+    const panel = page.getByTestId("chat-panel");
     await expect(panel).toBeVisible({ timeout: 3_000 });
     console.log("PASS: Chat panel opened");
 
     // 3. Input and send button present
-    await expect(page.locator('[data-testid="chat-input"]')).toBeVisible();
-    await expect(page.locator('[data-testid="send-btn"]')).toBeVisible();
+    await expect(page.getByTestId("chat-input")).toBeVisible();
+    await expect(page.getByTestId("send-btn")).toBeVisible();
     console.log("PASS: Chat input and send button present");
 
     // 4. Close panel
-    await page.locator('[data-testid="close-btn"]').click();
+    await page.getByTestId("close-btn").click();
     await page.waitForTimeout(500);
     await expect(panel).not.toBeVisible();
     console.log("PASS: Chat panel closed");
@@ -129,10 +129,10 @@ test.describe("Full Verification: Simple Chat", () => {
       web.eval('(put! current-stream (llm/chat-stream (list {:role "user" :content "Say hi"}) {}))');
     });
 
-    await expect(page.locator(".message.user").first()).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId("msg-user").first()).toBeVisible({ timeout: 5_000 });
     console.log("PASS: User message rendered");
 
-    await expect(page.locator(".message.assistant").first()).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByTestId("msg-assistant").or(page.getByTestId("msg-assistant-streaming")).first()).toBeVisible({ timeout: 30_000 });
     await page.waitForFunction(
       () => {
         const msgs = document.querySelectorAll(".message.assistant");

--- a/examples/web-demo/tests/widget-demo.spec.ts
+++ b/examples/web-demo/tests/widget-demo.spec.ts
@@ -19,7 +19,7 @@ test.describe("Chat Widget Demo", () => {
     await waitForSema(page);
 
     // FAB button should be visible
-    const fab = page.locator('[data-testid="chat-fab"]');
+    const fab = page.getByTestId("chat-fab");
     await expect(fab).toBeVisible({ timeout: 10_000 });
   });
 
@@ -27,19 +27,19 @@ test.describe("Chat Widget Demo", () => {
     await page.goto("/widget.html");
     await waitForSema(page);
 
-    const fab = page.locator('[data-testid="chat-fab"]');
+    const fab = page.getByTestId("chat-fab");
     await expect(fab).toBeVisible({ timeout: 10_000 });
 
     // Panel should not be visible initially
-    await expect(page.locator('[data-testid="chat-panel"]')).not.toBeVisible();
+    await expect(page.getByTestId("chat-panel")).not.toBeVisible();
 
     // Click to open
     await fab.click();
-    await expect(page.locator('[data-testid="chat-panel"]')).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId("chat-panel")).toBeVisible({ timeout: 5_000 });
 
     // Close via close button
-    await page.locator('[data-testid="close-btn"]').click();
-    await expect(page.locator('[data-testid="chat-panel"]')).not.toBeVisible({ timeout: 5_000 });
+    await page.getByTestId("close-btn").click();
+    await expect(page.getByTestId("chat-panel")).not.toBeVisible({ timeout: 5_000 });
   });
 
   test("send a message and receive streaming response", async ({ page }) => {
@@ -47,11 +47,11 @@ test.describe("Chat Widget Demo", () => {
     await waitForSema(page);
 
     // Open the widget
-    await page.locator('[data-testid="chat-fab"]').click();
-    await expect(page.locator('[data-testid="chat-panel"]')).toBeVisible({ timeout: 5_000 });
+    await page.getByTestId("chat-fab").click();
+    await expect(page.getByTestId("chat-panel")).toBeVisible({ timeout: 5_000 });
 
     // Type and send a message
-    const input = page.locator('[data-testid="chat-input"]');
+    const input = page.getByTestId("chat-input");
     await input.fill("Hello there");
 
     // Update reactive state to match the filled value
@@ -59,19 +59,19 @@ test.describe("Chat Widget Demo", () => {
       (window as any).__semaWeb.eval('(put! input-text "Hello there")');
     });
 
-    await page.locator('[data-testid="send-btn"]').click();
+    await page.getByTestId("send-btn").click();
 
     // User message should appear
-    await expect(page.locator('[data-testid="msg-user"]').first()).toBeVisible({ timeout: 5_000 });
-    await expect(page.locator('[data-testid="msg-user"]').first()).toContainText("Hello there");
+    await expect(page.getByTestId("msg-user").first()).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId("msg-user").first()).toContainText("Hello there");
 
     // Wait for streaming to start (typing indicator or streaming text)
     await expect(
-      page.locator('[data-testid="typing-indicator"], [data-testid="streaming-msg"]').first()
+      page.getByTestId("typing-indicator").or(page.getByTestId("streaming-msg")).first()
     ).toBeVisible({ timeout: 10_000 });
 
     // Wait for assistant response to complete
-    await expect(page.locator('[data-testid="msg-assistant"]').first()).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByTestId("msg-assistant").first()).toBeVisible({ timeout: 30_000 });
   });
 
   test("conversation persists across reloads via localStorage", async ({ page }) => {
@@ -91,21 +91,21 @@ test.describe("Chat Widget Demo", () => {
     });
 
     // Verify messages are visible
-    await page.locator('[data-testid="chat-fab"]').click();
-    await expect(page.locator('[data-testid="chat-panel"]')).toBeVisible({ timeout: 5_000 });
-    await expect(page.locator('[data-testid="msg-user"]').first()).toContainText("Persisted message");
-    await expect(page.locator('[data-testid="msg-assistant"]').first()).toContainText("I remember you");
+    await page.getByTestId("chat-fab").click();
+    await expect(page.getByTestId("chat-panel")).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId("msg-user").first()).toContainText("Persisted message");
+    await expect(page.getByTestId("msg-assistant").first()).toContainText("I remember you");
 
     // Reload the page
     await page.reload();
     await waitForSema(page);
 
     // Open widget again
-    await page.locator('[data-testid="chat-fab"]').click();
-    await expect(page.locator('[data-testid="chat-panel"]')).toBeVisible({ timeout: 5_000 });
+    await page.getByTestId("chat-fab").click();
+    await expect(page.getByTestId("chat-panel")).toBeVisible({ timeout: 5_000 });
 
     // Messages should still be there from localStorage
-    await expect(page.locator('[data-testid="msg-user"]').first()).toContainText("Persisted message");
-    await expect(page.locator('[data-testid="msg-assistant"]').first()).toContainText("I remember you");
+    await expect(page.getByTestId("msg-user").first()).toContainText("Persisted message");
+    await expect(page.getByTestId("msg-assistant").first()).toContainText("I remember you");
   });
 });

--- a/packages/sema-web/e2e/dev-server/multi-file.spec.ts
+++ b/packages/sema-web/e2e/dev-server/multi-file.spec.ts
@@ -42,6 +42,8 @@ test("runs a multi-file app (import resolves via the built .vfs)", async ({ page
   expect(initError, "SemaWeb.init() should not error").toBeFalsy();
 
   // The imported module's export rendered — the `import` resolved in the browser.
+  // #app / #__sema-error come from crates/sema/src/web/shell.html (the `sema web`
+  // dev-server template), outside packages/sema-web — no data-testid to add here.
   await expect(page.locator("#app")).toHaveText("Imported module works");
   // No error overlay.
   await expect(page.locator("#__sema-error")).toHaveCount(0);

--- a/packages/sema-web/e2e/dev-server/render.spec.ts
+++ b/packages/sema-web/e2e/dev-server/render.spec.ts
@@ -38,6 +38,9 @@ test("renders and runs the app in the browser", async ({ page }) => {
 
   // The app's Sema source rendered its DOM.
   await expect(page.getByRole("heading", { name: "Sema Counter" })).toBeVisible();
+  // #app comes from crates/sema/src/web/shell.html (the `sema web` dev-server
+  // template); the app source itself is examples/web/counter.sema — both are
+  // outside packages/sema-web, so there's no data-testid to add here.
   await expect(page.locator("#app")).toContainText("0");
 
   // Event handlers work end-to-end: clicking + runs Sema, updates the DOM.

--- a/packages/sema-web/e2e/fixtures/basic.html
+++ b/packages/sema-web/e2e/fixtures/basic.html
@@ -2,7 +2,7 @@
 <html>
 <head><title>Basic Test</title></head>
 <body>
-<div id="app"></div>
+<div id="app" data-testid="app"></div>
 <script type="text/sema">
 (dom/set-text! (dom/query "#app") "Hello from Sema!")
 </script>

--- a/packages/sema-web/e2e/fixtures/no-autoload.html
+++ b/packages/sema-web/e2e/fixtures/no-autoload.html
@@ -2,7 +2,7 @@
 <html>
 <head><title>No Autoload Test</title></head>
 <body>
-<div id="app">untouched</div>
+<div id="app" data-testid="app">untouched</div>
 <script type="text/sema">
 (dom/set-text! (dom/query "#app") "This should NOT run")
 </script>

--- a/packages/sema-web/e2e/fixtures/scripts/chat.sema
+++ b/packages/sema-web/e2e/fixtures/scripts/chat.sema
@@ -19,7 +19,8 @@
           (put! current-stream s))))))
 
 (define (format-message msg)
-  [:div {:class (string-append "message " (get msg :role))}
+  [:div {:class (string-append "message " (get msg :role))
+         :data-testid (if (equal? (get msg :role) "user") "msg-user" "msg-assistant")}
     [:strong (string-append (get msg :role) ": ")]
     [:span (get msg :content)]])
 
@@ -34,14 +35,14 @@
               (fn (msgs) (append msgs (list {:role "assistant" :content (get val :text)})))))
           (put! current-stream nil)
           [:span])
-        [:div {:class "message assistant streaming"}
+        [:div {:class "message assistant streaming" :data-testid "streaming-msg"}
           [:strong "assistant: "]
           [:span (get val :text)]]))
     [:span]))
 
 (define (chat-view)
-  [:div {:class "chat-container"}
-    [:h2 "Sema AI Chat"]
+  [:div {:class "chat-container" :data-testid "chat-container"}
+    [:h2 {:data-testid "chat-title"} "Sema AI Chat"]
     [:div {:class "messages" :id "message-list"}
       (map format-message @messages)
       (render-stream-status)]
@@ -51,7 +52,8 @@
                :placeholder "Ask something..."
                :value @input-text
                :on-input "update-input"
-               :autocomplete "off"}]
-      [:button {:type "submit"} "Send"]]])
+               :autocomplete "off"
+               :data-testid "chat-input"}]
+      [:button {:type "submit" :data-testid "send-btn"} "Send"]]])
 
 (mount! "#app" chat-view)

--- a/packages/sema-web/e2e/fixtures/scripts/counter.sema
+++ b/packages/sema-web/e2e/fixtures/scripts/counter.sema
@@ -6,9 +6,9 @@
 
 (defcomponent counter-view ()
   [:div
-    [:p {:id "count-display"} (number->string @count)]
-    [:button {:id "btn-inc" :on-click "handle-inc"} "+"]
-    [:button {:id "btn-dec" :on-click "handle-dec"} "-"]
-    [:button {:id "btn-reset" :on-click "handle-reset"} "Reset"]])
+    [:p {:id "count-display" :data-testid "count-display"} (number->string @count)]
+    [:button {:id "btn-inc" :on-click "handle-inc" :data-testid "btn-inc"} "+"]
+    [:button {:id "btn-dec" :on-click "handle-dec" :data-testid "btn-dec"} "-"]
+    [:button {:id "btn-reset" :on-click "handle-reset" :data-testid "btn-reset"} "Reset"]])
 
 (mount! "#app" "counter-view")

--- a/packages/sema-web/e2e/fixtures/scripts/error-component.sema
+++ b/packages/sema-web/e2e/fixtures/scripts/error-component.sema
@@ -3,6 +3,6 @@
 (define (maybe-error-view)
   (if @should-error
     (error "intentional render error")
-    [:p {:id "content"} "OK"]))
+    [:p {:id "content" :data-testid "content"} "OK"]))
 
 (mount! "#app" "maybe-error-view")

--- a/packages/sema-web/e2e/fixtures/scripts/focus.sema
+++ b/packages/sema-web/e2e/fixtures/scripts/focus.sema
@@ -6,9 +6,9 @@
 
 (define (focus-view)
   [:div
-    [:input {:id "text-input" :value @label :on-input "update-label"}]
+    [:input {:id "text-input" :value @label :on-input "update-label" :data-testid "text-input"}]
     [:p {:id "label-display"} @label]
-    [:button {:id "btn-bump" :on-click "bump"} "Bump counter"]
-    [:p {:id "counter-display"} (number->string @counter)]])
+    [:button {:id "btn-bump" :on-click "bump" :data-testid "btn-bump"} "Bump counter"]
+    [:p {:id "counter-display" :data-testid "counter-display"} (number->string @counter)]])
 
 (mount! "#app" "focus-view")

--- a/packages/sema-web/e2e/fixtures/scripts/mounted-sip-errors.sema
+++ b/packages/sema-web/e2e/fixtures/scripts/mounted-sip-errors.sema
@@ -6,13 +6,13 @@
 
 (defcomponent mounted-sip-errors-view ()
   [:div
-    [:span {:id "before"} "before"]
+    [:span {:id "before" :data-testid "before"} "before"]
     (if (equal? @mode "bad-tag")
       ["bad tag" "broken"]
-      [:span {:id "middle"} "ok"])
+      [:span {:id "middle" :data-testid "middle"} "ok"])
     (if (equal? @mode "bad-attr")
-      [:button {"bad attr name" "x" :id "after" :on-click "inc"} "after"]
-      [:button {:id "after" :on-click "inc"} "after"])
-    [:span {:id "clicks"} (number->string @clicks)]])
+      [:button {"bad attr name" "x" :id "after" :on-click "inc" :data-testid "after"} "after"]
+      [:button {:id "after" :on-click "inc" :data-testid "after"} "after"])
+    [:span {:id "clicks" :data-testid "clicks"} (number->string @clicks)]])
 
 (mount! "#app" "mounted-sip-errors-view")

--- a/packages/sema-web/e2e/fixtures/scripts/svg-component.sema
+++ b/packages/sema-web/e2e/fixtures/scripts/svg-component.sema
@@ -5,12 +5,12 @@
 
 (defcomponent svg-view ()
   [:div
-    ["svg" {:id "icon" "viewBox" "0 0 10 10" :on-click "toggle"}
+    ["svg" {:id "icon" "viewBox" "0 0 10 10" :on-click "toggle" :data-testid "icon"}
       ["defs"
         ["circle" {:id "dot" :cx "5" :cy "5" :r "4"}]]
       ["use" {:id "use-dot" "xlink:href" "#dot"}]
       ["foreignObject" {:x "0" :y "0" :width "10" :height "10"}
         [:div {:id "html-inside"} "html"]]]
-    [:span {:id "toggle-state"} (if @toggled "on" "off")]])
+    [:span {:id "toggle-state" :data-testid "toggle-state"} (if @toggled "on" "off")]])
 
 (mount! "#app" "svg-view")

--- a/packages/sema-web/e2e/tests/archive-loading.spec.ts
+++ b/packages/sema-web/e2e/tests/archive-loading.spec.ts
@@ -58,6 +58,8 @@ test.afterAll(() => {
 test("built .vfs archives load and execute in the browser", async ({ page }) => {
   await page.goto("/archive-basic.html");
   await waitForSema(page);
+  // #app comes from crates/sema/src/web/shell.html (the dev-server template),
+  // outside packages/sema-web — no data-testid to add here.
   await expect(page.locator("#app")).toHaveText("Hello from compiled Sema!");
 });
 
@@ -65,17 +67,17 @@ test("built .vfs archives support defcomponent and mount!", async ({ page }) => 
   await page.goto("/archive-counter.html");
   await waitForSema(page);
 
-  const display = page.locator("#count-display");
+  const display = page.getByTestId("count-display");
   await expect(display).toHaveText("0");
 
-  await page.click("#btn-inc");
-  await page.click("#btn-inc");
+  await page.getByTestId("btn-inc").click();
+  await page.getByTestId("btn-inc").click();
   await expect(display).toHaveText("2");
 
-  await page.click("#btn-dec");
+  await page.getByTestId("btn-dec").click();
   await expect(display).toHaveText("1");
 
-  await page.click("#btn-reset");
+  await page.getByTestId("btn-reset").click();
   await expect(display).toHaveText("0");
 });
 

--- a/packages/sema-web/e2e/tests/error-recovery.spec.ts
+++ b/packages/sema-web/e2e/tests/error-recovery.spec.ts
@@ -7,7 +7,7 @@ test("component recovers after render error", async ({ page }) => {
   await waitForSema(page);
 
   // Initially renders OK
-  await expect(page.locator("#content")).toHaveText("OK");
+  await expect(page.getByTestId("content")).toHaveText("OK");
 
   // Trigger an error in the render function
   await semaEval(page, "(put! should-error true)");
@@ -23,5 +23,5 @@ test("component recovers after render error", async ({ page }) => {
   await semaEval(page, "(put! should-error false)");
 
   // Should render OK again
-  await expect(page.locator("#content")).toHaveText("OK");
+  await expect(page.getByTestId("content")).toHaveText("OK");
 });

--- a/packages/sema-web/e2e/tests/focus-preservation.spec.ts
+++ b/packages/sema-web/e2e/tests/focus-preservation.spec.ts
@@ -5,7 +5,7 @@ test("input retains focus and value after unrelated state change", async ({ page
   await page.goto("/focus.html");
   await waitForSema(page);
 
-  const input = page.locator("#text-input");
+  const input = page.getByTestId("text-input");
   await input.click();
   await input.fill("hello");
 
@@ -25,5 +25,5 @@ test("input retains focus and value after unrelated state change", async ({ page
   await expect(input).toHaveValue("hello");
 
   // Counter should have updated
-  await expect(page.locator("#counter-display")).toHaveText("1");
+  await expect(page.getByTestId("counter-display")).toHaveText("1");
 });

--- a/packages/sema-web/e2e/tests/mounted-sip-errors.spec.ts
+++ b/packages/sema-web/e2e/tests/mounted-sip-errors.spec.ts
@@ -6,22 +6,22 @@ test("malformed SIP inside a mounted component keeps siblings interactive", asyn
   await page.goto("/mounted-sip-errors.html");
   await waitForSema(page);
 
-  await expect(page.locator("#before")).toHaveText("before");
-  await expect(page.locator("#middle")).toHaveText("ok");
-  await expect(page.locator("#after")).toHaveText("after");
+  await expect(page.getByTestId("before")).toHaveText("before");
+  await expect(page.getByTestId("middle")).toHaveText("ok");
+  await expect(page.getByTestId("after")).toHaveText("after");
 
   await semaEval(page, '(put! mode "bad-tag")');
-  await expect(page.locator("#before")).toHaveText("before");
-  await expect(page.locator("#middle")).toHaveCount(0);
-  await expect(page.locator("#after")).toHaveText("after");
+  await expect(page.getByTestId("before")).toHaveText("before");
+  await expect(page.getByTestId("middle")).toHaveCount(0);
+  await expect(page.getByTestId("after")).toHaveText("after");
 
-  await page.click("#after");
-  await expect(page.locator("#clicks")).toHaveText("1");
+  await page.getByTestId("after").click();
+  await expect(page.getByTestId("clicks")).toHaveText("1");
   expect(failures.consoleErrors.some((msg) => msg.includes("sip-render:invalid-tag:bad tag"))).toBe(true);
   expect(failures.pageErrors).toEqual([]);
 
   await semaEval(page, '(put! mode "ok")');
-  await expect(page.locator("#middle")).toHaveText("ok");
+  await expect(page.getByTestId("middle")).toHaveText("ok");
 });
 
 test("malformed SIP attributes are skipped without disabling sibling attrs or events", async ({ page }) => {
@@ -30,9 +30,9 @@ test("malformed SIP attributes are skipped without disabling sibling attrs or ev
   await waitForSema(page);
 
   await semaEval(page, '(put! mode "bad-attr")');
-  await expect(page.locator("#after")).toHaveText("after");
-  await page.click("#after");
-  await expect(page.locator("#clicks")).toHaveText("1");
+  await expect(page.getByTestId("after")).toHaveText("after");
+  await page.getByTestId("after").click();
+  await expect(page.getByTestId("clicks")).toHaveText("1");
 
   expect(failures.consoleErrors.some((msg) => msg.includes("sip-render:attribute:bad attr name"))).toBe(true);
   expect(failures.pageErrors).toEqual([]);

--- a/packages/sema-web/e2e/tests/multi-instance.spec.ts
+++ b/packages/sema-web/e2e/tests/multi-instance.spec.ts
@@ -11,7 +11,7 @@ test("multiple SemaWeb instances are isolated", async ({ page }) => {
     webA.eval('(def count-a (state 0))');
     webA.eval(`
       (define (counter-a-view)
-        [:p {:id "count-a"} (number->string @count-a)])
+        [:p {:id "count-a" :data-testid "count-a"} (number->string @count-a)])
     `);
     webA.eval('(mount! "#app-a" "counter-a-view")');
   });
@@ -22,14 +22,14 @@ test("multiple SemaWeb instances are isolated", async ({ page }) => {
     webB.eval('(def count-b (state 0))');
     webB.eval(`
       (define (counter-b-view)
-        [:p {:id "count-b"} (number->string @count-b)])
+        [:p {:id "count-b" :data-testid "count-b"} (number->string @count-b)])
     `);
     webB.eval('(mount! "#app-b" "counter-b-view")');
   });
 
   // Both start at 0
-  await expect(page.locator("#count-a")).toHaveText("0");
-  await expect(page.locator("#count-b")).toHaveText("0");
+  await expect(page.getByTestId("count-a")).toHaveText("0");
+  await expect(page.getByTestId("count-b")).toHaveText("0");
 
   // Increment only instance A
   await page.evaluate(() => {
@@ -37,6 +37,6 @@ test("multiple SemaWeb instances are isolated", async ({ page }) => {
   });
 
   // A shows 1, B still shows 0
-  await expect(page.locator("#count-a")).toHaveText("1");
-  await expect(page.locator("#count-b")).toHaveText("0");
+  await expect(page.getByTestId("count-a")).toHaveText("1");
+  await expect(page.getByTestId("count-b")).toHaveText("0");
 });

--- a/packages/sema-web/e2e/tests/no-autoload.spec.ts
+++ b/packages/sema-web/e2e/tests/no-autoload.spec.ts
@@ -6,5 +6,5 @@ test("autoLoad: false prevents script tags from executing", async ({ page }) => 
   await waitForSema(page);
 
   // The inline sema script should NOT have run
-  await expect(page.locator("#app")).toHaveText("untouched");
+  await expect(page.getByTestId("app")).toHaveText("untouched");
 });

--- a/packages/sema-web/e2e/tests/reactive-counter.spec.ts
+++ b/packages/sema-web/e2e/tests/reactive-counter.spec.ts
@@ -5,20 +5,20 @@ test("reactive counter increments, decrements, and resets", async ({ page }) => 
   await page.goto("/counter.html");
   await waitForSema(page);
 
-  const display = page.locator("#count-display");
+  const display = page.getByTestId("count-display");
   await expect(display).toHaveText("0");
 
   // Increment three times
-  await page.click("#btn-inc");
-  await page.click("#btn-inc");
-  await page.click("#btn-inc");
+  await page.getByTestId("btn-inc").click();
+  await page.getByTestId("btn-inc").click();
+  await page.getByTestId("btn-inc").click();
   await expect(display).toHaveText("3");
 
   // Decrement once
-  await page.click("#btn-dec");
+  await page.getByTestId("btn-dec").click();
   await expect(display).toHaveText("2");
 
   // Reset
-  await page.click("#btn-reset");
+  await page.getByTestId("btn-reset").click();
   await expect(display).toHaveText("0");
 });

--- a/packages/sema-web/e2e/tests/script-loading.spec.ts
+++ b/packages/sema-web/e2e/tests/script-loading.spec.ts
@@ -4,5 +4,5 @@ import { waitForSema } from "../helpers";
 test("inline sema script sets text content", async ({ page }) => {
   await page.goto("/basic.html");
   await waitForSema(page);
-  await expect(page.locator("#app")).toHaveText("Hello from Sema!");
+  await expect(page.getByTestId("app")).toHaveText("Hello from Sema!");
 });

--- a/packages/sema-web/e2e/tests/svg-component.spec.ts
+++ b/packages/sema-web/e2e/tests/svg-component.spec.ts
@@ -22,7 +22,7 @@ test("mounted SVG SIP uses real namespaces and delegated events in Chromium", as
     htmlInside: "http://www.w3.org/1999/xhtml",
   });
 
-  await expect(page.locator("#toggle-state")).toHaveText("off");
-  await page.click("#icon");
-  await expect(page.locator("#toggle-state")).toHaveText("on");
+  await expect(page.getByTestId("toggle-state")).toHaveText("off");
+  await page.getByTestId("icon").click();
+  await expect(page.getByTestId("toggle-state")).toHaveText("on");
 });

--- a/packages/sema-web/e2e/tests/web-demo-board.spec.ts
+++ b/packages/sema-web/e2e/tests/web-demo-board.spec.ts
@@ -16,35 +16,35 @@ test.describe("Board demo — core board rendering and manual interactions", () 
     await page.goto("/board.html");
     await waitForSema(page);
 
-    await expect(page.locator('[data-testid="board-header"]')).toBeVisible();
-    await expect(page.locator('[data-testid="column-todo"]')).toBeVisible();
-    await expect(page.locator('[data-testid="column-in-progress"]')).toBeVisible();
-    await expect(page.locator('[data-testid="column-done"]')).toBeVisible();
+    await expect(page.getByTestId("board-header")).toBeVisible();
+    await expect(page.getByTestId("column-todo")).toBeVisible();
+    await expect(page.getByTestId("column-in-progress")).toBeVisible();
+    await expect(page.getByTestId("column-done")).toBeVisible();
 
     // Seed data: 3 todo, 2 in-progress, 1 done (see make-seed-data in board.sema)
-    await expect(page.locator('[data-testid="count-todo"]')).toHaveText("3");
-    await expect(page.locator('[data-testid="count-in-progress"]')).toHaveText("2");
-    await expect(page.locator('[data-testid="count-done"]')).toHaveText("1");
+    await expect(page.getByTestId("count-todo")).toHaveText("3");
+    await expect(page.getByTestId("count-in-progress")).toHaveText("2");
+    await expect(page.getByTestId("count-done")).toHaveText("1");
 
-    await expect(page.locator('[data-testid="progress-text"]')).toContainText("1/6");
-    await expect(page.locator('[data-testid="board-card"]')).toHaveCount(6);
+    await expect(page.getByTestId("progress-text")).toContainText("1/6");
+    await expect(page.getByTestId("board-card")).toHaveCount(6);
   });
 
   test("manual card creation via the add-card form", async ({ page }) => {
     await page.goto("/board.html");
     await waitForSema(page);
 
-    await page.click('[data-testid="add-card-todo"]');
-    await expect(page.locator('[data-testid="add-card-form"]')).toBeVisible();
+    await page.getByTestId("add-card-todo").click();
+    await expect(page.getByTestId("add-card-form")).toBeVisible();
 
-    await page.fill('[data-testid="add-card-input"]', "Ship the release notes");
-    await page.click('[data-testid="submit-add-card"]');
+    await page.getByTestId("add-card-input").fill("Ship the release notes");
+    await page.getByTestId("submit-add-card").click();
 
     // Form closes and the new card appears in the todo column
-    await expect(page.locator('[data-testid="add-card-form"]')).toHaveCount(0);
-    await expect(page.locator('[data-testid="count-todo"]')).toHaveText("4");
+    await expect(page.getByTestId("add-card-form")).toHaveCount(0);
+    await expect(page.getByTestId("count-todo")).toHaveText("4");
     await expect(
-      page.locator('[data-testid="column-todo"] [data-testid="card-title"]', {
+      page.getByTestId("column-todo").getByTestId("card-title").filter({
         hasText: "Ship the release notes",
       }),
     ).toBeVisible();
@@ -55,17 +55,17 @@ test.describe("Board demo — core board rendering and manual interactions", () 
     await waitForSema(page);
 
     // "Implement user authentication" is seeded in the in-progress column
-    const card = page.locator('[data-testid="board-card"]', {
+    const card = page.getByTestId("board-card").filter({
       hasText: "Implement user authentication",
     });
     await expect(card).toBeVisible();
 
-    await card.locator('[data-testid="move-right-btn"]').click();
+    await card.getByTestId("move-right-btn").click();
 
-    await expect(page.locator('[data-testid="count-in-progress"]')).toHaveText("1");
-    await expect(page.locator('[data-testid="count-done"]')).toHaveText("2");
+    await expect(page.getByTestId("count-in-progress")).toHaveText("1");
+    await expect(page.getByTestId("count-done")).toHaveText("2");
     await expect(
-      page.locator('[data-testid="column-done"] [data-testid="board-card"]', {
+      page.getByTestId("column-done").getByTestId("board-card").filter({
         hasText: "Implement user authentication",
       }),
     ).toBeVisible();
@@ -75,18 +75,18 @@ test.describe("Board demo — core board rendering and manual interactions", () 
     await page.goto("/board.html");
     await waitForSema(page);
 
-    const card = page.locator('[data-testid="board-card"]', { hasText: "Write API documentation" });
+    const card = page.getByTestId("board-card").filter({ hasText: "Write API documentation" });
     await card.click();
 
-    const modal = page.locator('[data-testid="card-modal"]');
+    const modal = page.getByTestId("card-modal");
     await expect(modal).toBeVisible();
-    await expect(page.locator('[data-testid="modal-title"]')).toHaveText("Write API documentation");
+    await expect(page.getByTestId("modal-title")).toHaveText("Write API documentation");
 
     // Seeded priority is "medium" -> cycles to "high"
-    await page.click('[data-testid="cycle-priority"]');
-    await expect(modal.locator('[data-testid="priority-badge"]')).toHaveText("high");
+    await page.getByTestId("cycle-priority").click();
+    await expect(modal.getByTestId("priority-badge")).toHaveText("high");
 
-    await page.click('[data-testid="modal-close"]');
+    await page.getByTestId("modal-close").click();
     await expect(modal).toHaveCount(0);
   });
 });
@@ -96,25 +96,26 @@ test.describe("Board demo — AI task generation (mocked LLM stream)", () => {
     await page.goto("/board.html");
     await waitForSema(page);
 
-    await expect(page.locator('[data-testid="board-card"]')).toHaveCount(6);
+    await expect(page.getByTestId("board-card")).toHaveCount(6);
 
-    await page.click('[data-testid="ai-generate-btn"]');
+    await page.getByTestId("ai-generate-btn").click();
 
     // Button flips to a disabled "Generating..." state while the stream is open
-    await expect(page.locator('[data-testid="ai-generate-btn"]')).toHaveText("Generating...");
+    await expect(page.getByTestId("ai-generate-btn")).toHaveText("Generating...");
 
     // The mock proxy recognizes the board's task-generation prompt and streams
     // back a canned JSON array of 3 tasks; board.sema decodes it via its
     // poll-ai-stream interval and appends AI-tagged cards to the "todo" column.
-    await expect(page.locator('[data-testid="ai-badge"]')).toHaveCount(3, { timeout: 10_000 });
-    await expect(page.locator('[data-testid="board-card"]')).toHaveCount(9);
+    await expect(page.getByTestId("ai-badge")).toHaveCount(3, { timeout: 10_000 });
+    await expect(page.getByTestId("board-card")).toHaveCount(9);
 
     // Button reverts once generation completes
-    await expect(page.locator('[data-testid="ai-generate-btn"]')).toHaveText("✨ AI Generate");
+    await expect(page.getByTestId("ai-generate-btn")).toHaveText("✨ AI Generate");
 
     const aiTitles = await page
-      .locator('[data-testid="board-card"]', { has: page.locator('[data-testid="ai-badge"]') })
-      .locator('[data-testid="card-title"]')
+      .getByTestId("board-card")
+      .filter({ has: page.getByTestId("ai-badge") })
+      .getByTestId("card-title")
       .allTextContents();
     expect(aiTitles).toEqual([
       "Set up staging environment",

--- a/packages/sema-web/e2e/tests/web-demo-chat-widget.spec.ts
+++ b/packages/sema-web/e2e/tests/web-demo-chat-widget.spec.ts
@@ -13,26 +13,28 @@ test.describe("Chat widget demo — mocked SSE streaming", () => {
     await page.goto("/chat-widget.html");
     await waitForSema(page);
 
-    await expect(page.locator('[data-testid="chat-fab"]')).toBeVisible();
-    await expect(page.locator('[data-testid="chat-panel"]')).toHaveCount(0);
+    await expect(page.getByTestId("chat-fab")).toBeVisible();
+    await expect(page.getByTestId("chat-panel")).toHaveCount(0);
 
-    await page.click('[data-testid="chat-fab"]');
-    await expect(page.locator('[data-testid="chat-panel"]')).toBeVisible();
+    await page.getByTestId("chat-fab").click();
+    await expect(page.getByTestId("chat-panel")).toBeVisible();
 
-    await page.click('[data-testid="close-btn"]');
-    await expect(page.locator('[data-testid="chat-panel"]')).toHaveCount(0);
+    await page.getByTestId("close-btn").click();
+    await expect(page.getByTestId("chat-panel")).toHaveCount(0);
   });
 
   test("sending a message shows a typing indicator, streams incrementally, then lands in the transcript", async ({ page }) => {
     await page.goto("/chat-widget.html");
     await waitForSema(page);
 
-    await page.click('[data-testid="chat-fab"]');
-    await expect(page.locator('[data-testid="chat-panel"]')).toBeVisible();
+    await page.getByTestId("chat-fab").click();
+    await expect(page.getByTestId("chat-panel")).toBeVisible();
 
     // Track the streaming bubble's shape over time: it starts as a
     // typing-indicator (no text yet), then flips to a growing streaming-msg
     // once the first token arrives.
+    // NOTE: runs inside the page's own JS context via page.evaluate(), so it
+    // uses document.querySelector directly rather than a Playwright locator.
     await page.evaluate(() => {
       (window as any).__states = [];
       const container = document.querySelector("#widget-msg-list")!;
@@ -48,19 +50,19 @@ test.describe("Chat widget demo — mocked SSE streaming", () => {
       obs.observe(container, { childList: true, subtree: true, characterData: true });
     });
 
-    await page.fill('[data-testid="chat-input"]', "Hi widget");
-    await page.click('[data-testid="send-btn"]');
+    await page.getByTestId("chat-input").fill("Hi widget");
+    await page.getByTestId("send-btn").click();
 
-    await expect(page.locator('[data-testid="msg-user"]')).toHaveText("Hi widget");
-    await expect(page.locator('[data-testid="chat-input"]')).toHaveValue("");
+    await expect(page.getByTestId("msg-user")).toHaveText("Hi widget");
+    await expect(page.getByTestId("chat-input")).toHaveValue("");
 
     const finalText = "Mock reply to: Hi widget";
 
-    await expect(page.locator('[data-testid="msg-assistant"]')).toHaveText(finalText, {
+    await expect(page.getByTestId("msg-assistant")).toHaveText(finalText, {
       timeout: 5_000,
     });
-    await expect(page.locator('[data-testid="streaming-msg"]')).toHaveCount(0);
-    await expect(page.locator('[data-testid="typing-indicator"]')).toHaveCount(0);
+    await expect(page.getByTestId("streaming-msg")).toHaveCount(0);
+    await expect(page.getByTestId("typing-indicator")).toHaveCount(0);
 
     const states: string[] = await page.evaluate(() => (window as any).__states);
     // Must have seen the typing indicator before any streamed text appeared.
@@ -77,21 +79,21 @@ test.describe("Chat widget demo — mocked SSE streaming", () => {
     await page.goto("/chat-widget.html");
     await waitForSema(page);
 
-    await page.click('[data-testid="chat-fab"]');
-    await page.fill('[data-testid="chat-input"]', "Remember this");
-    await page.click('[data-testid="send-btn"]');
+    await page.getByTestId("chat-fab").click();
+    await page.getByTestId("chat-input").fill("Remember this");
+    await page.getByTestId("send-btn").click();
 
-    await expect(page.locator('[data-testid="msg-assistant"]')).toHaveText(
+    await expect(page.getByTestId("msg-assistant")).toHaveText(
       "Mock reply to: Remember this",
       { timeout: 5_000 },
     );
 
     await page.reload();
     await waitForSema(page);
-    await page.click('[data-testid="chat-fab"]');
+    await page.getByTestId("chat-fab").click();
 
-    await expect(page.locator('[data-testid="msg-user"]')).toHaveText("Remember this");
-    await expect(page.locator('[data-testid="msg-assistant"]')).toHaveText(
+    await expect(page.getByTestId("msg-user")).toHaveText("Remember this");
+    await expect(page.getByTestId("msg-assistant")).toHaveText(
       "Mock reply to: Remember this",
     );
   });

--- a/packages/sema-web/e2e/tests/web-demo-chat.spec.ts
+++ b/packages/sema-web/e2e/tests/web-demo-chat.spec.ts
@@ -14,10 +14,10 @@ test.describe("Chat demo — mocked SSE streaming", () => {
     await page.goto("/chat.html");
     await waitForSema(page);
 
-    await expect(page.locator(".chat-container")).toBeVisible();
-    await expect(page.locator("h2")).toHaveText("Sema AI Chat");
-    await expect(page.locator("#chat-input")).toBeVisible();
-    await expect(page.locator('button[type="submit"]')).toHaveText("Send");
+    await expect(page.getByTestId("chat-container")).toBeVisible();
+    await expect(page.getByTestId("chat-title")).toHaveText("Sema AI Chat");
+    await expect(page.getByTestId("chat-input")).toBeVisible();
+    await expect(page.getByTestId("send-btn")).toHaveText("Send");
   });
 
   test("sending a message streams the mocked reply incrementally, then lands in the transcript", async ({ page }) => {
@@ -27,11 +27,13 @@ test.describe("Chat demo — mocked SSE streaming", () => {
     // Record every distinct textContent the streaming bubble passes through
     // via MutationObserver — this observes every DOM patch morphdom makes,
     // so it can't miss an intermediate frame the way a polled assertion could.
+    // NOTE: runs inside the page's own JS context via page.evaluate(), so it
+    // uses document.querySelector directly rather than a Playwright locator.
     await page.evaluate(() => {
       (window as any).__streamStates = [];
       const container = document.querySelector("#message-list")!;
       const obs = new MutationObserver(() => {
-        const el = document.querySelector(".message.assistant.streaming");
+        const el = document.querySelector('[data-testid="streaming-msg"]');
         if (el) {
           const states = (window as any).__streamStates as string[];
           const text = el.textContent ?? "";
@@ -41,23 +43,23 @@ test.describe("Chat demo — mocked SSE streaming", () => {
       obs.observe(container, { childList: true, subtree: true, characterData: true });
     });
 
-    await page.fill("#chat-input", "Hello there");
-    await page.click('button[type="submit"]');
+    await page.getByTestId("chat-input").fill("Hello there");
+    await page.getByTestId("send-btn").click();
 
     // User message appears immediately, input clears
-    await expect(page.locator(".message.user")).toHaveText("user: Hello there");
-    await expect(page.locator("#chat-input")).toHaveValue("");
+    await expect(page.getByTestId("msg-user")).toHaveText("user: Hello there");
+    await expect(page.getByTestId("chat-input")).toHaveValue("");
 
     const finalText = "Mock reply to: Hello there";
 
     // Eventually the stream completes and the reply moves into the static
     // transcript as a plain (non-streaming) assistant message.
-    await expect(page.locator(".message.assistant")).toHaveText(`assistant: ${finalText}`, {
+    await expect(page.getByTestId("msg-assistant")).toHaveText(`assistant: ${finalText}`, {
       timeout: 5_000,
     });
-    await expect(page.locator(".message.assistant.streaming")).toHaveCount(0);
-    await expect(page.locator(".message.user")).toHaveCount(1);
-    await expect(page.locator(".message.assistant")).toHaveCount(1);
+    await expect(page.getByTestId("streaming-msg")).toHaveCount(0);
+    await expect(page.getByTestId("msg-user")).toHaveCount(1);
+    await expect(page.getByTestId("msg-assistant")).toHaveCount(1);
 
     // The observer must have recorded multiple distinct, growing text states —
     // proof the bubble filled in token-by-token rather than appearing whole.

--- a/playground/index.html
+++ b/playground/index.html
@@ -68,11 +68,11 @@
           <sema-button variant="secondary" size="sm" id="debug-btn" data-testid="debug-btn" disabled>Debug</sema-button>
         </sema-tooltip>
         <div class="debug-controls hidden" id="debug-controls" data-testid="debug-controls">
-          <sema-tooltip content="Continue (F5)" placement="bottom"><sema-button variant="debug" id="dbg-continue" aria-label="Continue">▶</sema-button></sema-tooltip>
-          <sema-tooltip content="Step Over (F10)" placement="bottom"><sema-button variant="debug" id="dbg-step-over" aria-label="Step Over">⏭</sema-button></sema-tooltip>
-          <sema-tooltip content="Step Into (F11)" placement="bottom"><sema-button variant="debug" id="dbg-step-into" aria-label="Step Into">↓</sema-button></sema-tooltip>
-          <sema-tooltip content="Step Out (⇧F11)" placement="bottom"><sema-button variant="debug" id="dbg-step-out" aria-label="Step Out">↑</sema-button></sema-tooltip>
-          <sema-tooltip content="Stop (Esc)" placement="bottom"><sema-button variant="debug" danger id="dbg-stop" aria-label="Stop">⬛</sema-button></sema-tooltip>
+          <sema-tooltip content="Continue (F5)" placement="bottom"><sema-button variant="debug" id="dbg-continue" data-testid="dbg-continue" aria-label="Continue">▶</sema-button></sema-tooltip>
+          <sema-tooltip content="Step Over (F10)" placement="bottom"><sema-button variant="debug" id="dbg-step-over" data-testid="dbg-step-over" aria-label="Step Over">⏭</sema-button></sema-tooltip>
+          <sema-tooltip content="Step Into (F11)" placement="bottom"><sema-button variant="debug" id="dbg-step-into" data-testid="dbg-step-into" aria-label="Step Into">↓</sema-button></sema-tooltip>
+          <sema-tooltip content="Step Out (⇧F11)" placement="bottom"><sema-button variant="debug" id="dbg-step-out" data-testid="dbg-step-out" aria-label="Step Out">↑</sema-button></sema-tooltip>
+          <sema-tooltip content="Stop (Esc)" placement="bottom"><sema-button variant="debug" danger id="dbg-stop" data-testid="dbg-stop" aria-label="Stop">⬛</sema-button></sema-tooltip>
         </div>
       </div>
     </div>

--- a/playground/src/app.js
+++ b/playground/src/app.js
@@ -379,6 +379,7 @@ async function main() {
       setWorkerOutputHandler((line) => {
         const div = document.createElement('div');
         div.className = 'output-line';
+        div.setAttribute('data-testid', 'output-line');
         div.textContent = line;
         outputEl.appendChild(div);
         outputEl.scrollTop = outputEl.scrollHeight;
@@ -481,6 +482,7 @@ async function run() {
       for (const line of result.output) {
         const div = document.createElement('div');
         div.className = 'output-line';
+        div.setAttribute('data-testid', 'output-line');
         div.textContent = line;
         outputEl.appendChild(div);
       }
@@ -490,11 +492,13 @@ async function run() {
   if (result.error) {
     const div = document.createElement('div');
     div.className = 'output-error';
+    div.setAttribute('data-testid', 'output-error');
     div.textContent = result.error;
     outputEl.appendChild(div);
   } else if (result.value !== null) {
     const div = document.createElement('div');
     div.className = 'output-value';
+    div.setAttribute('data-testid', 'output-value');
     div.textContent = `=> ${result.value}`;
     outputEl.appendChild(div);
   }
@@ -539,6 +543,7 @@ document.getElementById('fmt-btn').addEventListener('click', () => {
     outputEl.innerHTML = '';
     const div = document.createElement('div');
     div.className = 'output-error';
+    div.setAttribute('data-testid', 'output-error');
     div.textContent = `Format error: ${result.error}`;
     outputEl.appendChild(div);
   } else if (result.formatted !== null) {
@@ -695,6 +700,7 @@ function handleDebugResult(result) {
     for (const line of result.output) {
       const div = document.createElement('div');
       div.className = 'output-line';
+      div.setAttribute('data-testid', 'output-line');
       div.textContent = line;
       outputEl.appendChild(div);
     }
@@ -725,6 +731,7 @@ function handleDebugResult(result) {
     if (result.value !== null && result.value !== undefined) {
       const div = document.createElement('div');
       div.className = 'output-value';
+      div.setAttribute('data-testid', 'output-value');
       div.textContent = `=> ${result.value}`;
       outputEl.appendChild(div);
     }
@@ -733,6 +740,7 @@ function handleDebugResult(result) {
   } else if (result.status === 'error') {
     const div = document.createElement('div');
     div.className = 'output-error';
+    div.setAttribute('data-testid', 'output-error');
     div.textContent = result.error;
     outputEl.appendChild(div);
     interp.debugStop();
@@ -771,6 +779,7 @@ async function handleDebugHttpNeeded(request) {
 function showDebugError(e) {
   const div = document.createElement('div');
   div.className = 'output-error';
+  div.setAttribute('data-testid', 'output-error');
   div.textContent = e.message || String(e);
   outputEl.appendChild(div);
   try { interp.debugStop(); } catch (_) { /* ignore */ }
@@ -793,6 +802,7 @@ function updateVariablesPanel() {
   const panel = document.createElement('div');
   panel.id = 'debug-vars';
   panel.className = 'debug-vars-panel';
+  panel.setAttribute('data-testid', 'debug-vars');
 
   const header = document.createElement('div');
   header.className = 'debug-vars-header';
@@ -802,7 +812,8 @@ function updateVariablesPanel() {
   for (const v of locals) {
     const row = document.createElement('div');
     row.className = 'debug-var-row';
-    row.innerHTML = `<span class="debug-var-name">${escapeHtml(v.name)}</span> = <span class="debug-var-value">${escapeHtml(v.value)}</span> <span class="debug-var-type">(${escapeHtml(v.type)})</span>`;
+    row.setAttribute('data-testid', 'debug-var-row');
+    row.innerHTML = `<span class="debug-var-name" data-testid="debug-var-name">${escapeHtml(v.name)}</span> = <span class="debug-var-value" data-testid="debug-var-value">${escapeHtml(v.value)}</span> <span class="debug-var-type">(${escapeHtml(v.type)})</span>`;
     panel.appendChild(row);
   }
 

--- a/playground/tests/async-debugger.spec.ts
+++ b/playground/tests/async-debugger.spec.ts
@@ -7,29 +7,34 @@ import { test, expect, Page } from '@playwright/test';
 
 async function waitForReady(page: Page) {
   await page.goto('/');
-  await page.waitForSelector('[data-testid="status"].status-ready', { timeout: 15000 });
+  await expect(page.getByTestId('status')).toHaveClass(/status-ready/, { timeout: 15000 });
 }
 
 async function setEditorCode(page: Page, code: string) {
   await page.getByTestId('editor').fill(code);
 }
 
-/** Click a gutter line number to toggle a breakpoint. */
+/** Click a gutter line number to toggle a breakpoint.
+ *  `.gutter-line` is rendered inside <sema-editor> (from @sema-lang/ui, not this
+ *  repo) with no exposed role/testid for individual line numbers — CSS nth-child
+ *  is the only way to target a specific line. */
 async function toggleBreakpoint(page: Page, lineNum: number) {
-  await page.click(`.gutter-line:nth-child(${lineNum})`);
+  await page.locator(`.gutter-line:nth-child(${lineNum})`).click();
 }
 
-/** Get the current line the debugger highlights. */
+/** Get the current line the debugger highlights.
+ *  `.gutter-line` internals come from <sema-editor> (@sema-lang/ui) — see
+ *  toggleBreakpoint for why CSS stays the fallback locator here. */
 async function getCurrentDebugLine(page: Page): Promise<number | null> {
-  const el = await page.$('.gutter-line.current-line');
-  if (!el) return null;
-  const text = await el.textContent();
+  const locator = page.locator('.gutter-line.current-line');
+  if ((await locator.count()) === 0) return null;
+  const text = await locator.textContent();
   return text ? parseInt(text, 10) : null;
 }
 
 /** Get all error output. */
 async function getErrors(page: Page): Promise<string[]> {
-  return page.$$eval('#output .output-error', els => els.map(el => el.textContent ?? ''));
+  return page.getByTestId('output-error').allTextContents();
 }
 
 /** Wait for the debugger to pause (status bar shows "Paused at line ..."). */
@@ -49,16 +54,17 @@ async function waitForIdle(page: Page, timeout = 12000) {
 }
 
 async function getStatus(page: Page): Promise<string> {
-  return await page.$eval('#status', el => el.textContent ?? '');
+  return await page.getByTestId('status').textContent() ?? '';
 }
 
 async function getOutputLines(page: Page): Promise<string[]> {
-  return page.$$eval('#output .output-line', els => els.map(el => el.textContent ?? ''));
+  return page.getByTestId('output-line').allTextContents();
 }
 
-/** Click a debug control and wait until the debugger is paused again or idle. */
-async function clickAndSettle(page: Page, selector: string) {
-  await page.click(selector);
+/** Click a debug control (by testid) and wait until the debugger is paused
+ *  again or idle. */
+async function clickAndSettle(page: Page, testId: string) {
+  await page.getByTestId(testId).click();
   await page.waitForFunction(
     () => {
       const s = document.getElementById('status')?.textContent ?? '';
@@ -68,15 +74,15 @@ async function clickAndSettle(page: Page, selector: string) {
   );
 }
 
-/** Repeatedly click `selector` (a step/continue control), recording the line at
+/** Repeatedly click `testId` (a step/continue control), recording the line at
  *  each stop, until the program goes idle or `maxSteps` is reached. */
-async function recordStops(page: Page, selector: string, maxSteps = 12): Promise<number[]> {
+async function recordStops(page: Page, testId: string, maxSteps = 12): Promise<number[]> {
   const lines: number[] = [];
   const first = await getCurrentDebugLine(page);
   if (first !== null) lines.push(first);
   for (let i = 0; i < maxSteps; i++) {
     if ((await getStatus(page)) === 'Ready') break;
-    await clickAndSettle(page, selector);
+    await clickAndSettle(page, testId);
     if ((await getStatus(page)) === 'Ready') break;
     const l = await getCurrentDebugLine(page);
     if (l !== null) lines.push(l);
@@ -89,7 +95,7 @@ async function recordStops(page: Page, selector: string, maxSteps = 12): Promise
 async function driveToIdle(page: Page, maxContinues = 25) {
   for (let i = 0; i < maxContinues; i++) {
     if ((await getStatus(page)) === 'Ready') return;
-    await clickAndSettle(page, '#dbg-continue');
+    await clickAndSettle(page, 'dbg-continue');
   }
   await waitForIdle(page);
 }
@@ -116,7 +122,7 @@ test.describe('Async debugger (cooperative WASM)', () => {
     expect(await getCurrentDebugLine(page)).toBe(2);
 
     // Continue → the task + the await must run to completion.
-    await page.click('#dbg-continue');
+    await page.getByTestId('dbg-continue').click();
     await waitForIdle(page);
 
     expect((await getErrors(page)).join('\n')).not.toContain('scheduler');
@@ -144,7 +150,7 @@ test.describe('Async debugger (cooperative WASM)', () => {
     // top-level async/all.
     expect(await getCurrentDebugLine(page)).toBe(4);
 
-    await page.click('#dbg-continue');
+    await page.getByTestId('dbg-continue').click();
     await waitForIdle(page);
 
     expect((await getErrors(page)).join('\n')).not.toContain('scheduler');
@@ -178,7 +184,7 @@ test.describe('Async debugger (cooperative WASM)', () => {
     await page.getByTestId('debug-btn').click();
     await waitForPaused(page);
 
-    const stops = await recordStops(page, '#dbg-continue');
+    const stops = await recordStops(page, 'dbg-continue');
     console.log('multi-bp Continue stops:', stops);
     // Each breakpoint is hit, in source order: main(1) → task body(4) → main(7).
     expect(stops).toEqual([1, 4, 7]);
@@ -193,7 +199,7 @@ test.describe('Async debugger (cooperative WASM)', () => {
     await page.getByTestId('debug-btn').click(); // no breakpoints → stop on entry
     await waitForPaused(page);
 
-    const lines = await recordStops(page, '#dbg-step-into');
+    const lines = await recordStops(page, 'dbg-step-into');
     console.log('step-into lines:', lines);
     // Step-into must DESCEND into add's body (which lives on line 1), so line 1 is
     // visited more than once (as the definition AND as the body during the call).
@@ -208,7 +214,7 @@ test.describe('Async debugger (cooperative WASM)', () => {
     await page.getByTestId('debug-btn').click();
     await waitForPaused(page);
 
-    const lines = await recordStops(page, '#dbg-step-over');
+    const lines = await recordStops(page, 'dbg-step-over');
     console.log('step-over lines:', lines);
     // Stays at the top level — line 1 is visited exactly once (the definition);
     // the call on line 2 is stepped OVER, never descending back into line 1.
@@ -231,7 +237,7 @@ test.describe('Async debugger (cooperative WASM)', () => {
     await waitForPaused(page);
     expect(await getCurrentDebugLine(page)).toBe(2);
 
-    await clickAndSettle(page, '#dbg-step-out');
+    await clickAndSettle(page, 'dbg-step-out');
     const after = await getCurrentDebugLine(page);
     const status = await getStatus(page);
     console.log('after step-out: line', after, 'status', status);
@@ -261,16 +267,16 @@ test.describe('Async debugger (cooperative WASM)', () => {
     expect(await getCurrentDebugLine(page)).toBe(2);
 
     // Stepping inside the stopped task advances within the task (2 → 3 → 4).
-    await clickAndSettle(page, '#dbg-step-into');
+    await clickAndSettle(page, 'dbg-step-into');
     const l3 = await getCurrentDebugLine(page);
     console.log('within-task step 1 → line', l3);
     expect(l3).toBe(3);
-    await clickAndSettle(page, '#dbg-step-into');
+    await clickAndSettle(page, 'dbg-step-into');
     const l4 = await getCurrentDebugLine(page);
     console.log('within-task step 2 → line', l4);
     expect(l4).toBe(4);
 
-    await page.click('#dbg-continue');
+    await page.getByTestId('dbg-continue').click();
     await waitForIdle(page);
     expect((await getErrors(page)).join('\n')).not.toContain('scheduler');
   });

--- a/playground/tests/debug_exchange.spec.ts
+++ b/playground/tests/debug_exchange.spec.ts
@@ -6,7 +6,7 @@ test('debug exchange-rates via UI with HTTP fetch', async ({ page }) => {
   page.on('pageerror', err => logs.push(`[PAGE_ERROR] ${err.message}`));
 
   await page.goto('/');
-  await page.waitForSelector('[data-testid="status"].status-ready', { timeout: 15000 });
+  await expect(page.getByTestId('status')).toHaveClass(/status-ready/, { timeout: 15000 });
 
   // Load exchange-rates example code
   const code = await page.evaluate(async () => {
@@ -15,8 +15,11 @@ test('debug exchange-rates via UI with HTTP fetch', async ({ page }) => {
   });
   await page.getByTestId('editor').fill(code);
 
-  // Set breakpoint on line 13 (the println after HTTP data is parsed)
-  await page.click('.gutter-line:nth-child(13)');
+  // Set breakpoint on line 13 (the println after HTTP data is parsed).
+  // `.gutter-line` is rendered inside <sema-editor> (@sema-lang/ui, not this
+  // repo) with no exposed testid/role per line — CSS nth-child is the only way
+  // to target a specific line.
+  await page.locator('.gutter-line:nth-child(13)').click();
 
   // Click Debug
   await page.getByTestId('debug-btn').click();
@@ -27,21 +30,22 @@ test('debug exchange-rates via UI with HTTP fetch', async ({ page }) => {
     { timeout: 30000 }
   );
 
-  const status = await page.$eval('#status', el => el.textContent);
+  const status = await page.getByTestId('status').textContent();
   console.log('Status after debug + HTTP:', status);
 
-  // The debugger should have stopped (either entry or breakpoint)
-  const curLine = await page.$('.gutter-line.current-line');
-  const lineNum = curLine ? await curLine.textContent() : 'null';
+  // The debugger should have stopped (either entry or breakpoint). Same
+  // ui-library caveat as above for `.gutter-line`.
+  const curLineLocator = page.locator('.gutter-line.current-line');
+  const lineNum = (await curLineLocator.count()) > 0 ? await curLineLocator.textContent() : 'null';
   console.log('Stopped at line:', lineNum);
 
   // Continue to breakpoint at line 13
   while (true) {
-    const s = await page.$eval('#status', el => el.textContent ?? '');
+    const s = (await page.getByTestId('status').textContent()) ?? '';
     if (s === 'Ready') break;
     if (s.includes('13')) break;
 
-    await page.click('#dbg-continue');
+    await page.getByTestId('dbg-continue').click();
     await page.waitForFunction(
       () => {
         const s = document.getElementById('status')?.textContent ?? '';
@@ -51,11 +55,11 @@ test('debug exchange-rates via UI with HTTP fetch', async ({ page }) => {
     );
   }
 
-  const finalStatus = await page.$eval('#status', el => el.textContent);
+  const finalStatus = await page.getByTestId('status').textContent();
   console.log('Final status:', finalStatus);
 
   // Stop
-  await page.click('#dbg-stop');
+  await page.getByTestId('dbg-stop').click();
   await page.waitForFunction(
     () => document.getElementById('status')?.textContent === 'Ready',
     { timeout: 5000 }
@@ -71,7 +75,7 @@ test('debug exchange-rates.sema with breakpoint at line 18', async ({ page }) =>
   page.on('pageerror', err => logs.push(`[PAGE_ERROR] ${err.message}`));
 
   await page.goto('/');
-  await page.waitForSelector('[data-testid="status"].status-ready', { timeout: 15000 });
+  await expect(page.getByTestId('status')).toHaveClass(/status-ready/, { timeout: 15000 });
 
   // Read the exchange-rates example code
   const code = await page.evaluate(async () => {

--- a/playground/tests/debugger.spec.ts
+++ b/playground/tests/debugger.spec.ts
@@ -2,67 +2,72 @@ import { test, expect, Page } from '@playwright/test';
 
 async function waitForReady(page: Page) {
   await page.goto('/');
-  await page.waitForSelector('[data-testid="status"].status-ready', { timeout: 15000 });
+  await expect(page.getByTestId('status')).toHaveClass(/status-ready/, { timeout: 15000 });
 }
 
 async function setEditorCode(page: Page, code: string) {
   await page.getByTestId('editor').fill(code);
 }
 
-/** Click a gutter line number to toggle a breakpoint. */
+/** Click a gutter line number to toggle a breakpoint.
+ *  `.gutter-line` is rendered inside <sema-editor> (from @sema-lang/ui, not this
+ *  repo) with no exposed role/testid for individual line numbers — CSS nth-child
+ *  is the only way to target a specific line. */
 async function toggleBreakpoint(page: Page, lineNum: number) {
-  await page.click(`.gutter-line:nth-child(${lineNum})`);
+  await page.locator(`.gutter-line:nth-child(${lineNum})`).click();
 }
 
 /** Get the current debug state from the status bar. */
 async function getStatus(page: Page): Promise<string> {
-  return await page.$eval('#status', el => el.textContent ?? '');
+  return await page.getByTestId('status').textContent() ?? '';
 }
 
-/** Get the current line the debugger highlights. */
+/** Get the current line the debugger highlights.
+ *  `.gutter-line` internals come from <sema-editor> (@sema-lang/ui) — see
+ *  toggleBreakpoint for why CSS stays the fallback locator here. */
 async function getCurrentDebugLine(page: Page): Promise<number | null> {
-  const el = await page.$('.gutter-line.current-line');
-  if (!el) return null;
-  const text = await el.textContent();
+  const locator = page.locator('.gutter-line.current-line');
+  if ((await locator.count()) === 0) return null;
+  const text = await locator.textContent();
   return text ? parseInt(text, 10) : null;
 }
 
-/** Get all breakpoint line numbers. */
+/** Get all breakpoint line numbers.
+ *  `.gutter-line` internals come from <sema-editor> (@sema-lang/ui) — see
+ *  toggleBreakpoint for why CSS stays the fallback locator here. */
 async function getBreakpointLines(page: Page): Promise<number[]> {
-  return page.$$eval('.gutter-line.breakpoint', els =>
-    els.map(el => parseInt(el.textContent ?? '0', 10))
-  );
+  const texts = await page.locator('.gutter-line.breakpoint').allTextContents();
+  return texts.map(t => parseInt(t, 10));
 }
 
 /** Get all output lines (text content). */
 async function getOutputLines(page: Page): Promise<string[]> {
-  return page.$$eval('#output .output-line', els =>
-    els.map(el => el.textContent ?? '')
-  );
+  return page.getByTestId('output-line').allTextContents();
 }
 
 /** Get all error output. */
 async function getErrors(page: Page): Promise<string[]> {
-  return page.$$eval('#output .output-error', els =>
-    els.map(el => el.textContent ?? '')
-  );
+  return page.getByTestId('output-error').allTextContents();
 }
 
 /** Get debug variable names from the variables panel. */
 async function getDebugVarNames(page: Page): Promise<string[]> {
-  return page.$$eval('.debug-var-name', els =>
-    els.map(el => el.textContent ?? '')
-  );
+  return page.getByTestId('debug-var-name').allTextContents();
 }
 
 /** Get debug variable values from the variables panel. */
 async function getDebugVars(page: Page): Promise<{name: string, value: string}[]> {
-  return page.$$eval('.debug-var-row', els =>
-    els.map(el => ({
-      name: el.querySelector('.debug-var-name')?.textContent ?? '',
-      value: el.querySelector('.debug-var-value')?.textContent ?? '',
-    }))
-  );
+  const rows = page.getByTestId('debug-var-row');
+  const count = await rows.count();
+  const result: {name: string, value: string}[] = [];
+  for (let i = 0; i < count; i++) {
+    const row = rows.nth(i);
+    result.push({
+      name: (await row.getByTestId('debug-var-name').textContent()) ?? '',
+      value: (await row.getByTestId('debug-var-value').textContent()) ?? '',
+    });
+  }
+  return result;
 }
 
 /** Wait for debugger to pause (status bar shows "Paused at line ..."). */
@@ -98,7 +103,7 @@ test.describe('Debugger', () => {
     expect(line).toBe(1);
     
     // Stop debugging
-    await page.click('#dbg-stop');
+    await page.getByTestId('dbg-stop').click();
     await waitForIdle(page);
   });
 
@@ -133,7 +138,7 @@ test.describe('Debugger', () => {
     expect(bpLine).toBe(3);
 
     // Continue to end
-    await page.click('#dbg-continue');
+    await page.getByTestId('dbg-continue').click();
     await waitForIdle(page);
   });
 
@@ -154,7 +159,7 @@ test.describe('Debugger', () => {
     await toggleBreakpoint(page, 2);
     await page.getByTestId('debug-btn').click();
     await waitForPaused(page);
-    await page.click('#dbg-continue');
+    await page.getByTestId('dbg-continue').click();
     await waitForIdle(page);
 
     const errors = await getErrors(page);
@@ -176,7 +181,7 @@ test.describe('Debugger', () => {
     expect(entryLine).toBe(1);
 
     // Continue to end
-    await page.click('#dbg-continue');
+    await page.getByTestId('dbg-continue').click();
     await waitForIdle(page);
   });
 
@@ -196,7 +201,7 @@ test.describe('Debugger', () => {
       const status = await getStatus(page);
       if (status === 'Ready') break;
       
-      await page.click('#dbg-step-into');
+      await page.getByTestId('dbg-step-into').click();
       // Wait for either paused or idle
       await page.waitForFunction(
         () => {
@@ -236,7 +241,7 @@ test.describe('Debugger', () => {
       const status = await getStatus(page);
       if (status === 'Ready') break;
       
-      await page.click('#dbg-step-over');
+      await page.getByTestId('dbg-step-over').click();
       await page.waitForFunction(
         () => {
           const s = document.getElementById('status')?.textContent ?? '';
@@ -272,7 +277,7 @@ test.describe('Debugger', () => {
     expect(firstStop).toBe(2);
     
     // Continue past the breakpoint - should NOT stop on line 2 again
-    await page.click('#dbg-continue');
+    await page.getByTestId('dbg-continue').click();
     
     // Should reach end (idle), not stop on line 2 again
     await waitForIdle(page);
@@ -295,7 +300,7 @@ test.describe('Debugger', () => {
     console.log(`First loop hit: line ${firstHit}`);
 
     // Continue - should hit the same breakpoint again on the next iteration
-    await page.click('#dbg-continue');
+    await page.getByTestId('dbg-continue').click();
     await waitForPaused(page);
 
     const secondHit = await getCurrentDebugLine(page);
@@ -303,7 +308,7 @@ test.describe('Debugger', () => {
     expect(secondHit).toBe(firstHit);
     
     // Stop
-    await page.click('#dbg-stop');
+    await page.getByTestId('dbg-stop').click();
     await waitForIdle(page);
   });
 
@@ -315,11 +320,11 @@ test.describe('Debugger', () => {
     await waitForPaused(page);
     
     // Step past first define
-    await page.click('#dbg-step-into');
+    await page.getByTestId('dbg-step-into').click();
     await waitForPaused(page);
     
     // Step past second define  
-    await page.click('#dbg-step-into');
+    await page.getByTestId('dbg-step-into').click();
     await waitForPaused(page);
     
     // Check variables panel
@@ -331,7 +336,7 @@ test.describe('Debugger', () => {
     // At minimum, we should see some variables
     console.log('Variable names:', varNames);
     
-    await page.click('#dbg-stop');
+    await page.getByTestId('dbg-stop').click();
     await waitForIdle(page);
   });
 
@@ -342,7 +347,7 @@ test.describe('Debugger', () => {
     await waitForPaused(page);
     
     // Stop
-    await page.click('#dbg-stop');
+    await page.getByTestId('dbg-stop').click();
     await waitForIdle(page);
     
     // Verify UI is reset
@@ -361,8 +366,7 @@ test.describe('Debugger', () => {
     expect(curLine).toBeNull();
     
     // No variables panel
-    const varsPanel = await page.$('#debug-vars');
-    expect(varsPanel).toBeNull();
+    expect(await page.getByTestId('debug-vars').count()).toBe(0);
   });
 
   test('error during debug shows error and resets', async ({ page }) => {
@@ -373,7 +377,7 @@ test.describe('Debugger', () => {
     await waitForPaused(page);
     
     // Continue - should hit division by zero
-    await page.click('#dbg-continue');
+    await page.getByTestId('dbg-continue').click();
     
     // Wait for either error or idle
     await page.waitForFunction(
@@ -401,13 +405,13 @@ test.describe('Debugger', () => {
     await waitForPaused(page);
     
     // Continue — this enters the infinite loop
-    await page.click('#dbg-continue');
+    await page.getByTestId('dbg-continue').click();
     
     // Wait a moment for the yield loop to start
     await page.waitForTimeout(500);
     
     // Click stop — should work because VM yields to event loop
-    await page.click('#dbg-stop');
+    await page.getByTestId('dbg-stop').click();
     await waitForIdle(page, 3000);
     
     const status = await getStatus(page);
@@ -425,7 +429,7 @@ test.describe('Debugger', () => {
     await waitForPaused(page);
     
     // Entry stop - continue to breakpoint inside inner
-    await page.click('#dbg-continue');
+    await page.getByTestId('dbg-continue').click();
     
     // Should stop when inner is called  
     await page.waitForFunction(
@@ -439,7 +443,7 @@ test.describe('Debugger', () => {
     const line = await getCurrentDebugLine(page);
     console.log(`Stopped at line: ${line}`);
     
-    await page.click('#dbg-stop');
+    await page.getByTestId('dbg-stop').click();
     await waitForIdle(page);
   });
 
@@ -449,20 +453,18 @@ test.describe('Debugger', () => {
     // First session
     await page.getByTestId('debug-btn').click();
     await waitForPaused(page);
-    await page.click('#dbg-continue');
+    await page.getByTestId('dbg-continue').click();
     await waitForIdle(page);
     
     // Second session with different code
     await setEditorCode(page, '(* 3 4)');
     await page.getByTestId('debug-btn').click();
     await waitForPaused(page);
-    await page.click('#dbg-continue');
+    await page.getByTestId('dbg-continue').click();
     await waitForIdle(page);
     
     // Verify output from second session
-    const values = await page.$$eval('#output .output-value', els =>
-      els.map(el => el.textContent ?? '')
-    );
+    const values = await page.getByTestId('output-value').allTextContents();
     console.log('Output values:', values);
   });
 
@@ -477,7 +479,7 @@ test.describe('Debugger', () => {
     await waitForPaused(page);
     
     // Step to line 2
-    await page.click('#dbg-step-into');
+    await page.getByTestId('dbg-step-into').click();
     await page.waitForFunction(
       () => {
         const s = document.getElementById('status')?.textContent ?? '';
@@ -490,7 +492,7 @@ test.describe('Debugger', () => {
     console.log(`After first step: line ${atLine2}`);
     
     // Step into the function body
-    await page.click('#dbg-step-into');
+    await page.getByTestId('dbg-step-into').click();
     await page.waitForFunction(
       () => {
         const s = document.getElementById('status')?.textContent ?? '';
@@ -503,7 +505,7 @@ test.describe('Debugger', () => {
     console.log(`Inside function body: line ${inBody}`);
     
     // Step out — may finish execution since (f 10) is the last expression
-    await page.click('#dbg-step-out');
+    await page.getByTestId('dbg-step-out').click();
     await page.waitForFunction(
       () => {
         const s = document.getElementById('status')?.textContent ?? '';
@@ -518,7 +520,7 @@ test.describe('Debugger', () => {
     
     // Either paused at caller or finished — both are valid
     if (status !== 'Ready') {
-      await page.click('#dbg-stop');
+      await page.getByTestId('dbg-stop').click();
       await waitForIdle(page);
     }
   });
@@ -652,7 +654,7 @@ test.describe('Debugger', () => {
     expect(entryLine).toBe(1);
 
     // Continue — should hit the snapped breakpoint
-    await page.click('#dbg-continue');
+    await page.getByTestId('dbg-continue').click();
     await page.waitForFunction(
       () => {
         const s = document.getElementById('status')?.textContent ?? '';
@@ -667,7 +669,7 @@ test.describe('Debugger', () => {
       console.log(`Snapped breakpoint fired at line: ${bpLine}`);
       // Should have stopped at a valid line (1 or 3), not line 2
       expect(bpLine === 1 || bpLine === 3).toBe(true);
-      await page.click('#dbg-stop');
+      await page.getByTestId('dbg-stop').click();
       await waitForIdle(page);
     }
     // If status is 'Ready', session already finished — no cleanup needed

--- a/playground/tests/perlin_debug.spec.ts
+++ b/playground/tests/perlin_debug.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 async function waitForReady(page) {
   await page.goto('/');
-  await page.waitForSelector('[data-testid="status"].status-ready', { timeout: 15000 });
+  await expect(page.getByTestId('status')).toHaveClass(/status-ready/, { timeout: 15000 });
 }
 
 const PERLIN_HELPERS = `

--- a/playground/tests/vfs-demo.spec.ts
+++ b/playground/tests/vfs-demo.spec.ts
@@ -2,12 +2,12 @@ import { test, expect, Page } from '@playwright/test';
 
 async function waitForReady(page: Page) {
   await page.goto('/');
-  await page.waitForSelector('#status.status-ready', { timeout: 15000 });
+  await expect(page.getByTestId('status')).toHaveClass(/status-ready/, { timeout: 15000 });
 }
 
 async function clickRun(page: Page) {
   await page.getByTestId('run-btn').click();
-  await page.waitForSelector('#status.status-ready', { timeout: 30000 });
+  await expect(page.getByTestId('status')).toHaveClass(/status-ready/, { timeout: 30000 });
 }
 
 test('VFS: run file-creating script and check file tree', async ({ page }) => {
@@ -21,12 +21,14 @@ test('VFS: run file-creating script and check file tree', async ({ page }) => {
 
   await clickRun(page);
 
-  // File tree is always visible in the files panel. It dogfoods <sema-tree>,
-  // so entries are <sema-tree-item> nodes keyed by their `label` attribute.
+  // File tree is always visible in the files panel. It dogfoods <sema-tree>
+  // (from @sema-lang/ui, not this repo) — entries are <sema-tree-item> nodes
+  // whose visible label is their `label` attribute value, so getByText locates
+  // them without depending on that internal attribute selector.
   const fileTree = page.getByTestId('file-tree');
   await expect(fileTree).toBeVisible();
-  await expect(fileTree.locator('sema-tree-item[label="test-dir"]')).toBeVisible();
-  await expect(fileTree.locator('sema-tree-item[label="hello.txt"]')).toBeVisible();
+  await expect(fileTree.getByText('test-dir', { exact: true })).toBeVisible();
+  await expect(fileTree.getByText('hello.txt', { exact: true })).toBeVisible();
 });
 
 test('VFS: clicking a file shows content in preview pane', async ({ page }) => {
@@ -37,8 +39,9 @@ test('VFS: clicking a file shows content in preview pane', async ({ page }) => {
 `);
   await clickRun(page);
 
-  // Click on the file in the tree (a <sema-tree-item> leaf)
-  const fileEntry = page.locator('sema-tree-item[label="greeting.txt"]');
+  // Click on the file in the tree (a <sema-tree-item> leaf from @sema-lang/ui;
+  // getByText matches its visible label rather than the internal attribute).
+  const fileEntry = page.getByTestId('file-tree').getByText('greeting.txt', { exact: true });
   await fileEntry.click();
 
   // File viewer should show content


### PR DESCRIPTION
## e2e: prefer `getByTestId` over brittle CSS/attribute selectors

Refactors the Playwright e2e suites to select by `data-testid` instead of raw CSS/attribute/id selectors (`page.$`, `page.$$`, `page.$eval`, `waitForSelector('[…]'/'.'/'#')`, `locator('[…]'/'.'/'#')`). Where a target element had no testid, one was **added to this repo's source**; where the target is a third-party `@sema-lang/ui` element (not editable here), the test falls back to `getByRole`/`getByText` (still more robust than CSS), documented inline.

### Coverage (5 areas, locator-only — no test logic/assertions changed)
| Area | selectors → getByTestId | testids added |
|---|---|---|
| `packages/sema-web/e2e` | ~78 | 19 (fixture `.sema`/`.html`) |
| `examples/web-demo/tests` | 96 | 4 (`chat.sema`) |
| `playground/tests` (debugger/vfs/async/perlin/exchange) | ~55 | 12 (`index.html`, `src/app.js` output/debug nodes) |
| `crates/sema-notebook/tests/e2e` | 29 | 1 (`cell-output-header`) |
| `crates/sema/tests/e2e-workflow-view` | 27 | 9 (run-dashboard `index.html`) |

`playground.spec.ts` and `playwright.config.ts` are intentionally untouched — they're handled in the R7RS-quartet PR (#75). `ui` (Vitest component tests, not Playwright) and `website` (no e2e) are out of scope.

### Verification
- **Static, both confirmed:** zero residual brittle `$`/`waitForSelector` selectors in the converted specs, and every introduced `getByTestId('X')` resolves to a real `data-testid="X"` in source — including JS-set (`setAttribute`) and dynamic Alpine (`:data-testid`) bindings.
- Kept non-brittle selectors as-is (Playwright `text=`, plain tags, `:visible`/`hasText` filters, `.and()` on semantic data-attributes, in-page `waitForFunction`/`evaluate`).
- **The runtime gate is CI's `e2e` job**, which stands up each app in a browser and runs the converted suites.
