### PR TITLE
Easy wins: sema mcp list, de-flake wall bounds, stale doc closures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **`sema mcp list`** — lists every MCP server with cached credentials, one
+  line per server with its token status (`token present` / `token expired`).
+  Reads only the local credential store (never the network); the keychain
+  backend, which has no enumeration API, says so and points at
+  `SEMA_MCP_TOKEN_STORE=file` instead of pretending the store is empty.
+
+### Improved
+
+- De-flaked the concurrent-agent overlap tests: the load-sensitive
+  `wall_ms < 700` ceilings are gone, leaving the load-safe
+  `io_peak_inflight() >= 2` lower bound as the concurrency oracle.
+
 ## 1.32.1
 
 ### Fixed

--- a/crates/sema-mcp/src/client_auth.rs
+++ b/crates/sema-mcp/src/client_auth.rs
@@ -1,4 +1,4 @@
-//! CLI entry points for MCP client authentication (`sema mcp login/logout`),
+//! CLI entry points for MCP client authentication (`sema mcp login/logout/list`),
 //! plus [`login_interactive`] — the same browser-loopback flow, returned to
 //! the caller instead of persisted, for embedders that own their own
 //! credential placement (the workflow run-start interactive auth path in the
@@ -138,5 +138,28 @@ pub fn mcp_login_token(url: &str, token: &str, expires_in: Option<u64>) -> Resul
 pub fn mcp_logout(url: &str) -> Result<(), String> {
     oauth::store::default_store().delete(url)?;
     eprintln!("Cleared cached credentials for {url}.");
+    Ok(())
+}
+
+/// Print every server with cached credentials in the default store, one line
+/// per server: the canonical URL and its token status (`token present`, or
+/// `token expired` when the stored expiry has passed). Purely local — never
+/// touches the network — and the keychain backend surfaces its no-enumeration
+/// limitation as an error rather than an empty listing.
+pub fn mcp_list() -> Result<(), String> {
+    let servers = oauth::store::default_store().list()?;
+    if servers.is_empty() {
+        println!("no known servers");
+        return Ok(());
+    }
+    let now = oauth::store::now_unix();
+    for creds in servers {
+        let status = if creds.tokens.is_expired(now, 0) {
+            "token expired"
+        } else {
+            "token present"
+        };
+        println!("{}  {status}", creds.server_url);
+    }
     Ok(())
 }

--- a/crates/sema-mcp/src/lib.rs
+++ b/crates/sema-mcp/src/lib.rs
@@ -15,7 +15,7 @@ pub use builtins::{
     ConnectOpts, ConnectedClient,
 };
 pub use client::{McpClient, McpClientConfig, McpHttpConfig};
-pub use client_auth::{login_interactive, mcp_login, mcp_login_token, mcp_logout};
+pub use client_auth::{login_interactive, mcp_list, mcp_login, mcp_login_token, mcp_logout};
 pub use server::{run_mcp_server, run_mcp_server_on, run_mcp_server_sync};
 
 /// A random 128-bit value as 32 lowercase hex characters (a UUID v4 with the

