### PR TITLE
fix(vm): loaded-unit recursive fns read live globals, not a stale cache (#82)

### DIFF
--- a/crates/sema-core/src/value.rs
+++ b/crates/sema-core/src/value.rs
@@ -2951,7 +2951,16 @@ impl fmt::Debug for Value {
 pub struct Env {
     pub bindings: Rc<RefCell<SpurMap<Spur, Value>>>,
     pub parent: Option<Rc<Env>>,
-    pub version: Cell<u64>,
+    /// Monotonic mutation counter the VM's inline global cache is keyed on.
+    /// Held behind an `Rc` so it travels *with* `bindings`: every `Env` handle
+    /// cloned from this one shares this same cell. A mutation through any handle
+    /// (a `set!` on a `load`ed unit's per-form-VM clone, a different frame's
+    /// home-globals handle) is therefore observed by a cache entry keyed on any
+    /// other handle to the same bindings — a fresh cell per clone would let a
+    /// recursive reader keep serving a value its own handle's `set!` never bumped
+    /// (issue #82). A distinct bindings map (`new`/`with_parent`) still gets its
+    /// own cell, since it is a genuinely independent scope.
+    pub version: Rc<Cell<u64>>,
 }
 
 impl Env {
@@ -2959,7 +2968,7 @@ impl Env {
         Env {
             bindings: Rc::new(RefCell::new(SpurMap::new())),
             parent: None,
-            version: Cell::new(0),
+            version: Rc::new(Cell::new(0)),
         }
     }
 
@@ -2967,15 +2976,14 @@ impl Env {
         Env {
             bindings: Rc::new(RefCell::new(SpurMap::new())),
             parent: Some(parent),
-            version: Cell::new(0),
+            version: Rc::new(Cell::new(0)),
         }
     }
 
-    /// Bump the environment's version counter. The VM's inline global cache is
-    /// keyed on this version, so call this after mutating `bindings` through a
-    /// different `Env` handle that shares the same `bindings` Rc but has its own
-    /// version cell (e.g. a `load`ed module body run on a cloned-Env VM), so a
-    /// VM observing this `Env` re-reads instead of serving a stale cached value.
+    /// Bump the version counter shared by every handle to this scope's bindings.
+    /// The VM's inline global cache is keyed on it, so bumping after any mutation
+    /// makes every VM observing this scope (through any clone) re-read instead of
+    /// serving a stale cached value.
     pub fn bump_version(&self) {
         self.version.set(self.version.get().wrapping_add(1));
     }

--- a/crates/sema-eval/src/eval.rs
+++ b/crates/sema-eval/src/eval.rs
@@ -889,11 +889,10 @@ pub fn eval_module_body_vm(
         )?;
         result = vm.execute(prog.closure, ctx)?;
     }
-    // Each per-form VM ran on a clone of `env` with its own version cell, so any
-    // globals (re)defined by the body did not bump `env`'s version. Bump it now
-    // so the calling VM (whose globals share `env`'s bindings) invalidates its
-    // inline global cache and re-reads, rather than serving stale cached values.
-    env.bump_version();
+    // Each per-form VM ran on `Rc::new(env.clone())`; the clone shares both
+    // `env`'s bindings map and its version cell (`Env::version` is `Rc`-held),
+    // so any global the body (re)defined or `set!`d already bumped the version
+    // the calling VM's inline cache is keyed on — no explicit re-bump needed.
     Ok(result)
 }
 

--- a/crates/sema/tests/integration_test.rs
+++ b/crates/sema/tests/integration_test.rs
@@ -431,6 +431,61 @@ fn test_load_special_form() {
 }
 
 #[test]
+fn test_load_recursive_fn_reads_live_global_after_cross_fn_set() {
+    // Regression for issue #82: a self-recursive function DEFINED IN A `load`ed
+    // unit that directly reads a mutable global must observe a cross-function
+    // `set!` to that global performed mid-loop. The write itself lands (fresh
+    // calls see it), but a broken VM kept the in-flight recursive reader pinned
+    // to the pre-`set!` value forever — an infinite loop (the shape of every
+    // "loop until a callback flips a flag" event loop, e.g. a TUI `/quit`).
+    //
+    // Root cause: each top-level form of a `load`ed unit runs on its own per-form
+    // VM over a clone of the caller env, and `Env::clone` used to fork the
+    // version cell the inline global cache is keyed on. So `run` and `quit!`
+    // captured home-globals handles with *independent* version cells that share
+    // one bindings map: `quit!`'s `set!` bumped only its own cell, while `run`'s
+    // recursive reader kept hitting its own never-bumped cache entry and served
+    // the pre-`set!` value forever.
+    //
+    // The manifestation is inline-cache-slot-layout sensitive (adding a colliding
+    // global read to the reproducing functions accidentally masks it), so this
+    // test keeps the exact reported repro shape (named-let + a direct `unless`
+    // read + a trailing form) and bounds a regressed hang with an eval step limit
+    // rather than by editing the loop — a broken build errors out fast instead of
+    // wedging CI.
+    let dir = std::env::temp_dir().join(format!("sema-issue82-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let lib = dir.join("lib.sema");
+    std::fs::write(
+        &lib,
+        r#"
+(define *sq* #f)
+(define (quit!) (set! *sq* #t))
+(define (advance i) (when (= i 2) (quit!)))
+(define (run)
+  (let loop ((i 0))
+    (advance i)
+    (unless *sq* (loop (+ i 1))))
+  'exited-ok)
+"#,
+    )
+    .unwrap();
+    let lib_path = lib.to_string_lossy().replace('\\', "/");
+
+    let interp = Interpreter::new();
+    // Bound a regressed infinite loop: the guard fires on the named-let's
+    // backward jump, so a broken build hits the limit and errors rather than
+    // hanging. The fixed build exits after 3 iterations, far under the limit.
+    interp.ctx.set_eval_step_limit(1_000_000);
+    let result = interp
+        .eval_str(&format!("(load \"{lib_path}\")\n(run)"))
+        .expect("issue #82: recursive reader in a loaded unit never observed the cross-function set! (step limit tripped)");
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert_eq!(result, eval("'exited-ok"));
+}
+
+#[test]
 fn test_defmacro() {
     assert_eq!(
         eval(

--- a/docs/bugs/load-unit-stale-global-read-in-recursive-fns.md
+++ b/docs/bugs/load-unit-stale-global-read-in-recursive-fns.md
@@ -1,0 +1,98 @@
+# Stale global reads in recursive functions from `load`ed units
+
+**Status:** FIXED (2026-07-10, issue #82). See "Fix" below.
+**Found:** 2026-07-09, while hardening `examples/sema-coder` on 1.30.0.
+**Severity:** high — silently breaks the "loop until a callback flips a flag"
+pattern, which is the standard shape of every event loop. It is why the
+sema-coder TUI cannot exit via `/quit`, Ctrl-C, or Ctrl-D (worked when the TUI
+shipped, so this regressed somewhere in the 1.29.x–1.30.0 window; the TUI now
+carries an accessor-read workaround, see `tui.sema` `should-quit?`).
+
+## Repro (9 lines)
+
+```scheme
+;; lib.sema
+(define *sq* #f)
+(define (quit!) (set! *sq* #t))
+(define (advance i) (when (= i 2) (quit!)))   ;; name it `advance`, not `step`:
+                                              ;; `step` collides with a prelude macro
+(define (run)
+  (let loop ((i 0))
+    (advance i)
+    (unless *sq* (loop (+ i 1))))   ;; direct global read — never sees the set!
+  (println "exited ok"))
+
+;; main.sema
+(load "lib.sema")
+(run)                               ;; hangs forever
+```
+
+`run` looped forever: the `set!` performed two calls down the stack was never
+observed by the loop's direct read of `*sq*`.
+
+## Characterization (all on 1.30.0, release build)
+
+| Variant | Result |
+| --- | --- |
+| Exactly as above (named let, via `load`) | **hung** |
+| Same file run directly (no `load`) | works |
+| Loop reads the flag through an accessor fn `(sq?)` instead of directly | works |
+| Plain self-recursion instead of named let (`(define (spin i) … (unless *sq* (spin …)))`) | **hung** |
+| Non-tail self-recursion (`(+ 0 (spin …))`) | **hung** (overflowed; every frame read stale `#f`) |
+
+So it was *not* specific to the named-let/SelfTailCall rewrite: any function in
+a `load`ed unit that **directly reads a global** and **recurses** (tail or
+non-tail) kept seeing the value from before a cross-function `set!`. Fresh
+invocations (the accessor variant) saw the new value — the write itself landed;
+the in-flight recursive reader is what went stale.
+
+## Root cause
+
+The VM's inline global cache (`LOAD_GLOBAL`) is keyed on `(name, env.version)`:
+a cached `(name, version, value)` triple is served as long as
+`self.globals.version` is unchanged. `set!` (`STORE_GLOBAL`) bumps the version
+of the env it writes through, invalidating the cache.
+
+`Env::version` was a per-handle `Cell<u64>`, but `bindings` is a shared `Rc`.
+`Env` derives `Clone`, so `env.clone()` shared the bindings map yet **forked the
+version cell**. `eval_module_body_vm` runs each top-level form of a `load`ed
+unit on its own per-form VM over `Rc::new(env.clone())`, so every function
+defined in the unit captured a *different* home-globals handle: same bindings,
+independent version cell. `run` resolved `*sq*` against handle **A**; `quit!`'s
+`set!` bumped handle **B**. A's version never moved, so the loop's cache entry
+`(*sq*, A.version, #f)` kept hitting and served `#f` forever.
+
+- Single-file works: all top-level closures capture `self.globals.clone()`,
+  which is an `Rc::clone` of the one base-globals `Env` — one shared version cell.
+- The accessor variant "worked" only by accident: `sq?` and `quit!` collide on
+  the same shared `inline_cache` slot, so an unrelated read clobbered the stale
+  entry and forced a re-read. Layout-sensitive, hence fragile.
+
+This is the same family as the 1.29.x "frame-dynamic globals left stale by
+run_nested_closure" HOF fix — a cloned-Env handle diverging from the table
+`set!` writes through — surfacing on the `load` path.
+
+## Fix
+
+Make the version counter travel *with* the bindings: `Env::version` is now an
+`Rc<Cell<u64>>` (`crates/sema-core/src/value.rs`). Cloning an `Env` handle now
+shares one version cell across all handles to the same bindings map, so a `set!`
+through any handle is observed by a cache entry keyed on any other handle —
+recursive reader and cross-function writer are back in sync by construction. A
+genuinely new scope (`Env::new` / `Env::with_parent`) still gets its own cell.
+The change is strictly safe: sharing a cell can only cause *more* cache
+invalidations (re-reads), never a stale hit. The now-redundant explicit
+`env.bump_version()` after `eval_module_body_vm` was removed.
+
+Regression test:
+`crates/sema/tests/integration_test.rs::test_load_recursive_fn_reads_live_global_after_cross_fn_set`
+(keeps the exact fragile repro shape and bounds a regressed hang with an eval
+step limit, so a reintroduction errors fast instead of wedging CI).
+
+## Notes
+
+- `sema-coder` structure that hit it: `main.sema` `load`s `tui.sema`; the
+  key loop `(unless *should-quit* (loop))` never saw `run-command!`'s
+  `(set! *should-quit* #t)` even though instrumentation proved the `set!` ran.
+- Historical workaround for user code (no longer needed): read the flag via a
+  helper function, or keep the flag in a `mutable-cell`.


### PR DESCRIPTION
Fixes the stale-global read that made loaded-unit recursive functions (and thus the sema-coder TUI's `/quit`) hang.

## Root cause

The VM's inline global cache (`LOAD_GLOBAL`) is keyed on `(name, self.globals.version)`; `set!` (`STORE_GLOBAL`) bumps the version of the env it writes through to invalidate the cache. But `Env::version` was a per-handle `Cell<u64>` while `bindings` is a shared `Rc`. `Env` derives `Clone`, so `env.clone()` shares the bindings map **but forks the version cell**.

`eval_module_body_vm` runs each top-level form of a `load`ed unit on its own per-form VM over `Rc::new(env.clone())`, so every function defined in the unit captured a *different* home-globals handle — same bindings, independent version cell. At runtime a recursive reader resolved the flag against handle A and cached it; a sibling's `set!` bumped handle B's counter. A's version never moved, so the cache entry kept hitting and served the pre-`set!` value forever. Single-file code works because all top-level closures share one `Rc::clone` of the base globals (one version cell).

## Fix

Make the counter travel *with* the bindings: `Env::version` is now `Rc<Cell<u64>>`. Cloning a handle shares one version cell across all handles to the same bindings map, so a `set!` through any handle invalidates cache entries keyed on any other handle. A genuinely new scope (`Env::new`/`with_parent`) still gets its own cell. All `.get()`/`.set()` call sites are unchanged (Rc auto-derefs). Strictly safe: a shared cell can only cause *more* re-reads, never a stale hit. Also removed the now-redundant explicit `bump_version()` after `eval_module_body_vm`.

## Files
- `crates/sema-core/src/value.rs` — `Env::version` `Cell` → `Rc<Cell<u64>>`
- `crates/sema-eval/src/eval.rs` — drop redundant post-module `bump_version`
- `crates/sema/tests/integration_test.rs` — regression test
- `docs/bugs/load-unit-stale-global-read-in-recursive-fns.md` — marked FIXED

## Verification
- New test `test_load_recursive_fn_reads_live_global_after_cross_fn_set` — confirmed failing before / passing after; uses an eval-step limit so a regression errors fast instead of hanging CI.
- `cargo test --workspace` green (44 suites, 0 failures); `jake smoke-bytecode` 80/0; `jake examples` 80 pass/12 skip/0 fail; `clippy -D warnings` + `fmt --check` clean.
- Manual repro (`main.sema` `load`s `lib.sema`) now prints `exited ok` instantly (independently re-verified).

Closes #82

---
Branched from `5ccb8fcb` (merge-base with current `main`). Touches `integration_test.rs`, which PR #89 also appends tests to — expect a trivial append-conflict for whichever merges second.
