### PR TITLE
feat: add string/truncate-width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Added
+
+- **`string/truncate-width`** (#92) — clamp a string to a target display width,
+  the truncation counterpart to `string/width`. Splits on grapheme-cluster
+  boundaries so wide glyphs (CJK, emoji) are never cut in half, and takes an
+  optional ellipsis string appended within the width budget. TUI cells that
+  clip long text (palette descriptions, tool-arg cells) no longer misalign by
+  falling back to a codepoint count.
+
 ### Changed
 
 - **`examples/sema-coder` moved to its own repo** (like the editor plugins) —

--- a/crates/sema-docs/builtin_docs.generated.json
+++ b/crates/sema-docs/builtin_docs.generated.json
@@ -11635,6 +11635,18 @@
       "body": "Remove trailing whitespace only. See `string/trim-left` for the leading side and `string/trim` for both.\n\n```sema\n(string/trim-right \"hi  \")     ; => \"hi\"\n(string/trim-right \"  hi  \")   ; => \"  hi\"   ; leading space kept\n```"
     },
     {
+      "name": "string/truncate-width",
+      "module": "strings",
+      "section": "Core String Operations",
+      "summary": "Clamp a string to a target **display width**, in columns — the truncation counterpart to `string/width`. Splits on grapheme-cluster boundaries, so wide characters (CJK, most emoji) are never cut in half. A string already at or under the width is returned unchanged; like `string/pad-left`/`string/pad-right` only pad, this only shrinks.",
+      "returns": "string",
+      "examples": [
+        "(string/truncate-width \"hello world\" 5)        ; => \"hello\"\n(string/truncate-width \"hi\" 10)                ; => \"hi\"            ; already fits, unchanged\n(string/truncate-width \"日本語です\" 6)          ; => \"日本語\"        ; grapheme-safe (wide chars = 2 cols)\n(string/truncate-width \"hello world\" 6 \"…\")    ; => \"hello…\"\n(string/truncate-width \"hi\" 6 \"…\")             ; => \"hi\"            ; fits, ellipsis unused"
+      ],
+      "body": "Clamp a string to a target **display width**, in columns — the truncation counterpart to `string/width`. Splits on grapheme-cluster boundaries, so wide characters (CJK, most emoji) are never cut in half. A string already at or under the width is returned unchanged; like `string/pad-left`/`string/pad-right` only pad, this only shrinks.\n\nWith an optional `ellipsis` string, an over-width input is truncated to leave room for it, and the ellipsis is appended — the result never exceeds `width` columns. If `ellipsis` itself is wider than `width`, it's truncated in the content's place.\n\n```sema\n(string/truncate-width \"hello world\" 5)        ; => \"hello\"\n(string/truncate-width \"hi\" 10)                ; => \"hi\"            ; already fits, unchanged\n(string/truncate-width \"日本語です\" 6)          ; => \"日本語\"        ; grapheme-safe (wide chars = 2 cols)\n(string/truncate-width \"hello world\" 6 \"…\")    ; => \"hello…\"\n(string/truncate-width \"hi\" 6 \"…\")             ; => \"hi\"            ; fits, ellipsis unused\n```",
+      "syntax": "(string/truncate-width s width [ellipsis])"
+    },
+    {
       "name": "string/unwrap",
       "module": "strings",
       "section": "Prefix & Suffix",

--- a/crates/sema-docs/entries/stdlib/strings/string-truncate-width.md
+++ b/crates/sema-docs/entries/stdlib/strings/string-truncate-width.md
@@ -1,0 +1,19 @@
+---
+name: "string/truncate-width"
+module: "strings"
+section: "Core String Operations"
+syntax: "(string/truncate-width s width [ellipsis])"
+returns: "string"
+---
+
+Clamp a string to a target **display width**, in columns — the truncation counterpart to `string/width`. Splits on grapheme-cluster boundaries, so wide characters (CJK, most emoji) are never cut in half. A string already at or under the width is returned unchanged; like `string/pad-left`/`string/pad-right` only pad, this only shrinks.
+
+With an optional `ellipsis` string, an over-width input is truncated to leave room for it, and the ellipsis is appended — the result never exceeds `width` columns. If `ellipsis` itself is wider than `width`, it's truncated in the content's place.
+
+```sema
+(string/truncate-width "hello world" 5)        ; => "hello"
+(string/truncate-width "hi" 10)                ; => "hi"            ; already fits, unchanged
+(string/truncate-width "日本語です" 6)          ; => "日本語"        ; grapheme-safe (wide chars = 2 cols)
+(string/truncate-width "hello world" 6 "…")    ; => "hello…"
+(string/truncate-width "hi" 6 "…")             ; => "hi"            ; fits, ellipsis unused
+```

--- a/crates/sema-stdlib/src/string.rs
+++ b/crates/sema-stdlib/src/string.rs
@@ -37,6 +37,36 @@ fn pad_to_width(s: &str, target: usize, pad_char: char, left: bool) -> String {
     }
 }
 
