### PR TITLE
fix(fuzz): validate grammar-fuzz arguments before they reach bash arithmetic

### DIFF
--- a/jake/scripts.jake
+++ b/jake/scripts.jake
@@ -28,6 +28,11 @@ task fmt:
     echo "shfmt: formatted scripts/*.sh"
 
 @group scripts
-@desc "Shell sanity gate: shellcheck + shfmt formatting check"
-task check: [lint, fmt-check]
+@desc "Check grammar-fuzz CLI argument validation"
+task grammar-fuzz-args-test:
+    bash scripts/grammar-fuzz-args-test.sh
+
+@group scripts
+@desc "Shell sanity gate: shellcheck + shfmt + argument tests"
+task check: [lint, fmt-check, grammar-fuzz-args-test]
     echo "scripts: clean"

--- a/scripts/grammar-fuzz-args-test.sh
+++ b/scripts/grammar-fuzz-args-test.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DRIVER="$ROOT/scripts/grammar-fuzz.sh"
+
+assert_usage_error() {
+  local expected="$1"
+  shift
+  local output status
+  set +e
+  output="$("$DRIVER" "$@" 2>&1)"
+  status=$?
+  set -e
+  if [ "$status" -ne 64 ]; then
+    echo "expected exit 64 for: $*; got $status" >&2
+    echo "$output" >&2
+    return 1
+  fi
+  if [[ "$output" != *"$expected"* ]]; then
+    echo "expected '$expected' for: $*" >&2
+    echo "$output" >&2
+    return 1
+  fi
+}
+
+assert_usage_error "BATCH must be greater than zero" check --async -n 1 -b 0
+assert_usage_error "BATCH must be a non-negative decimal integer" check --async -n 1 -b nope
+assert_usage_error "BUDGET must be greater than zero" check --async -n 1 -t 0
+assert_usage_error "COUNT must be greater than zero" check -n 0
+assert_usage_error "DEPTH must be a non-negative decimal integer" check -d -1
+
+# Leading zeroes are valid decimal input and must not reach Bash as octal.
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf -- "$TEST_ROOT"' EXIT
+cat >"$TEST_ROOT/sema" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$TEST_ROOT/sema"
+PATH="$TEST_ROOT:$PATH" \
+  "$DRIVER" check --async -n 01 -d 00 -s -08 -b 01 -t 01 >/dev/null
+
+echo "grammar-fuzz argument tests: clean"

--- a/scripts/grammar-fuzz.sh
+++ b/scripts/grammar-fuzz.sh
@@ -82,7 +82,66 @@ while getopts "n:d:s:o:b:t:v" opt; do
   esac
 done
 
-# Locate (or build) the sema binary.
+# Default counts per mode.
+if [ -z "$COUNT" ]; then
+  if [ "$MODE" = "emit" ]; then COUNT="20"; else COUNT="5000"; fi
+fi
+
+# Random seed if not pinned.
+if [ -z "$SEED" ]; then
+  SEED=$((($(date +%s) ^ ($$ << 13) ^ ${RANDOM:-0}) % 1000000000))
+fi
+
+# Parse an unsigned decimal integer and remove leading zeroes. Normalizing is
+# required because Bash arithmetic otherwise treats values such as 08 as octal.
+normalize_uint() {
+  local label="$1"
+  local value="$2"
+  local allow_zero="$3"
+  case "$value" in
+    "" | *[!0-9]*)
+      echo "$label must be a non-negative decimal integer (got '$value')" >&2
+      return 1
+      ;;
+  esac
+  while [ "${value#0}" != "$value" ]; do
+    value="${value#0}"
+  done
+  [ -n "$value" ] || value="0"
+  if [ "$allow_zero" != "1" ] && [ "$value" = "0" ]; then
+    echo "$label must be greater than zero" >&2
+    return 1
+  fi
+  printf '%s\n' "$value"
+}
+
+normalize_int() {
+  local label="$1"
+  local value="$2"
+  local sign=""
+  case "$value" in
+    -*)
+      sign="-"
+      value="${value#-}"
+      ;;
+    +*) value="${value#+}" ;;
+  esac
+  value="$(normalize_uint "$label" "$value" 1)" || return 1
+  if [ "$sign" = "-" ] && [ "$value" != "0" ]; then
+    printf -- '-%s\n' "$value"
+  else
+    printf '%s\n' "$value"
+  fi
+}
+
+COUNT="$(normalize_uint COUNT "$COUNT" 0)" || exit 64
+DEPTH="$(normalize_uint DEPTH "$DEPTH" 1)" || exit 64
+SEED="$(normalize_int SEED "$SEED")" || exit 64
+BATCH="$(normalize_uint BATCH "$BATCH" 0)" || exit 64
+BUDGET="$(normalize_uint BUDGET "$BUDGET" 0)" || exit 64
+
+# Locate (or build) the sema binary after validation, so invalid input fails
+# promptly without starting a release build.
 BIN=""
 for cand in "$ROOT/target/release/sema" "$ROOT/target/debug/sema" "$(command -v sema 2>/dev/null || true)"; do
   if [ -n "$cand" ] && [ -x "$cand" ]; then
@@ -97,16 +156,6 @@ if [ -z "$BIN" ]; then
     exit 70
   }
   BIN="$ROOT/target/release/sema"
-fi
-
-# Default counts per mode.
-if [ -z "$COUNT" ]; then
-  if [ "$MODE" = "emit" ]; then COUNT="20"; else COUNT="5000"; fi
-fi
-
-# Random seed if not pinned.
-if [ -z "$SEED" ]; then
-  SEED=$((($(date +%s) ^ ($$ << 13) ^ ${RANDOM:-0}) % 1000000000))
 fi
 
 export SEMA_FUZZ_COUNT="$COUNT"


### PR DESCRIPTION
Recovered from an uncommitted worktree — the test script existed only on disk, in no branch.

`grammar-fuzz.sh` passed `-n/-d/-s/-b/-t` straight into arithmetic like `deadline=$((n * BUDGET))`. Bash reads a leading-zero value as octal, so `-t 08` aborted the run with `value too great for base`; a non-numeric value failed the same way with no useful message.

`normalize_uint`/`normalize_int` now parse each value as a decimal integer, strip leading zeroes, and reject bad input with a named error and exit 64. Validation also moved **ahead of locating/building the binary**, so a typo fails immediately instead of after a release build.

`scripts/grammar-fuzz-args-test.sh` asserts the exit code and message for each rejection (`-b 0`, `-b nope`, `-t 0`, `-n 0`, `-d -1`) plus a positive case proving `-n 01 -d 00 -s -08 -b 01 -t 01` is accepted. `jake scripts.check` now runs it alongside shellcheck and shfmt.

Verified: the bug reproduces (`bash -c 'echo $((08))'` → `value too great for base`), the new test passes, and `jake scripts.check` is green.