### PR TITLE
Add map-indexed and enumerate builtins (#90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Added
+
+- **`map-indexed` and `enumerate` builtins** (#90). `(map-indexed f xs)` calls
+  `f` with each element's 0-based index and value (`(f i x)`), collecting
+  results into a list; `(enumerate xs)` pairs each element with its index as
+  `(index element)` lists. Both accept a list or vector and always return a
+  list.
+
 ### Changed
 
 - **`examples/sema-coder` moved to its own repo** (like the editor plugins) —

--- a/crates/sema-docs/builtin_docs.generated.json
+++ b/crates/sema-docs/builtin_docs.generated.json
@@ -3491,6 +3491,18 @@
       "body": "Drop the leading elements of `seq` for which `pred` is truthy, returning the rest unchanged. Same as `list/drop-while`.\n\n```sema\n(drop-while (fn (x) (< x 4)) '(1 2 3 4 1))   ; => (4 1)\n```"
     },
     {
+      "name": "enumerate",
+      "module": "lists",
+      "section": "Higher-Order Functions",
+      "summary": "Pair each element of `seq` with its 0-based index, returning a list of `(index element)` lists. Accepts a list or vector; the input is never mutated and the result is always a list.",
+      "returns": "list",
+      "examples": [
+        "(enumerate '(10 20 30))   ; => ((0 10) (1 20) (2 30))\n(enumerate (vector 'a 'b)) ; => ((0 a) (1 b))"
+      ],
+      "body": "Pair each element of `seq` with its 0-based index, returning a list of `(index element)` lists. Accepts a list or vector; the input is never mutated and the result is always a list.\n\n```sema\n(enumerate '(10 20 30))   ; => ((0 10) (1 20) (2 30))\n(enumerate (vector 'a 'b)) ; => ((0 a) (1 b))\n```\n\n`(enumerate xs)` is equivalent to `(map-indexed list xs)`. See also: `map-indexed` (transform with the index instead of just pairing).",
+      "syntax": "(enumerate seq)"
+    },
+    {
       "name": "every",
       "module": "lists",
       "section": "Searching",
@@ -4175,6 +4187,18 @@
       ],
       "body": "Apply a function to each element of a list, collecting the results into a new list. The input is never mutated.\n\nGiven several lists, `map` walks them in lockstep, calling the function with one element from each. Iteration stops at the **shortest** list, so mismatched lengths are truncated rather than erroring.\n\n```sema\n(map (fn (x) (* x x)) '(1 2 3))   ; => (1 4 9)\n(map + '(1 2 3) '(10 20 30))      ; => (11 22 33)\n(map + '(1 2 3) '(10 20))         ; => (11 22)   ; stops at shortest\n```\n\nSee also: `mapcar` (alias), `for-each` (run side effects, discard results), `filter`/`list/reject` (keep/drop by predicate).",
       "syntax": "(map f lst ...)"
+    },
+    {
+      "name": "map-indexed",
+      "module": "lists",
+      "section": "Higher-Order Functions",
+      "summary": "Apply `f` to each element of `seq` along with its 0-based index, collecting the results into a new list. `f` is called as `(f index element)`. Accepts a list or vector; the input is never mutated and the result is always a list.",
+      "returns": "list",
+      "examples": [
+        "(map-indexed (fn (i x) (list i x)) '(10 20 30))   ; => ((0 10) (1 20) (2 30))\n(map-indexed (fn (i x) (+ i x)) (vector 10 20 30)) ; => (10 21 32)"
+      ],
+      "body": "Apply `f` to each element of `seq` along with its 0-based index, collecting the results into a new list. `f` is called as `(f index element)`. Accepts a list or vector; the input is never mutated and the result is always a list.\n\n```sema\n(map-indexed (fn (i x) (list i x)) '(10 20 30))   ; => ((0 10) (1 20) (2 30))\n(map-indexed (fn (i x) (+ i x)) (vector 10 20 30)) ; => (10 21 32)\n```\n\nSee also: `map` (no index), `enumerate` (pairs elements with their index without transforming them).",
+      "syntax": "(map-indexed f seq)"
     },
     {
       "name": "mapcar",

--- a/crates/sema-docs/entries/stdlib/lists/enumerate.md
+++ b/crates/sema-docs/entries/stdlib/lists/enumerate.md
@@ -1,0 +1,16 @@
+---
+name: "enumerate"
+module: "lists"
+section: "Higher-Order Functions"
+syntax: "(enumerate seq)"
+returns: "list"
+---
+
+Pair each element of `seq` with its 0-based index, returning a list of `(index element)` lists. Accepts a list or vector; the input is never mutated and the result is always a list.
+
+```sema
+(enumerate '(10 20 30))   ; => ((0 10) (1 20) (2 30))
+(enumerate (vector 'a 'b)) ; => ((0 a) (1 b))
+```
+
+`(enumerate xs)` is equivalent to `(map-indexed list xs)`. See also: `map-indexed` (transform with the index instead of just pairing).

--- a/crates/sema-docs/entries/stdlib/lists/map-indexed.md
+++ b/crates/sema-docs/entries/stdlib/lists/map-indexed.md
@@ -1,0 +1,16 @@
+---
+name: "map-indexed"
+module: "lists"
+section: "Higher-Order Functions"
+syntax: "(map-indexed f seq)"
+returns: "list"
+---
+
+Apply `f` to each element of `seq` along with its 0-based index, collecting the results into a new list. `f` is called as `(f index element)`. Accepts a list or vector; the input is never mutated and the result is always a list.
+
+```sema
+(map-indexed (fn (i x) (list i x)) '(10 20 30))   ; => ((0 10) (1 20) (2 30))
+(map-indexed (fn (i x) (+ i x)) (vector 10 20 30)) ; => (10 21 32)
+```
+
+See also: `map` (no index), `enumerate` (pairs elements with their index without transforming them).

--- a/crates/sema-stdlib/src/list.rs
+++ b/crates/sema-stdlib/src/list.rs
@@ -188,6 +188,29 @@ pub fn register(env: &sema_core::Env) {
         }
     });
 
