### PR TITLE
Let deftool values be called directly with tool/invoke (#124)

### DIFF
--- a/crates/sema-llm/src/builtins.rs
+++ b/crates/sema-llm/src/builtins.rs
@@ -5861,6 +5861,30 @@ pub fn register_llm_builtins(env: &Env, sandbox: &sema_core::Sandbox) {
         sema_core::set_yield_signal(sema_core::YieldReason::AwaitIo(handle));
         Ok(Value::nil())
     });
+
+    // (tool/invoke tool args) — Direct invocation of a deftool handler
+    register_fn_ctx(env, "tool/invoke", |ctx, args| {
+        if args.len() != 2 {
+            return Err(SemaError::arity("tool/invoke", "2", args.len()));
+        }
+        let tool_def = args[0]
+            .as_tool_def_rc()
+            .ok_or_else(|| SemaError::type_error("tool", args[0].type_name()))?;
+        let _ = args[1]
+            .as_map_rc()
+            .ok_or_else(|| SemaError::type_error("map", args[1].type_name()))?;
+
+        if let Err(msg) = validate_extraction(&args[1], &tool_def.parameters) {
+            return Err(SemaError::Llm(format!(
+                "invalid arguments for tool '{name}': {msg}",
+                name = tool_def.name
+            )));
+        }
+
+        let json_args = sema_core::value_to_json_lossy(&args[1]);
+        let sema_args = json_args_to_sema(&tool_def.parameters, &json_args, &tool_def.handler);
+        sema_core::call_callback(ctx, &tool_def.handler, &sema_args)
+    });
 }
 
 fn require_matching_bytevectors<'a>(

--- a/crates/sema/tests/suites/eval_stdlib_test.rs
+++ b/crates/sema/tests/suites/eval_stdlib_test.rs
@@ -206,6 +206,12 @@ eval_tests! {
     agent_pred: r#"(begin (deftool greet "Greet" {:name {:type :string}} (lambda (name) name)) (defagent greeter {:system "You greet." :tools [greet]}) (agent? greeter))"# => Value::bool(true),
     agent_name: r#"(begin (deftool greet "Greet" {:name {:type :string}} (lambda (name) name)) (defagent greeter {:system "You greet." :tools [greet]}) (agent/name greeter))"# => Value::string("greeter"),
     agent_system: r#"(begin (deftool greet "Greet" {:name {:type :string}} (lambda (name) name)) (defagent greeter {:system "You greet." :tools [greet]}) (agent/system greeter))"# => Value::string("You greet."),
+    tool_invoke_ping: r#"(begin (deftool ping "Return pong" {} (lambda () "pong")) (tool/invoke ping {}))"# => Value::string("pong"),
+    tool_invoke_typed: r#"(begin (deftool add-numbers "Add" {:a {:type :number} :b {:type :number}} (lambda (a b) (+ a b))) (tool/invoke add-numbers {:a 2 :b 3}))"# => Value::int(5),
+}
+
+eval_error_tests! {
+    tool_invoke_invalid_args: r#"(begin (deftool calc "Add" {:x {:type :number}} (lambda (x) x)) (tool/invoke calc {}))"# => "invalid arguments for tool 'calc': missing key: x",
 }
 
 // ============================================================


### PR DESCRIPTION
## What & why

A `deftool` value couldn't be called directly — `(ping)` errored with "not callable," and the only way to run a tool's handler was through an LLM agent. That made loaded or scripted tools awkward to reuse from the REPL and tests. This adds `tool/invoke` so you can call a tool's handler directly, with the same schema validation the agent path uses.

## How

- Added a `tool/invoke` builtin in `crates/sema-llm/src/builtins.rs` taking a tool value and an argument map.
- It validates the args against the tool's `tool/parameters`, maps named args to the handler's declared order, and calls the stored handler — reusing the same validation and callback path as `execute_tool_call`.
- Returns the handler's raw Sema value (not an LLM-facing string), and propagates validation/handler errors normally.

## Verification

```bash
cargo test -p sema-llm
sema -e '(begin (deftool ping "Return pong" {} (lambda () "pong")) (tool/invoke ping {}))'
# => "pong"
sema -e '(begin (deftool always-five "Return five" {} (lambda () 5)) (+ 1 (tool/invoke always-five {})))'
# => 6  (confirms it returns a real number, not a string)
```

Closes #124