+/// Clamp `s` to a target *display width*, splitting on grapheme-cluster
+/// boundaries (never mid-cluster) so combining sequences and emoji are kept
+/// whole. Strings already at/under the target are returned unchanged — like
+/// `pad_to_width`, this never grows a string, only shrinks it. When `ellipsis`
+/// is non-empty and `s` is over width, content is truncated to leave room for
+/// the ellipsis, which is then appended; if `ellipsis` alone is wider than the
+/// target, it's truncated in its place (recursing with `ellipsis = ""`).
+fn truncate_to_width(s: &str, target: usize, ellipsis: &str) -> String {
+    if display_width(s) <= target {
+        return s.to_string();
+    }
+    let ellipsis_w = display_width(ellipsis);
+    if ellipsis_w > target {
+        return truncate_to_width(ellipsis, target, "");
+    }
+    let budget = target - ellipsis_w;
+    let mut out = String::new();
+    let mut w = 0usize;
+    for g in s.graphemes(true) {
+        let gw = UnicodeWidthStr::width(g);
+        if w + gw > budget {
+            break;
+        }
+        out.push_str(g);
+        w += gw;
+    }
+    out.push_str(ellipsis);
+    out
+}
+
 /// Hard-break a single word (no spaces) into chunks each ≤ `width` display
 /// columns, splitting on grapheme-cluster boundaries so combining sequences and
 /// emoji clusters are never split mid-cluster.
@@ -1482,6 +1512,29 @@ pub fn register(env: &sema_core::Env) {
             }
         }
         Ok(Value::list(out))
+    });
+
+    // (string/truncate-width s width [ellipsis]) -> S clamped to WIDTH display
+    // columns, splitting on grapheme-cluster boundaries so wide glyphs (CJK,
+    // emoji) are never cut in half. Strings already at/under WIDTH are
+    // returned unchanged — this only shrinks, unlike string/pad-* which only
+    // grows. With ELLIPSIS, an over-width string is truncated to leave room
+    // for it, and the ellipsis is appended (so the total never exceeds WIDTH);
+    // without it, truncation is a plain clamp.
+    register_fn(env, "string/truncate-width", |args| {
+        check_arity!(args, "string/truncate-width", 2..=3);
+        let s = args[0]
+            .as_str()
+            .ok_or_else(|| SemaError::type_error("string", args[0].type_name()))?;
+        let width = args[1].as_index("string/truncate-width")?;
+        let ellipsis = if args.len() == 3 {
+            args[2]
+                .as_str()
+                .ok_or_else(|| SemaError::type_error("string", args[2].type_name()))?
+        } else {
+            ""
+        };
+        Ok(Value::string_owned(truncate_to_width(s, width, ellipsis)))
     });
 
     // Silent aliases for other Lisp dialects (undocumented)