--- a/crates/sema-mcp/src/oauth/store.rs
+++ b/crates/sema-mcp/src/oauth/store.rs
@@ -83,6 +83,19 @@ pub trait TokenStore {
     fn load(&self, server_url: &str) -> Option<StoredCredentials>;
     fn save(&self, creds: &StoredCredentials) -> Result<(), String>;
     fn delete(&self, server_url: &str) -> Result<(), String>;
+
+    /// Enumerate every stored credential set, sorted by server URL (for
+    /// `sema mcp list`). Defaulted to a plain "unsupported" error because most
+    /// backends have nothing to enumerate with — the OS keychain exposes no
+    /// per-service listing API — and pretending such a store is empty would be
+    /// worse than saying so.
+    fn list(&self) -> Result<Vec<StoredCredentials>, String> {
+        Err(
+            "this credential store cannot enumerate servers (the OS keychain has no \
+             listing API); only the file backend (SEMA_MCP_TOKEN_STORE=file) can be listed"
+                .to_string(),
+        )
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -186,6 +199,11 @@ impl TokenStore for FileStore {
         let mut doc = self.read_doc()?;
         doc.servers.remove(server_url);
         self.write_doc(&doc)
+    }
+
+    // `servers` is a BTreeMap keyed by URL, so the order is stable for free.
+    fn list(&self) -> Result<Vec<StoredCredentials>, String> {
+        Ok(self.read_doc()?.servers.into_values().collect())
     }
 }
 
@@ -366,6 +384,32 @@ mod tests {
         store.save(&b).unwrap();
         assert_eq!(store.load("https://a.example.com/mcp"), Some(a));
         assert_eq!(store.load("https://b.example.com/mcp"), Some(b));
+    }
+
+    #[test]
+    fn file_store_lists_servers_in_url_order() {
+        let store = FileStore::new(temp_path());
+        assert_eq!(store.list().unwrap(), vec![]);
+        store.save(&sample("https://b.example.com/mcp")).unwrap();
+        store.save(&sample("https://a.example.com/mcp")).unwrap();
+        let urls: Vec<String> = store
+            .list()
+            .unwrap()
+            .into_iter()
+            .map(|c| c.server_url)
+            .collect();
+        assert_eq!(
+            urls,
+            ["https://a.example.com/mcp", "https://b.example.com/mcp"]
+        );
+    }
+
+    #[test]
+    fn keychain_list_is_unsupported_not_empty() {
+        // No keychain access needed: the default trait impl answers before any
+        // backend call, and the message must steer at the file backend.
+        let err = KeychainStore::new().list().unwrap_err();
+        assert!(err.contains("SEMA_MCP_TOKEN_STORE=file"), "{err}");
     }
 
     #[cfg(unix)]

--- a/crates/sema/src/main.rs
+++ b/crates/sema/src/main.rs
@@ -325,7 +325,7 @@ enum Commands {
     Lsp,
     /// Start the Debug Adapter Protocol (DAP) server
     Dap,
-    /// Start the Model Context Protocol (MCP) server, or manage client auth (`login`/`logout`)
+    /// Start the Model Context Protocol (MCP) server, or manage client auth (`login`/`logout`/`list`)
     #[command(args_conflicts_with_subcommands = true)]
     Mcp {
         /// Client-auth subcommand; when omitted, runs the MCP server
@@ -468,6 +468,8 @@ enum McpAuthCommands {
         /// The MCP server URL whose cached credentials to clear
         url: String,
     },
+    /// List servers with cached credentials and each token's status (local only)
+    List,
 }
 
 #[derive(Subcommand)]
@@ -1016,6 +1018,7 @@ fn main() {
                             ..
                         } => sema_mcp::mcp_login(&url, device, client_id.as_deref()),
                         McpAuthCommands::Logout { url } => sema_mcp::mcp_logout(&url),
+                        McpAuthCommands::List => sema_mcp::mcp_list(),
                     };
                     if let Err(e) = result {
                         eprintln!("mcp: {e}");

--- a/crates/sema/tests/agent_async_test.rs
+++ b/crates/sema/tests/agent_async_test.rs
@@ -11,28 +11,22 @@
 //! Deterministic + keyless: a `FakeProvider` with `tool_loop` (a request-keyed
 //! multi-round script that stays reproducible under ANY interleaving — see
 //! `FakeProvider::tool_loop`) plus an injected `chat_delay` per round. Overlap is
-//! proven three ways: peak offloaded futures in flight ≥ 2, a max-not-sum wall
-//! clock, and a sibling ticker that advances *during* the agent's rounds.
+//! proven two ways: peak offloaded futures in flight ≥ 2, and a sibling ticker
+//! that advances *during* the agent's rounds.
 //!
 //! Own binary — the `IO_INFLIGHT` instrumentation atomics and the provider registry
 //! are process-global, so these `#[serial]` tests must not share a process with
 //! unrelated inflight capture.
 
-//! CONCURRENCY-OVERLAP TESTS ARE WALL-CLOCK UPPER BOUNDS (noted 2026-07-28).
+//! CONCURRENCY ORACLE: `io_peak_inflight() >= 2`, never a wall-clock ceiling.
 //!
-//! The `concurrent_agents_overlap_*` tests assert `wall_ms < N` to prove agents
-//! ran concurrently rather than serially. An upper bound on elapsed time is
-//! load-sensitive by construction: it holds in isolation (measured 5/5 and
-//! 20/20) and fails intermittently under `cargo nextest run --workspace`, where
-//! 7300 tests contend for the same cores. Two different tests of this shape
-//! failed on two consecutive full runs and both passed in isolation.
-//!
-//! A single failure here, in a full-workspace run, on a machine doing other
-//! work, is contention — re-run the test alone before believing it. A failure
-//! in isolation is real: the runtime agent round is blocking the VM thread.
-//!
-//! The lower-bound assertion in the same tests (`io_peak_inflight() >= 2`) is
-//! the load-safe half and can be trusted either way.
+//! The `concurrent_agents_overlap_*` tests prove overlap with that lower bound
+//! alone: serial execution can never have two offloaded provider rounds in
+//! flight at once, and a lower bound holds no matter how loaded the machine
+//! is. They deliberately assert no `wall_ms < N` upper bound — an elapsed-time
+//! ceiling is load-sensitive by construction and fails intermittently under a
+//! full-workspace `cargo nextest run` while passing in isolation (see
+//! docs/bugs/2026-07-28-sibling-interleaving-tests-are-load-sensitive.md).
 
 #![cfg(not(target_arch = "wasm32"))]
 
@@ -45,10 +39,11 @@ use sema_llm::fake::FakeProvider;
 use serial_test::serial;
 
 /// N agents, each a 2-tool-round conversation (3 provider calls) with a 120 ms
-/// delay per round, spawned concurrently. Blocking today: each agent hogs the VM
-/// thread through all its rounds, so they run serially (peak in-flight = 1, wall ≈
-/// N·3·120). Non-blocking: every round offloads + yields, so the agents overlap
-/// (peak in-flight ≥ 2, wall ≈ 3·120 — the single-agent critical path).
+/// delay per round, spawned concurrently. Blocking would mean each agent hogs
+/// the VM thread through all its rounds, so they run serially and peak
+/// in-flight stays at 1. Non-blocking: every round offloads + yields, so the
+/// agents overlap and peak in-flight reaches ≥ 2 — the load-safe concurrency
+/// oracle (a wall-clock ceiling would be load-sensitive; see the module note).
 #[test]
 #[serial]
 fn concurrent_agents_overlap_and_peak_inflight() {
@@ -66,31 +61,23 @@ fn concurrent_agents_overlap_and_peak_inflight() {
     reset_runtime_state();
     register_test_provider(Box::new(fake));
 
-    // 3 agents × (2 tool rounds + 1 final) × 120 ms:
-    //   serial floor ≈ 1080 ms; overlapped ≈ 360 ms.
+    // 3 agents × (2 tool rounds + 1 final) × 120 ms per round.
     let program = r#"
         (deftool ping "ping" {:n {:type :number}} (fn (n) "pong"))
         (defagent bot {:model "fake-model" :tools [ping] :max-turns 6})
-        (let ((t0 (sys/elapsed)))
-          (async/all
-            (map (fn (i) (async/spawn (fn () (agent/run bot "go"))))
-                 (list 1 2 3)))
-          (floor (/ (- (sys/elapsed) t0) 1000000)))
+        (async/all
+          (map (fn (i) (async/spawn (fn () (agent/run bot "go"))))
+               (list 1 2 3)))
     "#;
-    let wall = interp
+    interp
         .eval_str_compiled(program)
         .expect("3 concurrent agents evaluated");
-    let wall_ms = wall.as_int().expect("wall ms");
 
     assert!(
         io_peak_inflight() >= 2,
         "expected peak offloaded futures in flight >= 2 (agents overlapping across \
          rounds), got {} — agent/run still blocks per round",
         io_peak_inflight()
-    );
-    assert!(
-        wall_ms < 700,
-        "expected overlapped wall < 700 ms (serial floor ~1080 ms), got {wall_ms} ms"
     );
 }
 

--- a/crates/sema/tests/agent_runtime_test.rs
+++ b/crates/sema/tests/agent_runtime_test.rs
@@ -9,21 +9,15 @@
 //! tool-error-recovery contract (a tool that errors → fed back as a tool result →
 //! the loop recovers), mirroring `mcp_builtin_test`.
 
-//! CONCURRENCY-OVERLAP TESTS ARE WALL-CLOCK UPPER BOUNDS (noted 2026-07-28).
+//! CONCURRENCY ORACLE: `io_peak_inflight() >= 2`, never a wall-clock ceiling.
 //!
-//! The `concurrent_agents_overlap_*` tests assert `wall_ms < N` to prove agents
-//! ran concurrently rather than serially. An upper bound on elapsed time is
-//! load-sensitive by construction: it holds in isolation (measured 5/5 and
-//! 20/20) and fails intermittently under `cargo nextest run --workspace`, where
-//! 7300 tests contend for the same cores. Two different tests of this shape
-//! failed on two consecutive full runs and both passed in isolation.
-//!
-//! A single failure here, in a full-workspace run, on a machine doing other
-//! work, is contention — re-run the test alone before believing it. A failure
-//! in isolation is real: the runtime agent round is blocking the VM thread.
-//!
-//! The lower-bound assertion in the same tests (`io_peak_inflight() >= 2`) is
-//! the load-safe half and can be trusted either way.
+//! The `concurrent_agents_overlap_*` tests prove overlap with that lower bound
+//! alone: serial execution can never have two offloaded provider rounds in
+//! flight at once, and a lower bound holds no matter how loaded the machine
+//! is. They deliberately assert no `wall_ms < N` upper bound — an elapsed-time
+//! ceiling is load-sensitive by construction and fails intermittently under a
+//! full-workspace `cargo nextest run` while passing in isolation (see
+//! docs/bugs/2026-07-28-sibling-interleaving-tests-are-load-sensitive.md).
 
 #![cfg(not(target_arch = "wasm32"))]
 
@@ -396,10 +390,11 @@ fn failed_tool_schema_validation_emits_end_error_via_runtime() {
 
 // GATE (full-flip blocker 1): two `agent/run`s spawned concurrently through the
 // UNIFIED RUNTIME must OVERLAP across their provider rounds — not serialize. Each
-// round now offloads the provider call to the executor IO pool and suspends the
-// task on an External wait, so sibling agents run during every inter-round park.
-// Proven two ways: peak offloaded futures in flight >= 2 AND a max-not-sum wall
-// clock (3 agents × 3 rounds × 120 ms ⇒ serial floor ~1080 ms, overlapped ~360 ms).
+// round offloads the provider call to the executor IO pool and suspends the task
+// on an External wait, so sibling agents run during every inter-round park.
+// Proven by the load-safe lower bound: peak offloaded futures in flight >= 2,
+// impossible under serial rounds (a wall-clock ceiling would be load-sensitive;
+// see the module note).
 #[test]
 #[serial]
 fn concurrent_agents_overlap_via_runtime() {
@@ -418,26 +413,19 @@ fn concurrent_agents_overlap_via_runtime() {
     let program = r#"
         (deftool ping "ping" {:n {:type :number}} (fn (n) "pong"))
         (defagent bot {:model "fake-model" :tools [ping] :max-turns 6})
-        (let ((t0 (sys/elapsed)))
-          (async/all
-            (map (fn (i) (async/spawn (fn () (agent/run bot "go"))))
-                 (list 1 2 3)))
-          (floor (/ (- (sys/elapsed) t0) 1000000)))
+        (async/all
+          (map (fn (i) (async/spawn (fn () (agent/run bot "go"))))
+               (list 1 2 3)))
     "#;
-    let wall = interp
+    interp
         .eval_str_via_runtime(program)
         .expect("3 concurrent agents evaluated through the runtime");
-    let wall_ms = wall.as_int().expect("wall ms");
 
     assert!(
         io_peak_inflight() >= 2,
         "expected peak offloaded futures in flight >= 2 (agents overlapping across \
          rounds), got {} — the runtime agent round still blocks the VM thread",
         io_peak_inflight()
-    );
-    assert!(
-        wall_ms < 700,
-        "expected overlapped wall < 700 ms (serial floor ~1080 ms), got {wall_ms} ms"
     );
 }
 

--- a/crates/sema/tests/integration_test.rs
+++ b/crates/sema/tests/integration_test.rs
@@ -16225,3 +16225,73 @@ fn test_u8_repl_bare_quit_exits() {
     let output = run_repl_with_input(":q\n");
     assert!(output.status.success(), ":q should exit cleanly");
 }
+
+/// `sema mcp list` reads only the local credential store — keyless, no network.
+/// Runs against the file backend (`SEMA_MCP_TOKEN_STORE=file`) under a
+/// throwaway HOME so the developer's real store is never touched. Unix-only:
+/// on Windows `directories` resolves the config dir via the known-folder API
+/// and ignores `$HOME`, so the redirection would silently read the real store.
+#[cfg(unix)]
+#[test]
+fn test_mcp_list_reads_the_file_store() {
+    let home = std::env::temp_dir().join(format!("sema-mcp-list-test-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&home);
+    std::fs::create_dir_all(&home).unwrap();
+
+    let run = |home: &std::path::Path| {
+        std::process::Command::new(env!("CARGO_BIN_EXE_sema"))
+            .args(["mcp", "list"])
+            .env("HOME", home)
+            .env("XDG_CONFIG_HOME", home.join(".config"))
+            .env("SEMA_MCP_TOKEN_STORE", "file")
+            .output()
+            .expect("failed to run sema mcp list")
+    };
+
+    // Empty store: a friendly line, exit 0.
+    let output = run(&home);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "no known servers\n"
+    );
+
+    // Seed two servers straight into the store file (the same JSON the file
+    // backend writes): one non-expiring token, one long expired.
+    #[cfg(target_os = "macos")]
+    let config_dir = home.join("Library").join("Application Support");
+    #[cfg(not(target_os = "macos"))]
+    let config_dir = home.join(".config");
+    let store_dir = config_dir.join("sema");
+    std::fs::create_dir_all(&store_dir).unwrap();
+    std::fs::write(
+        store_dir.join("mcp-auth.json"),
+        r#"{"servers": {
+            "https://b.example.com/mcp": {"server_url": "https://b.example.com/mcp",
+                "tokens": {"access_token": "tok-b", "expires_at": 1}},
+            "https://a.example.com/mcp": {"server_url": "https://a.example.com/mcp",
+                "tokens": {"access_token": "tok-a"}}}}"#,
+    )
+    .unwrap();
+
+    // One line per server, URL-sorted, expiry reflected — and never the token.
+    let output = run(&home);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout,
+        "https://a.example.com/mcp  token present\n\
+         https://b.example.com/mcp  token expired\n"
+    );
+    assert!(!stdout.contains("tok-"), "tokens must never be printed");
+
+    let _ = std::fs::remove_dir_all(&home);
+}

--- a/docs/bugs/2026-07-28-sema-web-adversarial-findings.md
+++ b/docs/bugs/2026-07-28-sema-web-adversarial-findings.md
@@ -8,15 +8,15 @@ Severity as found: 3 critical, 11 high, 13 medium, 10 low.
 
 ## Status after the harden phase (reconciled 2026-07-28)
 
-**34 FIXED, 2 PARTIALLY FIXED, 1 OPEN by decision.** Every finding below carries
+**34 FIXED, 1 PARTIALLY FIXED, 2 CLOSED BY DECISION.** Every finding below carries
 its own `**Status …**` line naming the regression test that covers it; this table
 is only the roll-up.
 
 | Verdict | Findings |
 | --- | --- |
 | FIXED | 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 30, 31, 32, 33, 35, 36, 37 |
-| PARTIALLY FIXED | 11 (every re-rendering shape refetches; a spec reading a signal the view never reads still does not, and the documented answer is `resource/refresh!` from an `effect`), 29 (the diagnosis names the cause; the ~100 wasted renders remain) |
-| OPEN by decision | 34 (`.once` migration in an unkeyed list — fixing it would re-arm a spent `.once` whenever a label changes, which is worse; shipped as a dev diagnostic plus docs instead) |
+| PARTIALLY FIXED | 29 (the diagnosis names the cause; the ~100 wasted renders remain) |
+| CLOSED BY DECISION | 11 (every re-rendering shape refetches; for a spec reading a signal the view never reads, the documented answer is `resource/refresh!` from an `effect` — docs shipped), 34 (`.once` migration in an unkeyed list — fixing it would re-arm a spent `.once` whenever a label changes, which is worse; the `sip-render:once-without-key` dev diagnostic and docs shipped instead) |
 
 Three of those are answered by *documentation* rather than by a behaviour change,
 each because this ledger's own **Expected** offered that as an alternative and the
@@ -25,6 +25,11 @@ code change was judged worse than the defect: **20** (effect re-run ownership),
 called out individually below rather than being quietly folded into "FIXED", and
 **20**'s two tests are flagged in place as contract coverage rather than as a
 regression witness — they pass before and after by construction.
+
+(**11**'s residual and **34** were reclassified CLOSED BY DECISION on
+2026-07-29: everything they resolve to has shipped — the docs in each case, and
+for **34** the `once-without-key` dev diagnostic, live at
+`packages/sema-web/src/sip.ts:389`.)
 
 Verification behind this reconciliation, exit codes checked (2026-07-28):
 `npm test` 996 passed / 39 files; `tsc --noEmit` clean; `npm run build` clean;
@@ -49,7 +54,11 @@ both recorded here so the next reader does not re-derive them:
   iteration reaches `number/to-string` first. The stdlib really does register
   both names (`crates/sema-stdlib/src/string.rs:515,1633`), so the fix is to
   merge the two entries — an editorial call for a Rust/docs owner, not a
-  sema-web change. Left open deliberately.
+  sema-web change. **Closed** by commit `146f7654` (2026-07-28): the alias
+  declaration was removed from
+  `crates/sema-docs/entries/stdlib/strings/number-to-string.md`, leaving the
+  `math` entry as the one canonical `number->string`; the previously flaky
+  test passed 20/20 after.
 
 One environmental flake, also not a product defect: with the default worker count
 on a loaded machine the Playwright suite can lose a single `composition.spec.ts`
@@ -225,9 +234,9 @@ Also `router/href` and `router/push!`/`router/replace!` with the same argument. 
 
 ### 11. [HIGH] A spec whose URL depends on props or signals never refetches when they change — the new spec is adopted but no attempt is scheduled
 
-**Status 2026-07-28 (harden phase): PARTIALLY FIXED.** Every shape where the component re-renders now refetches (props from a parent, a signal the view reads, a route param) via the finding-6 fingerprint check - including the plan's own `(fn () (http/get (string-append "/api/users/" (:id props))))`. Witness: `tests/resource.test.ts` -> "re-checks a spec whose closure identity never changes", "refetches when only the method, headers, or body move"; `tests/resource-sema.test.ts` and `e2e/tests/resource.spec.ts` drive it end to end.
+**Status 2026-07-28 (harden phase): FIXED for every re-rendering shape; residual CLOSED BY DECISION (2026-07-29).** Every shape where the component re-renders now refetches (props from a parent, a signal the view reads, a route param) via the finding-6 fingerprint check - including the plan's own `(fn () (http/get (string-append "/api/users/" (:id props))))`. Witness: `tests/resource.test.ts` -> "re-checks a spec whose closure identity never changes", "refetches when only the method, headers, or body move"; `tests/resource-sema.test.ts` and `e2e/tests/resource.spec.ts` drive it end to end.
 
-**Residual, stated plainly.** This finding's *literal* repro renders `(:name (:value @u))` and never reads `@uid` in the view, so `(put! uid "2")` re-renders nothing and a re-render-driven check cannot see it. Making the spec's signal reads *tracked* was designed and rejected: a spec that writes a signal becomes self-triggering, and two specs that read each other's writes produce a microtask loop no fingerprint can break (a frozen tab). For that shape the documented answer is the ledger's own second Expected - `(effect (list @uid) (fn () (resource/refresh! "user")))` - now in the module docstring, `README.md` and `website/docs/web/resources.md`.
+**Residual, stated plainly - closed by decision.** This finding's *literal* repro renders `(:name (:value @u))` and never reads `@uid` in the view, so `(put! uid "2")` re-renders nothing and a re-render-driven check cannot see it. Making the spec's signal reads *tracked* was designed and rejected: a spec that writes a signal becomes self-triggering, and two specs that read each other's writes produce a microtask loop no fingerprint can break (a frozen tab). For that shape the documented answer is the ledger's own second Expected - `(effect (list @uid) (fn () (resource/refresh! "user")))` - now in the module docstring, `README.md` and `website/docs/web/resources.md`. With those docs shipped, nothing here remains open.
 
 **Repro.** renderSema (real WASM): `(def uid (state "1"))` + `(defcomponent view () (def u (resource "user" (fn () (string-append "/api/user/" @uid)))) [:p (if (:loading @u) "..." (:name (:value @u)))])`, mounted; resolve the first response as {"name":"one"}; then `(put! uid "2")` and flush.
 
@@ -468,7 +477,7 @@ i.e. Sema `(router/init! {"routes" "routes-page"})` — a bare `pattern -> handl
 
 ### 34. [LOW] `.once` state migrates to the wrong row in an unkeyed list
 
-**Status 2026-07-28 (harden phase): OPEN - deliberate non-change, diagnosed and documented.** The behaviour is unchanged **on purpose**. The ledger's Expected is "either both reordered rows fire or neither does"; the only way to make both fire is to clear the spent mark when morphdom patches the element, and that destroys what `.once` is for - `[:button {:on-click.once "save"} (if @saving "Saving..." "Save")]` would re-arm the moment its label changes, so a double-click submits twice. That is a worse defect than the one being fixed and it would invert two existing contracts. Item identity genuinely is not recoverable from an unkeyed list; only a `:key` supplies it. What shipped instead: a dev-mode diagnostic `sip-render:once-without-key:<parent>` on exactly the hazardous shape (an unkeyed element declaring `.once` with unkeyed same-tag siblings), plus the `.once` bullet in `website/docs/web/sip-markup.md`. Witness: `tests/sip-keys.test.ts` -> the ".once on unkeyed siblings" block (8 tests, incl. "says nothing once the rows carry a :key" and "reports once per parent, not once per row") and a characterization test in `tests/event-modifiers.test.ts` reproducing the ledger's exact migration.
+**Status 2026-07-28 (harden phase, reclassified 2026-07-29): CLOSED BY DECISION - deliberate non-change, diagnosed and documented.** The behaviour is unchanged **on purpose**. The ledger's Expected is "either both reordered rows fire or neither does"; the only way to make both fire is to clear the spent mark when morphdom patches the element, and that destroys what `.once` is for - `[:button {:on-click.once "save"} (if @saving "Saving..." "Save")]` would re-arm the moment its label changes, so a double-click submits twice. That is a worse defect than the one being fixed and it would invert two existing contracts. Item identity genuinely is not recoverable from an unkeyed list; only a `:key` supplies it. What shipped instead: a dev-mode diagnostic `sip-render:once-without-key:<parent>` on exactly the hazardous shape (an unkeyed element declaring `.once` with unkeyed same-tag siblings), live at `packages/sema-web/src/sip.ts:389`, plus the `.once` bullet in `website/docs/web/sip-markup.md`. Witness: `tests/sip-keys.test.ts` -> the ".once on unkeyed siblings" block (8 tests, incl. "says nothing once the rows carry a :key" and "reports once per parent, not once per row") and a characterization test in `tests/event-modifiers.test.ts` reproducing the ledger's exact migration.
 
 **Repro.** jsdom with the real morphdom and real signals. `[:ul (map (fn (r) [:li {:on-click.once "h"} r]) @rows)]` with `rows` = `("a" "b")`. Click row 0 ("a"), then set `rows` to `("b" "a")`, then click both rows. Cause: `firedOnce` is a `WeakMap<Element, Set<string>>` keyed by node identity (src/component.ts:612), and morphdom reuses the position-0 node for a different item when the list is unkeyed.
 

--- a/docs/bugs/2026-07-28-sibling-interleaving-tests-are-load-sensitive.md
+++ b/docs/bugs/2026-07-28-sibling-interleaving-tests-are-load-sensitive.md
@@ -91,6 +91,11 @@ bound and is trustworthy either way.
 The general rule: **lower bounds and orderings are load-safe; upper bounds are
 not.**
 
+**Update 2026-07-29:** the `wall_ms < 700` upper bounds were removed from both
+`concurrent_agents_overlap_*` tests — the likely trigger for runs 1–2 above —
+leaving `io_peak_inflight() >= 2` as each test's concurrency oracle (that
+answers open question 2 below).
+
 ## Open questions, in priority order
 
 1. What did the four failures actually assert? Nothing proceeds without this.

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -9,11 +9,7 @@ Things that came out of the May 2026 quality sweep (Wave 6 audit) but were inten
 
 ## MCP-1 — Named/aliased MCP servers
 
-**Found 2026-07-01, during the MCP client PR (#59).** Every `mcp/connect` and `sema mcp login/logout` repeats the full server config (`:url`/`:command`). A convenience layer would let you declare a server once — a `name → {:url …}`/`{:command …}` mapping (in a script or a small config file) — and refer to it by name (`(mcp/connect "asana")`, `sema mcp login asana`). Pairs naturally with the token store, which already keys by canonical URL. **Deferred because** it's a pure ergonomics feature with a design choice (script-level form vs. a config file), orthogonal to the client's correctness, and best done after the base client lands.
-
-## MCP-2 — `sema mcp list`
-
-**Found 2026-07-01 (PR #59).** No CLI command surfaces which remote servers have cached credentials or their token status. A `sema mcp list` would show authenticated/known servers (and, ideally, which script or config declared each — which depends on MCP-1). **Deferred because** it's additive tooling; the "which script declared it" part needs the alias registry from MCP-1 first.
+**Found 2026-07-01, during the MCP client PR (#59).** Every `mcp/connect` and `sema mcp login/logout` repeats the full server config (`:url`/`:command`). A convenience layer would let you declare a server once — a `name → {:url …}`/`{:command …}` mapping (in a script or a small config file) — and refer to it by name (`(mcp/connect "asana")`, `sema mcp login asana`). Pairs naturally with the token store, which already keys by canonical URL. **Deferred because** it's a pure ergonomics feature with a design choice (script-level form vs. a config file), orthogonal to the client's correctness, and best done after the base client lands. Note: `sema mcp list` exists (MCP-2, resolved 2026-07-29) but has no alias/declared-by column — the alias registry here would supply it.
 
 ## MCP-3 — Fully-offline agent replay (cassette `tools/list` + `connect` skip)
 

--- a/docs/plans/archive/deferred-resolved.md
+++ b/docs/plans/archive/deferred-resolved.md
@@ -135,6 +135,12 @@ feature, not part of the numeric tower's scope. Applications needing arbitrary-p
 arithmetic use general lists or other dynamic collections; applications needing arrays use
 typed arrays with appropriately-in-range inputs.
 
+## MCP-2 — `sema mcp list` — RESOLVED (2026-07-29)
+
+**Found 2026-07-01 (PR #59).** No CLI command surfaces which remote servers have cached credentials or their token status. A `sema mcp list` would show authenticated/known servers (and, ideally, which script or config declared each — which depends on MCP-1). **Deferred because** it's additive tooling; the "which script declared it" part needs the alias registry from MCP-1 first.
+
+**Resolved 2026-07-29:** `sema mcp list` shipped — enumerates the default token store (canonical-URL-keyed; the keychain backend reports enumeration as unsupported) and prints one line per server with `token present`/`token expired` status, no network calls; the declared-by/alias column still waits on MCP-1.
+
 ## MCP-4 — `mcp/call` blocks the cooperative scheduler (RESOLVED 2026-07-10)
 
 **Found 2026-07-10 during the workflow `:mcp` work; resolved the same day**

--- a/website/docs/cli.md
+++ b/website/docs/cli.md
@@ -414,16 +414,20 @@ Start the [Model Context Protocol](/docs/mcp) server (exposes Sema's tools to LL
 
 ```
 sema mcp [FILES]...                 # run the MCP server (optionally loading tool files)
-sema mcp login  <url> [--device] [--client-id ID]
+sema mcp login  <url> [--device] [--client-id ID] [--token TOKEN [--expires-in SECS]]
 sema mcp logout <url>
+sema mcp list
 ```
 
 - `sema mcp` (no subcommand) starts the stdio MCP **server** — see the [MCP documentation](/docs/mcp).
-- `sema mcp login <url>` authenticates to a remote MCP **server** you want to *consume* and caches the OAuth token so later `mcp/connect` calls are silent. `--device` uses the headless device-code flow; `--client-id` supplies a pre-registered OAuth client.
+- `sema mcp login <url>` authenticates to a remote MCP **server** you want to *consume* and caches the OAuth token so later `mcp/connect` calls are silent. `--device` uses the headless device-code flow; `--client-id` supplies a pre-registered OAuth client; `--token` installs a pre-issued access token directly (the headless/CI escape hatch — no browser, no device flow), optionally with `--expires-in`.
 - `sema mcp logout <url>` clears the cached credentials for a server.
+- `sema mcp list` prints every server with cached credentials — one line per server (in canonical-URL order): the URL followed by `token present` or `token expired`. It reads only the local credential store (never the network) and never prints token values. The OS keychain backend has no enumeration API, so `list` reports that limitation and points at `SEMA_MCP_TOKEN_STORE=file` instead of pretending the store is empty.
 
 ```bash
 sema mcp login https://mcp.asana.com/mcp
+sema mcp list
+# https://mcp.asana.com/mcp  token present
 sema mcp logout https://mcp.asana.com/mcp
 ```
 

--- a/website/docs/mcp.md
+++ b/website/docs/mcp.md
@@ -406,8 +406,12 @@ Prefer to authenticate ahead of time (recommended, and required on a headless bo
 sema mcp login  https://mcp.example.com/mcp             # opens a browser
 sema mcp login  https://mcp.example.com/mcp --device    # RFC 8628 device-code flow (headless)
 sema mcp login  https://mcp.example.com/mcp --client-id ID   # pre-registered client
+sema mcp login  https://mcp.example.com/mcp --token T   # install a pre-issued token (CI)
 sema mcp logout https://mcp.example.com/mcp             # clear cached credentials
+sema mcp list                                           # what's cached, per server
 ```
+
+`sema mcp list` prints one line per server with cached credentials — the canonical URL plus `token present` or `token expired` — reading only the local store (no network, and token values are never printed). It can only enumerate the file backend: the OS keychain has no listing API, so `list` says so and points at `SEMA_MCP_TOKEN_STORE=file` rather than pretending the store is empty.
 
 **Token storage.** Credentials are kept per server URL in the OS keychain by default, falling back to a `0600`-permission `mcp-auth.json` in the platform config directory on headless boxes (Linux: `$XDG_CONFIG_HOME` or `~/.config/sema/`; macOS: `~/Library/Application Support/sema/`; Windows: `%APPDATA%\sema\`). Override the backend with an environment variable:
 
@@ -461,7 +465,7 @@ A call is keyed by a hash of the server identity + tool name + arguments; a repl
 
 ### Troubleshooting
 
-- **`OAuth login failed` / no browser opens** — on a headless machine, use `sema mcp login <url> --device` (device-code flow) or pass a token directly via `:headers {"Authorization" "Bearer …"}`.
+- **`OAuth login failed` / no browser opens** — on a headless machine, use `sema mcp login <url> --device` (device-code flow), `sema mcp login <url> --token <token>` (pre-issued token), or pass a token directly via `:headers {"Authorization" "Bearer …"}`.
 - **Repeated macOS Keychain prompts while developing** — expected for a frequently-rebuilt dev binary; set `SEMA_MCP_TOKEN_STORE=file`.
 - **`mcp/connect requires a :command or :url entry`** — the config map needs one of `:command` (stdio) or `:url` (http).
 - Errors surface as `SemaError` values, so wrap `mcp/connect`/`mcp/call` in your usual error handling.


### PR DESCRIPTION
Closes deferred MCP-2; removes the by-construction load-sensitive assertions; closes three stale bug-doc items. Full local gate green (lint + workspace suite).