### PR TITLE
fix(cli): honor sema eval --timeout via the VM eval deadline

### DIFF
--- a/crates/sema/src/main.rs
+++ b/crates/sema/src/main.rs
@@ -391,7 +391,7 @@ enum Commands {
         #[arg(long)]
         path: Option<String>,
 
-        /// Kill evaluation after N milliseconds (default: 5000)
+        /// Kill evaluation after N milliseconds; 0 disables the timeout (default: 5000)
         #[arg(long, default_value = "5000")]
         timeout: u64,
 
@@ -996,11 +996,11 @@ fn main() {
                 expr,
                 json,
                 path,
-                timeout: _timeout,
+                timeout,
                 sandbox,
                 no_llm,
             } => {
-                run_eval(stdin, expr, json, path, sandbox, no_llm);
+                run_eval(stdin, expr, json, path, timeout, sandbox, no_llm);
             }
             Commands::Update {
                 check,
@@ -1649,6 +1649,7 @@ fn run_eval(
     expr: Option<String>,
     json: bool,
     path: Option<String>,
+    timeout_ms: u64,
     sandbox_arg: Option<String>,
     no_llm: bool,
 ) {
@@ -1745,6 +1746,17 @@ fn run_eval(
     let captured_stderr: Rc<RefCell<String>> = Rc::new(RefCell::new(String::new()));
     if json {
         install_capturing_io(&interpreter, &captured_stdout, &captured_stderr);
+    }
+
+    // Arm the VM's wall-clock deadline so runaway loops abort with an eval
+    // error instead of hanging the caller. Armed after (llm/auto-configure)
+    // so setup time is not billed to the user's program; it stays armed
+    // through the async drain so spawned tasks are bounded too. A saturating
+    // deadline (checked_add → None) means "no timeout", same as 0.
+    if timeout_ms > 0 {
+        let deadline =
+            std::time::Instant::now().checked_add(std::time::Duration::from_millis(timeout_ms));
+        interpreter.ctx.set_eval_deadline(deadline);
     }
 
     let start = std::time::Instant::now();

--- a/crates/sema/tests/integration_test.rs
+++ b/crates/sema/tests/integration_test.rs
@@ -14513,6 +14513,38 @@ fn test_eval_error_json() {
 }
 
 #[test]
+fn test_eval_timeout_kills_runaway_loop() {
+    // Omega combinator: loops forever under TCO. The 10s ceiling is generous
+    // headroom for slow CI over the 300ms deadline — without a working
+    // --timeout the eval never returns at all.
+    let start = std::time::Instant::now();
+    let output = sema_cmd()
+        .args([
+            "eval",
+            "--expr",
+            "((fn (f) (f f)) (fn (f) (f f)))",
+            "--json",
+            "--no-llm",
+            "--timeout",
+            "300",
+        ])
+        .output()
+        .expect("failed to run sema eval");
+    assert!(
+        start.elapsed() < std::time::Duration::from_secs(10),
+        "--timeout did not abort the runaway loop"
+    );
+    assert!(output.status.success(), "expected exit 0 for --json error");
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    let msg = json["error"]["message"].as_str().unwrap();
+    assert!(
+        msg.contains("time budget"),
+        "expected deadline error, got: {msg}"
+    );
+}
+
+#[test]
 fn test_eval_expr_no_json() {
     let output = sema_cmd()
         .args(["eval", "--expr", "(+ 10 20)", "--no-llm"])

--- a/website/docs/cli.md
+++ b/website/docs/cli.md
@@ -57,7 +57,7 @@ sema eval [OPTIONS]
 | `--path <FILE>`       | Set file context for imports and error spans                     |
 | `--sandbox <MODE>`    | Sandbox mode (`strict`, `all`, or comma-separated capabilities)  |
 | `--no-llm`            | Disable LLM features                                             |
-| `--timeout <MS>`      | Kill evaluation after N ms (default: 5000)                       |
+| `--timeout <MS>`      | Kill evaluation after N ms; 0 disables (default: 5000)           |
 
 **Examples:**
 


### PR DESCRIPTION
## Problem

`sema eval --timeout N` is a no-op: the flag is parsed and then explicitly discarded (`timeout: _timeout` in the `Commands::Eval` match arm), and `run_eval` never sees it. A runaway eval runs forever:

```bash
echo '((fn (f) (f f)) (fn (f) (f f)))' | sema eval --stdin --json --timeout 500
# before: never returns — after: JSON error envelope at ~500ms
```

Found via the Sublime Text plugin, whose eval command passes `--timeout 10000` and relied on it working.

## Fix

Wire the flag through to `run_eval` and arm `EvalContext::set_eval_deadline` before evaluation — the VM's existing `check_loop_interrupt` back-edge guard then aborts with an eval error (`evaluation exceeded time budget`). No new mechanism.

- Armed after `(llm/auto-configure)` so setup isn't billed to the user's program; stays armed through `drain_async_scheduler` so spawned tasks are bounded too.
- `--timeout 0` disables the deadline (help text + `website/docs/cli.md` updated).
- Saturating `checked_add` treats absurd values as no-timeout instead of panicking.

## Not already fixed elsewhere

Checked before writing this: both #125 (`codex/unified-async-runtime`) and #127 (`fix/lsp-goto-definition-workspace`) still carry the `timeout: _timeout` discard, so neither addresses it. The diff here is small; if #125 lands first the conflict in `main.rs` is a two-line resolve.

## Testing

- New `test_eval_timeout_kills_runaway_loop` integration test (omega combinator + `--timeout 300`, asserts the `time budget` error and bounded wall clock).
- `cargo test -p sema-lang --test integration_test -- test_eval_`: 16 passed.
- `cargo clippy -p sema-lang --all-targets -- -D warnings` and `cargo fmt --check`: clean.