### PR TITLE
docs(macros-modules): fix capture example and ellipsis caveat

### DIFF
--- a/website/docs/language/macros-modules.md
+++ b/website/docs/language/macros-modules.md
@@ -44,14 +44,14 @@ This prevents **variable capture** — a common bug where macro-introduced bindi
 ```sema
 ;; Without auto-gensym — BUG if user has a variable named "tmp"
 (defmacro bad-inc (x)
-  `(let ((tmp ,x)) (+ tmp 1)))
+  `(let ((tmp 1)) (+ tmp ,x)))
 
 (let ((tmp 100))
-  (bad-inc tmp))   ; => 2, not 101! "tmp" is captured
+  (bad-inc tmp))   ; => 2, not 101! the macro's "tmp" captures the user's "tmp"
 
 ;; With auto-gensym — always correct
 (defmacro good-inc (x)
-  `(let ((tmp# ,x)) (+ tmp# 1)))
+  `(let ((tmp# 1)) (+ tmp# ,x)))
 
 (let ((tmp 100))
   (good-inc tmp))  ; => 101 ✓
@@ -143,7 +143,7 @@ Every *other* template identifier — free references to user-defined globals, b
 **Caveats** (the hygiene is an approximation, not full R7RS referential transparency):
 
 - Only template-introduced *binders* are renamed. The other direction isn't covered: if the use site shadows a global or special form that the template references freely, the template sees the shadowing binding.
-- Templates support a single level of ellipsis; a template with ellipsis depth > 1 (`x ... ...`) is rejected with a clear error rather than mis-expanded.
+- A template may use nested ellipsis (`x ... ...`) when the pattern binds the variable at the same depth — e.g. pattern `((x ...) ...)` with template `(list (list x ...) ...)`. Using more levels than the pattern provides is rejected with `syntax-rules: unsupported nested ellipsis depth in template` rather than mis-expanded.
 - Like `defmacro`, `define-syntax` must appear at the top level (or inside a top-level `begin`) to be visible to sibling forms — one nested inside a lambda or `let` body is not.
 - `syntax-case` is not supported.
 


### PR DESCRIPTION
## Problem

Two claims on the [Macros & Modules page](https://sema-lang.com/docs/language/macros-modules) were wrong, found by running every snippet on the page against the latest release (sema 1.33.0).

**1. The `bad-inc` capture example never captured anything.** `,x` sat in the `let`'s init position, which evaluates in the outer scope, so the expansion `(let ((tmp tmp)) (+ tmp 1))` returned 101 — not the claimed `2, not 101!`. The example could not demonstrate variable capture as written.

**2. The ellipsis caveat overstated the restriction.** It claimed templates support a single level of ellipsis and depth > 1 is rejected. In fact, nested ellipsis works when the pattern binds the variable at the same depth:

```sema
(define-syntax deep
  (syntax-rules ()
    ((_ ((x ...) ...))
     (list (list x ...) ...))))
(deep ((1 2) (3 4)))   ; => ((1 2) (3 4))
```

An error (`syntax-rules: unsupported nested ellipsis depth in template`) only fires when the template uses deeper ellipsis than the pattern supplies.

## Fix

- Capture example: moved `,x` from the `let` init into the body — `(let ((tmp 1)) (+ tmp ,x))`. Verified: `bad-inc` => 2, `good-inc` => 101 on sema 1.33.0.
- Ellipsis caveat: states the real rule (template depth must not exceed the pattern's binding depth) and quotes the exact error message.

All other snippets on the page were verified correct and are unchanged.