--- a/crates/sema/tests/eval_test.rs
+++ b/crates/sema/tests/eval_test.rs
@@ -342,6 +342,16 @@ eval_tests! {
     string_wrap_words: r#"(string/word-wrap "the quick brown fox" 10)"# => common::eval(r#"'("the quick" "brown fox")"#),
     string_wrap_hard_break: r#"(string/word-wrap "abcdefghij k" 5)"# => common::eval(r#"'("abcde" "fghij" "k")"#),
     string_wrap_keeps_newlines: r#"(string/word-wrap "a\nb" 10)"# => common::eval(r#"'("a" "b")"#),
+    // string/truncate-width — clamp to display columns, grapheme-safe, optional ellipsis.
+    string_truncate_width_unchanged: r#"(string/truncate-width "hello" 10)"# => Value::string("hello"),
+    string_truncate_width_exact: r#"(string/truncate-width "hello" 5)"# => Value::string("hello"),
+    string_truncate_width_plain: r#"(string/truncate-width "hello world" 5)"# => Value::string("hello"),
+    string_truncate_width_cjk: r#"(string/truncate-width "日本語です" 6)"# => Value::string("日本語"),
+    string_truncate_width_emoji_boundary: r#"(string/truncate-width "a👋b" 2)"# => Value::string("a"),
+    string_truncate_width_ellipsis: r#"(string/truncate-width "hello world" 6 "…")"# => Value::string("hello…"),
+    string_truncate_width_ellipsis_unchanged: r#"(string/truncate-width "hi" 6 "…")"# => Value::string("hi"),
+    string_truncate_width_ellipsis_too_wide: r#"(string/truncate-width "hello world" 1 "…")"# => Value::string("…"),
+    string_truncate_width_zero: r#"(string/truncate-width "hello" 0)"# => Value::string(""),
     // Terminal setup/teardown guard macros return the body value and re-raise
     // after restoring (teardown always runs — the emitted escapes go to stdout).
     guard_alt_screen_returns_body: "(term/with-alt-screen 1 2 3)" => Value::int(3),
@@ -1897,6 +1907,7 @@ eval_error_tests! {
     // STD-4
     string_pad_left_negative: r#"(string/pad-left "x" -1)"# => "non-negative",
     string_pad_right_negative: r#"(string/pad-right "x" -1)"# => "non-negative",
+    string_truncate_width_negative: r#"(string/truncate-width "x" -1)"# => "non-negative",
     // STD-5
     list_chunk_negative: "(list/chunk -1 (list 1 2 3))" => "non-negative",
     list_split_at_negative: "(list/split-at (list 1 2 3) -1)" => "non-negative",

--- a/website/docs/stdlib/strings.md
+++ b/website/docs/stdlib/strings.md
@@ -205,6 +205,22 @@ which wraps a string in delimiters.
 (string/word-wrap "日本語 の テスト" 8)         ; => ("日本語" "の" "テスト")
 ```
 
+### `string/truncate-width`
+
+Clamp a string to a target **display width**, in columns — the truncation
+counterpart to `string/width`. Splits on grapheme-cluster boundaries, so wide
+characters (CJK, most emoji) are never cut in half. A string already at or
+under the width is returned unchanged; like `string/pad-left`/`string/pad-right`
+only pad, this only shrinks. An optional `ellipsis` string is appended within
+the width budget when the input is truncated.
+
+```sema
+(string/truncate-width "hello world" 5)        ; => "hello"
+(string/truncate-width "hi" 10)                ; => "hi"        ; already fits, unchanged
+(string/truncate-width "日本語です" 6)          ; => "日本語"
+(string/truncate-width "hello world" 6 "…")    ; => "hello…"
+```
+
 ### `string/number?`
 
 Test if a string represents a valid number.


### PR DESCRIPTION
## Summary
- Adds `string/truncate-width` — clamps a string to a target display width (grapheme-safe, wide-glyph-aware), the truncation counterpart to `string/width`. Accepts an optional ellipsis string appended within the width budget.
- Closes #92: TUI cells (`examples/sema-coder`'s palette descriptions, tool-arg cells) no longer need to hand-roll a codepoint-based `clip-width` that misaligns on CJK/emoji.

## Test plan
- [x] `cargo test -p sema-lang --test eval_test -- string_truncate_width` — new eval tests (basic clamp, exact fit, CJK/emoji grapheme boundary, ellipsis, ellipsis wider than width, zero width, negative-width arity error)
- [x] `jake lint` — clean
- [x] `jake test` — full workspace suite green
- [x] `jake docs-check` — new `crates/sema-docs/entries/stdlib/strings/string-truncate-width.md` entry generates cleanly and index is in sync
- [x] Manually verified the issue's repro: `(string/truncate-width "hello" 3)` => `"hel"`