+    register_fn(env, "map-indexed", |args| {
+        check_arity!(args, "map-indexed", 2);
+        let items = get_sequence(&args[1], "map-indexed")?;
+        let mut result = Vec::with_capacity(items.len());
+        for (i, item) in items.iter().enumerate() {
+            result.push(call_function(
+                &args[0],
+                &[Value::int(i as i64), item.clone()],
+            )?);
+        }
+        Ok(Value::list(result))
+    });
+
+    register_fn(env, "enumerate", |args| {
+        check_arity!(args, "enumerate", 1);
+        let items = get_sequence(&args[0], "enumerate")?;
+        let mut result = Vec::with_capacity(items.len());
+        for (i, item) in items.iter().enumerate() {
+            result.push(Value::list(vec![Value::int(i as i64), item.clone()]));
+        }
+        Ok(Value::list(result))
+    });
+
     register_fn(env, "filter", |args| {
         check_arity!(args, "filter", 2);
         let items = get_sequence(&args[1], "filter")?;

--- a/crates/sema/tests/eval_test.rs
+++ b/crates/sema/tests/eval_test.rs
@@ -1357,6 +1357,32 @@ eval_tests! {
 }
 
 // ============================================================
+// map-indexed and enumerate (#90)
+// ============================================================
+
+eval_tests! {
+    map_indexed_basic: "(map-indexed (fn (i x) (list i x)) '(10 20 30))"
+        => common::eval("'((0 10) (1 20) (2 30))"),
+    map_indexed_empty: "(map-indexed (fn (i x) (list i x)) '())" => Value::list(vec![]),
+    map_indexed_vector_input: "(map-indexed (fn (i x) (+ i x)) (vector 10 20 30))"
+        => Value::list(vec![Value::int(10), Value::int(21), Value::int(32)]),
+    map_indexed_index_only: "(map-indexed (fn (i x) i) '(a b c))"
+        => Value::list(vec![Value::int(0), Value::int(1), Value::int(2)]),
+
+    enumerate_basic: "(enumerate '(10 20 30))" => common::eval("'((0 10) (1 20) (2 30))"),
+    enumerate_empty: "(enumerate '())" => Value::list(vec![]),
+    enumerate_vector_input: "(enumerate (vector 'a 'b))" => common::eval("'((0 a) (1 b))"),
+    enumerate_then_map_destructure: "(map (fn (pair) (car pair)) (enumerate '(x y z)))"
+        => Value::list(vec![Value::int(0), Value::int(1), Value::int(2)]),
+}
+
+eval_error_tests! {
+    map_indexed_wrong_arity: "(map-indexed (fn (i x) x))" => "arity",
+    map_indexed_non_sequence_errors: "(map-indexed (fn (i x) x) 5)" => "list or vector",
+    enumerate_non_sequence_errors: "(enumerate 5)" => "list or vector",
+}
+
+// ============================================================
 // Input validation — negative counts/indices (C7, C8, C9)
 // ============================================================
 

--- a/website/docs/stdlib/lists.md
+++ b/website/docs/stdlib/lists.md
@@ -166,6 +166,22 @@ Apply a function to each element of one or more lists.
 (map + '(1 2 3) '(10 20 30))          ; => (11 22 33)
 ```
 
+### `map-indexed`
+
+Like `map`, but calls the function with the index and the element: `(f index element)`.
+
+```sema
+(map-indexed (fn (i x) (list i x)) '(10 20 30))   ; => ((0 10) (1 20) (2 30))
+```
+
+### `enumerate`
+
+Pair each element with its 0-based index.
+
+```sema
+(enumerate '(10 20 30))   ; => ((0 10) (1 20) (2 30))
+```
+
 ### `filter`
 
 Return elements that satisfy a predicate.


### PR DESCRIPTION
## Summary
- Adds `(map-indexed f xs)` — calls `f` as `(f index element)` for each element, collecting results into a list (Clojure-style).
- Adds `(enumerate xs)` — pairs each element with its 0-based index as `(index element)` lists, matching this codebase's existing pair convention (`zip`, `map/entries`) rather than a dotted cons cell.
- Both accept a list or vector via the shared `get_sequence` helper and always return a list, consistent with `map`/`filter`.

Closes #90.

## Test plan
- [x] `cargo test -p sema-lang --test eval_test -- map_indexed enumerate` — 11 new tests (basic, empty, vector input, index-only use, error/arity cases)
- [x] `jake lint` — fmt + clippy clean
- [x] `jake test` — full workspace suite green
- [x] `jake examples` — all runnable examples pass
- [x] `jake docs-check` — generated builtin docs index up to date, doc coverage test passes
- [x] Independent opus-model review of the diff for correctness/idiom-consistency — no blocking issues
