### PR TITLE
feat(stdlib): io/read-key-timeout and event/select yield in async context (#88)

### DIFF
--- a/crates/sema-stdlib/src/event.rs
+++ b/crates/sema-stdlib/src/event.rs
@@ -15,7 +15,7 @@
 use std::collections::BTreeMap;
 use std::time::{Duration, Instant};
 
-use sema_core::{check_arity, SemaError, Value};
+use sema_core::{check_arity, in_async_context, take_resume_value, SemaError, Value};
 
 use crate::register_fn;
 
@@ -105,6 +105,22 @@ pub fn register(env: &sema_core::Env) {
         let timeout_ms = explicit.or(min_timer).unwrap_or(10_000).max(0) as u128;
 
         let started = Instant::now();
+
+        // In an async task, cooperatively poll the sources on the scheduler
+        // thread rather than `std::thread::sleep`-blocking it between scans, so
+        // sibling tasks (e.g. an LLM/agent task) make progress while we wait for
+        // a source or the timeout. Reuses the same `AwaitIo` yield the
+        // file/http/shell async paths use. The sync path below is unchanged.
+        if in_async_context() {
+            if let Some(v) = take_resume_value() {
+                return Ok(v);
+            }
+            let deadline = started + Duration::from_millis(timeout_ms as u64);
+            return crate::io::await_io_until(deadline, move || {
+                sources.iter().find_map(|s| ready(s, started).map(Ok))
+            });
+        }
+
         loop {
             for s in &sources {
                 if let Some(ev) = ready(s, started) {

--- a/crates/sema-stdlib/src/event.rs
+++ b/crates/sema-stdlib/src/event.rs
@@ -115,8 +115,7 @@ pub fn register(env: &sema_core::Env) {
             if let Some(v) = take_resume_value() {
                 return Ok(v);
             }
-            let deadline = started + Duration::from_millis(timeout_ms as u64);
-            return crate::io::await_io_until(deadline, move || {
+            return crate::io::await_io_until(started, timeout_ms as u64, move || {
                 sources.iter().find_map(|s| ready(s, started).map(Ok))
             });
         }

--- a/crates/sema-stdlib/src/io.rs
+++ b/crates/sema-stdlib/src/io.rs
@@ -602,6 +602,38 @@ pub(crate) fn poll_key_event(_ms: u64) -> Option<Value> {
     None
 }
 
+/// Cooperatively poll `ready` on the scheduler thread until it yields a value or
+/// `deadline` passes (then `nil`), rather than blocking the OS thread in a
+/// `select(2)`/`sleep` wait. The async-context path of `io/read-key-timeout` and
+/// `event/select`: a "wait for input OR agent progress" loop must not stall the
+/// single cooperative scheduler thread while it waits, so we arm the same
+/// `AwaitIo` yield the file/http/shell async paths use — its poll closure
+/// re-checks readiness each scheduler tick (every sibling step, and at worst
+/// ~50 ms while every task is parked). `ready` returns `Some(Ok(v))` when input
+/// is available, `Some(Err(e))` to reject the task, or `None` while still
+/// waiting.
+///
+/// Unlike the `fs_offload`/`shell_async` poll closures (which cross no thread
+/// boundary but deliberately capture only `Send` data), `ready` here runs
+/// entirely on the VM thread and MAY capture Sema `Value`s (e.g. `event/select`'s
+/// source maps). That is sound: the cycle collector (Bacon–Rajan trial deletion)
+/// cannot trace into the boxed closure, so any `Value` it holds keeps a strong
+/// `Rc` the collector never subtracts — conservatively pinned, never freed — and
+/// the handle is dropped the moment the task resumes, so nothing leaks.
+pub(crate) fn await_io_until(
+    deadline: std::time::Instant,
+    mut ready: impl FnMut() -> Option<Result<Value, String>> + 'static,
+) -> Result<Value, SemaError> {
+    let handle = std::rc::Rc::new(sema_core::IoHandle::new(move || match ready() {
+        Some(Ok(v)) => sema_core::IoPoll::Ready(Ok(v)),
+        Some(Err(e)) => sema_core::IoPoll::Ready(Err(e)),
+        None if std::time::Instant::now() >= deadline => sema_core::IoPoll::Ready(Ok(Value::nil())),
+        None => sema_core::IoPoll::Pending,
+    }));
+    sema_core::set_yield_signal(sema_core::YieldReason::AwaitIo(handle));
+    Ok(Value::nil())
+}
+
 pub fn register(env: &sema_core::Env, sandbox: &sema_core::Sandbox) {
     register_fn(env, "display", |args| {
         let mut output = String::new();
@@ -1499,6 +1531,33 @@ pub fn register(env: &sema_core::Env, sandbox: &sema_core::Sandbox) {
                 .as_int()
                 .ok_or_else(|| SemaError::type_error("integer", args[0].type_name()))?
                 as u64;
+
+            // In an async task, park on a cooperative poll instead of blocking the
+            // scheduler thread in `select(2)` for the whole timeout, so a "key OR
+            // agent progress" loop lets sibling tasks run while it waits. Once a
+            // first byte is ready `parse_key_input` may briefly block reading a
+            // multi-byte sequence — identical to the sync path — but the idle wait
+            // no longer does. The sync path below is byte-identical to before.
+            if sema_core::in_async_context() {
+                if let Some(v) = sema_core::take_resume_value() {
+                    return Ok(v);
+                }
+                let deadline = std::time::Instant::now() + std::time::Duration::from_millis(ms);
+                return await_io_until(deadline, || {
+                    if !unix_stdin_ready(0) {
+                        return None;
+                    }
+                    match parse_key_input() {
+                        Ok(Some(v)) => Some(Ok(v)),
+                        Ok(None) => {
+                            STDIN_EOF.with(|f| f.set(true));
+                            Some(Ok(Value::nil()))
+                        }
+                        Err(e) => Some(Err(e.to_string())),
+                    }
+                });
+            }
+
             if !unix_stdin_ready(ms) {
                 return Ok(Value::nil());
             }

--- a/crates/sema-stdlib/src/io.rs
+++ b/crates/sema-stdlib/src/io.rs
@@ -603,31 +603,40 @@ pub(crate) fn poll_key_event(_ms: u64) -> Option<Value> {
 }
 
 /// Cooperatively poll `ready` on the scheduler thread until it yields a value or
-/// `deadline` passes (then `nil`), rather than blocking the OS thread in a
-/// `select(2)`/`sleep` wait. The async-context path of `io/read-key-timeout` and
-/// `event/select`: a "wait for input OR agent progress" loop must not stall the
-/// single cooperative scheduler thread while it waits, so we arm the same
-/// `AwaitIo` yield the file/http/shell async paths use — its poll closure
-/// re-checks readiness each scheduler tick (every sibling step, and at worst
-/// ~50 ms while every task is parked). `ready` returns `Some(Ok(v))` when input
-/// is available, `Some(Err(e))` to reject the task, or `None` while still
-/// waiting.
+/// `timeout_ms` milliseconds have elapsed since `started` (then `nil`), rather
+/// than blocking the OS thread in a `select(2)`/`sleep` wait. The async-context
+/// path of `io/read-key-timeout` and `event/select`: a "wait for input OR agent
+/// progress" loop must not stall the single cooperative scheduler thread while
+/// it waits, so we arm the same `AwaitIo` yield the file/http/shell async paths
+/// use — its poll closure re-checks readiness each scheduler tick (every
+/// sibling step, and at worst ~50 ms while every task is parked). `ready`
+/// returns `Some(Ok(v))` when input is available, `Some(Err(e))` to reject the
+/// task, or `None` while still waiting.
+///
+/// The timeout is checked as `started.elapsed() >= timeout_ms`, never as
+/// `started + Duration` — `Instant + Duration` panics on overflow, and unlike
+/// the sync path (`unix_stdin_ready`, a plain `libc::select` timeval) an
+/// arbitrarily large `ms` must not be able to crash the scheduler thread.
 ///
 /// Unlike the `fs_offload`/`shell_async` poll closures (which cross no thread
 /// boundary but deliberately capture only `Send` data), `ready` here runs
 /// entirely on the VM thread and MAY capture Sema `Value`s (e.g. `event/select`'s
 /// source maps). That is sound: the cycle collector (Bacon–Rajan trial deletion)
 /// cannot trace into the boxed closure, so any `Value` it holds keeps a strong
-/// `Rc` the collector never subtracts — conservatively pinned, never freed — and
-/// the handle is dropped the moment the task resumes, so nothing leaks.
+/// `Rc` the collector can't account for — but only for as long as the
+/// `IoHandle` is alive. The handle (closure and all) is dropped the moment the
+/// task resumes or is cancelled, which releases those `Rc`s normally; nothing
+/// is pinned beyond the handle's own lifetime.
 pub(crate) fn await_io_until(
-    deadline: std::time::Instant,
+    started: std::time::Instant,
+    timeout_ms: u64,
     mut ready: impl FnMut() -> Option<Result<Value, String>> + 'static,
 ) -> Result<Value, SemaError> {
+    let timeout = std::time::Duration::from_millis(timeout_ms);
     let handle = std::rc::Rc::new(sema_core::IoHandle::new(move || match ready() {
         Some(Ok(v)) => sema_core::IoPoll::Ready(Ok(v)),
         Some(Err(e)) => sema_core::IoPoll::Ready(Err(e)),
-        None if std::time::Instant::now() >= deadline => sema_core::IoPoll::Ready(Ok(Value::nil())),
+        None if started.elapsed() >= timeout => sema_core::IoPoll::Ready(Ok(Value::nil())),
         None => sema_core::IoPoll::Pending,
     }));
     sema_core::set_yield_signal(sema_core::YieldReason::AwaitIo(handle));
@@ -1542,8 +1551,8 @@ pub fn register(env: &sema_core::Env, sandbox: &sema_core::Sandbox) {
                 if let Some(v) = sema_core::take_resume_value() {
                     return Ok(v);
                 }
-                let deadline = std::time::Instant::now() + std::time::Duration::from_millis(ms);
-                return await_io_until(deadline, || {
+                let started = std::time::Instant::now();
+                return await_io_until(started, ms, || {
                     if !unix_stdin_ready(0) {
                         return None;
                     }

--- a/crates/sema/tests/vm_async_test.rs
+++ b/crates/sema/tests/vm_async_test.rs
@@ -1304,3 +1304,85 @@ fn parallel_and_pipeline_handle_empty_and_zero_stages() {
         common::eval(r#"'(1 2 3)"#)
     );
 }
+
+// === event/select and io/read-key-timeout yield in async context (#88) ===
+
+// event/select must NOT block the cooperative scheduler thread while it waits.
+// A task that `event/select`s on a source that never fires (a bogus :proc handle)
+// with an 80ms timeout is spawned FIRST; a sibling task that only sends a marker
+// is spawned second. If event/select blocked the OS thread for the whole timeout,
+// the sibling could not run until the select returned, so the select's marker
+// (:select-done) would reach the log channel FIRST. Because it yields, the sibling
+// runs to completion the instant the select parks — so :sibling-ran lands first.
+// This ordering is deterministic (the sibling does no I/O and no sleep, so it
+// finishes immediately once scheduled), which is exactly what distinguishes a
+// cooperative yield from a blocking wait.
+#[test]
+fn event_select_yields_to_sibling_in_async_context() {
+    let out = eval(
+        r#"
+        (let ((log (channel/new 4)))
+          (async/all
+            (list
+              (async
+                (event/select (list {:type :proc :handle 999999}) 80)
+                (channel/send log :select-done))
+              (async
+                (channel/send log :sibling-ran))))
+          (list (channel/recv log) (channel/recv log)))
+    "#,
+    );
+    assert_eq!(
+        out,
+        Value::list(vec![
+            Value::keyword("sibling-ran"),
+            Value::keyword("select-done"),
+        ]),
+        "event/select must yield so the sibling runs before the select's timeout resolves"
+    );
+}
+
+// event/select with no ready source still returns nil on timeout from within an
+// async context (the cooperative path must preserve the sync return semantics).
+#[test]
+fn event_select_times_out_to_nil_in_async_context() {
+    assert_eq!(
+        eval(r#"(await (async (event/select (list {:type :proc :handle 999999}) 20)))"#),
+        Value::nil()
+    );
+}
+
+// io/read-key-timeout: without a TTY we cannot deterministically feed a keystroke
+// nor force a clean idle timeout (a non-TTY stdin is often at EOF, which the first
+// poll resolves to nil immediately). So this does NOT prove the yield-during-wait
+// behavior — the event/select test above is the deterministic cooperative-yield
+// oracle. What it DOES prove: the async-context branch is wired up, returns
+// (nil on timeout/EOF, or a key), and neither panics nor deadlocks the scheduler
+// while a co-scheduled sibling task also runs to completion. Unix-only because
+// io/read-key-timeout is registered only on Unix.
+#[cfg(unix)]
+#[test]
+fn read_key_timeout_async_branch_completes_with_sibling() {
+    let out = eval(
+        r#"
+        (let ((log (channel/new 4)))
+          (async/all
+            (list
+              (async
+                (io/read-key-timeout 20)
+                (channel/send log :key-done))
+              (async
+                (channel/send log :sibling-ran))))
+          ;; Drain both markers as a set; ordering is NOT asserted (it depends on
+          ;; whether stdin is at EOF, which varies by test environment).
+          (let ((a (channel/recv log)) (b (channel/recv log)))
+            (list (or (= a :key-done) (= b :key-done))
+                  (or (= a :sibling-ran) (= b :sibling-ran)))))
+    "#,
+    );
+    assert_eq!(
+        out,
+        Value::list(vec![Value::bool(true), Value::bool(true)]),
+        "both the read-key-timeout task and its sibling must complete without deadlock"
+    );
+}


### PR DESCRIPTION
Makes `io/read-key-timeout` and `event/select` cooperative under the async scheduler so a "wait for key OR agent progress" loop no longer has to busy-pump.

## What changed
Both functions now branch on `sema_core::in_async_context()`:
- **Sync path (unchanged, byte-identical):** when not under the async scheduler, the original blocking `select(2)` / `std::thread::sleep` busy-loop runs exactly as before.
- **Async path (new):** reuses the **existing `AwaitIo`/`IoHandle` yield primitive** already used by `file/*`, `http/*`, and `shell` — no parallel mechanism. A shared `await_io_until(deadline, ready)` helper arms `YieldReason::AwaitIo` with a poll closure that re-checks readiness each scheduler tick, resolving to the key/event when ready or `nil` at the deadline. Return semantics are preserved exactly.

The `IoHandle` poll closure runs on the VM thread (not a worker), so it may capture Sema `Value`s (e.g. `event/select`'s source maps); this is safe under the Bacon–Rajan cycle collector and the handle drops the moment the task resumes. Rationale documented on the helper.

## Files
- `crates/sema-stdlib/src/io.rs` — `await_io_until` helper + async branch for `io/read-key-timeout`
- `crates/sema-stdlib/src/event.rs` — async branch for `event/select`
- `crates/sema/tests/vm_async_test.rs` — 3 tests

## Verification
- `event_select_yields_to_sibling_in_async_context` — deterministic yield oracle: a sibling task provably completes while an 80 ms `event/select` on a never-firing source is parked (log ordering inverts if it blocked the thread); stable across 5 runs.
- `event_select_times_out_to_nil_in_async_context`, `read_key_timeout_async_branch_completes_with_sibling` (unix). The read-key test documents the TTY limitation (can't inject a keystroke without a terminal); `event/select` is the real yield oracle.
- `vm_async_test` 100 pass, `sema-stdlib` 85 pass, `integration_test` 1049 pass; `clippy -D warnings` + `fmt --check` clean.

Closes #88
