### PR TITLE
fix: scope regex literals in Sema highlighters

### DIFF
--- a/website/.vitepress/sema.tmLanguage.json
+++ b/website/.vitepress/sema.tmLanguage.json
@@ -11,6 +11,9 @@
       "include": "#comment"
     },
     {
+      "include": "#regex"
+    },
+    {
       "include": "#string"
     },
     {
@@ -51,6 +54,17 @@
     }
   ],
   "repository": {
+    "regex": {
+      "name": "string.regexp.sema",
+      "begin": "#\"",
+      "end": "\"",
+      "patterns": [
+        {
+          "name": "string.regexp.sema",
+          "match": "\\\\."
+        }
+      ]
+    },
     "block-comment": {
       "name": "comment.block.sema",
       "begin": "#\\|",


### PR DESCRIPTION
Problem: website highlighting omitted the leading hash character from regex literal scopes.

Cause: the vendored TextMate grammar lacked a regex rule.

Fix: add the canonical dedicated regex scope before ordinary strings while preserving raw backslash handling.

Tests: JSON validation; embedded web runtime freshness check; full repository checks run in CI.